### PR TITLE
refactor(ui): introduce menu flow runtime

### DIFF
--- a/src/main/java/org/xcore/plugin/service/EventEditorService.java
+++ b/src/main/java/org/xcore/plugin/service/EventEditorService.java
@@ -1,0 +1,124 @@
+package org.xcore.plugin.service;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.xcore.plugin.database.repository.EventDataRepository;
+import org.xcore.plugin.database.repository.MapDataRepository;
+import org.xcore.plugin.database.repository.PlayerDataRepository;
+import org.xcore.plugin.model.EventData;
+import org.xcore.plugin.model.MapData;
+import org.xcore.plugin.model.PlayerData;
+import org.xcore.plugin.session.Session;
+
+@Singleton
+public class EventEditorService {
+
+    private final EventDataRepository eventDataRepository;
+    private final MapDataRepository mapDataRepository;
+    private final PlayerDataRepository playerDataRepository;
+
+    @Inject
+    public EventEditorService(EventDataRepository eventDataRepository,
+                              MapDataRepository mapDataRepository,
+                              PlayerDataRepository playerDataRepository) {
+        this.eventDataRepository = eventDataRepository;
+        this.mapDataRepository = mapDataRepository;
+        this.playerDataRepository = playerDataRepository;
+    }
+
+    public EventData initializeDraft(Session session, MapData map) {
+        EventData draft = session.getDraft(EventData.class);
+        draft.author = session.data.id;
+        if (map != null) {
+            draft.map = map.id;
+        }
+        return draft;
+    }
+
+    public void resetName(EventData draft) {
+        draft.name = new EventData().name;
+    }
+
+    public void updateName(EventData draft, String name) {
+        draft.name = name;
+    }
+
+    public void updateDescription(EventData draft, String description) {
+        draft.description = description;
+    }
+
+    public void toggleTemporary(EventData draft) {
+        draft.isTemporary = !draft.isTemporary;
+    }
+
+    public void toggleMajor(EventData draft) {
+        draft.isMajor = !draft.isMajor;
+    }
+
+    public void updatePlannedStartTime(EventData draft, String input) {
+        draft.plannedStartTime = parseTime(input);
+    }
+
+    public void updatePlannedEndTime(EventData draft, String input) {
+        draft.plannedEndTime = parseTime(input);
+    }
+
+    public boolean saveDraft(Session session) {
+        EventData draft = session.getDraft(EventData.class);
+        if (draft.map == null) {
+            session.locale().send("error-no-map");
+            return false;
+        }
+        eventDataRepository.save(draft);
+        session.clearDraft(EventData.class);
+        return true;
+    }
+
+    public void cancelDraft(Session session) {
+        session.clearDraft(EventData.class);
+    }
+
+    public MapData selectMapForDraft(Session session, String name, String fileName, String author, String gameMode) {
+        MapData data = mapDataRepository.findOrCreate(name, fileName, author, gameMode);
+        EventData draft = session.getDraft(EventData.class);
+        draft.map = data.id;
+        return data;
+    }
+
+    public MapData findMapForDraft(EventData draft) {
+        if (draft == null || draft.map == null) {
+            return null;
+        }
+        return mapDataRepository.findById(draft.map);
+    }
+
+    public PlayerData findAuthorForDraft(EventData draft) {
+        if (draft == null || draft.author == null) {
+            return null;
+        }
+        return playerDataRepository.findById(draft.author);
+    }
+
+    public long parseTime(String input) {
+        if (input == null || input.isEmpty()) {
+            return 0;
+        }
+        try {
+            if (input.startsWith("+")) {
+                long now = System.currentTimeMillis();
+                String valueStr = input.substring(1, input.length() - 1);
+                char unit = input.charAt(input.length() - 1);
+                long value = Long.parseLong(valueStr);
+                return now + switch (unit) {
+                    case 'm' -> value * 60_000L;
+                    case 'h' -> value * 3_600_000L;
+                    case 'd' -> value * 86_400_000L;
+                    default -> 0;
+                };
+            }
+            return Long.parseLong(input);
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+}

--- a/src/main/java/org/xcore/plugin/service/EventService.java
+++ b/src/main/java/org/xcore/plugin/service/EventService.java
@@ -90,6 +90,10 @@ public class EventService {
         });
     }
 
+    public void finishActiveEvent() {
+        eventDataRepository.finishActiveEvent();
+    }
+
     private void activateEventImmediately(Player player, EventData target) {
         eventDataRepository.activateEvent(target);
         sessionService.broadcast(

--- a/src/main/java/org/xcore/plugin/service/EventViewService.java
+++ b/src/main/java/org/xcore/plugin/service/EventViewService.java
@@ -1,0 +1,86 @@
+package org.xcore.plugin.service;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.bson.types.ObjectId;
+import org.xcore.plugin.common.CustomGatherers;
+import org.xcore.plugin.common.StatusEnum;
+import org.xcore.plugin.database.repository.EventDataRepository;
+import org.xcore.plugin.database.repository.MapDataRepository;
+import org.xcore.plugin.database.repository.PlayerDataRepository;
+import org.xcore.plugin.model.EventData;
+import org.xcore.plugin.model.MapData;
+import org.xcore.plugin.model.PlayerData;
+
+import java.util.List;
+import java.util.Map;
+
+@Singleton
+public class EventViewService {
+
+    private final EventDataRepository eventDataRepository;
+    private final MapDataRepository mapDataRepository;
+    private final PlayerDataRepository playerDataRepository;
+
+    @Inject
+    public EventViewService(EventDataRepository eventDataRepository,
+                            MapDataRepository mapDataRepository,
+                            PlayerDataRepository playerDataRepository) {
+        this.eventDataRepository = eventDataRepository;
+        this.mapDataRepository = mapDataRepository;
+        this.playerDataRepository = playerDataRepository;
+    }
+
+    public EventData activeEvent() {
+        return eventDataRepository.findActive().orElse(null);
+    }
+
+    public EventDetails details(EventData event) {
+        if (event == null) {
+            return new EventDetails(null, null, null);
+        }
+        return new EventDetails(event, findMap(event.map), findAuthor(event.author));
+    }
+
+    public EventPage page(int requestedPage, int perPage, Map<String, StatusEnum> filters) {
+        int total = (int) eventDataRepository.count(filters);
+        var pagination = CustomGatherers.calculatePagination(total, perPage);
+        if (total == 0) {
+            return new EventPage(List.of(), total, 1, pagination.totalPages());
+        }
+        int validPage = pagination.clampPage(requestedPage);
+        int skip = (validPage - 1) * perPage;
+        List<EventData> events = eventDataRepository.findPage(skip, perPage, filters);
+        return new EventPage(events, total, validPage, pagination.totalPages());
+    }
+
+    private MapData findMap(ObjectId mapId) {
+        if (mapId == null) {
+            return null;
+        }
+        return mapDataRepository.findById(mapId);
+    }
+
+    private PlayerData findAuthor(ObjectId authorId) {
+        if (authorId == null) {
+            return null;
+        }
+        return playerDataRepository.findById(authorId);
+    }
+
+    public record EventDetails(EventData event, MapData map, PlayerData author) {}
+
+    public record EventPage(List<EventData> events, int total, int page, int totalPages) {
+        public boolean isEmpty() {
+            return total == 0;
+        }
+
+        public boolean hasPrevious() {
+            return page > 1;
+        }
+
+        public boolean hasNext() {
+            return page < totalPages;
+        }
+    }
+}

--- a/src/main/java/org/xcore/plugin/service/PlayerProfileSettingsService.java
+++ b/src/main/java/org/xcore/plugin/service/PlayerProfileSettingsService.java
@@ -1,0 +1,210 @@
+package org.xcore.plugin.service;
+
+import arc.util.Strings;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.xcore.plugin.config.Config;
+import org.xcore.plugin.database.repository.PlayerDataRepository;
+import org.xcore.plugin.model.PlayerData;
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.session.SessionService;
+import org.xcore.protocol.generated.messages.chat.ChatMessages.PlayerActiveBadgeChangedCommandV1;
+import org.xcore.protocol.generated.messages.chat.ChatMessages.PlayerBadgeSymbolColorModeChangedCommandV1;
+import org.xcore.protocol.generated.messages.chat.ChatMessages.PlayerCustomNicknameChangedCommandV1;
+
+import java.nio.charset.StandardCharsets;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+@Singleton
+public class PlayerProfileSettingsService {
+
+    /** Vanilla Mindustry name length limit in UTF-8 bytes (see Vars.maxNameLength). */
+    public static final int MAX_PLAIN_NAME_BYTES = 40;
+    public static final int BADGE_ICON_RANGE_START = 0xE800;
+    public static final int BADGE_ICON_RANGE_END = 0xF8FF;
+
+    private final SessionService sessionService;
+    private final PlayerDataRepository playerDataRepository;
+    private final PlayerDisplayService playerDisplayService;
+    private final NetworkService network;
+    private final Config config;
+
+    @Inject
+    public PlayerProfileSettingsService(SessionService sessionService,
+                                        PlayerDataRepository playerDataRepository,
+                                        PlayerDisplayService playerDisplayService,
+                                        NetworkService network,
+                                        Config config) {
+        this.sessionService = sessionService;
+        this.playerDataRepository = playerDataRepository;
+        this.playerDisplayService = playerDisplayService;
+        this.network = network;
+        this.config = config;
+    }
+
+    public record NicknameValidationResult(boolean valid, String errorKey, int maxBytes) {
+        public static NicknameValidationResult ok() {
+            return new NicknameValidationResult(true, null, MAX_PLAIN_NAME_BYTES);
+        }
+
+        public static NicknameValidationResult tooLong(int maxBytes) {
+            return new NicknameValidationResult(false, "error-nickname-too-long", maxBytes);
+        }
+
+        public static NicknameValidationResult badgeGlyph() {
+            return new NicknameValidationResult(false, "error-nickname-badge-glyph", MAX_PLAIN_NAME_BYTES);
+        }
+    }
+
+    public NicknameValidationResult validateCustomNickname(String customNickname) {
+        if (customNickname == null || customNickname.isBlank()) {
+            return NicknameValidationResult.ok();
+        }
+
+        String plain = Strings.stripColors(customNickname);
+        if (plain.getBytes(StandardCharsets.UTF_8).length > MAX_PLAIN_NAME_BYTES) {
+            return NicknameValidationResult.tooLong(MAX_PLAIN_NAME_BYTES);
+        }
+
+        if (containsBadgeLikeGlyphs(plain)) {
+            return NicknameValidationResult.badgeGlyph();
+        }
+
+        return NicknameValidationResult.ok();
+    }
+
+    public void updateCustomNickname(PlayerData targetData, String customNickname, boolean refreshDisplay, boolean sync) {
+        mutate(targetData,
+                data -> data.customNickname = customNickname,
+                data -> playerDataRepository.updateCustomNickname(data.uuid, customNickname),
+                data -> new PlayerCustomNicknameChangedCommandV1(data.uuid, data.customNickname, config.server),
+                refreshDisplay,
+                sync);
+    }
+
+    public void updateDescription(PlayerData targetData, String description) {
+        mutate(targetData,
+                data -> data.description = description,
+                data -> playerDataRepository.updateDescription(data.uuid, description),
+                null,
+                false,
+                false);
+    }
+
+    public void updateLeaderboard(PlayerData targetData, boolean leaderboard) {
+        mutate(targetData,
+                data -> data.leaderboard = leaderboard,
+                data -> playerDataRepository.updateLeaderboard(data.uuid, leaderboard),
+                null,
+                false,
+                false);
+    }
+
+    public void updateLanguage(PlayerData targetData, String language) {
+        Session targetSession = sessionService.get(targetData.uuid);
+        if (targetSession != null) {
+            targetSession.updateLanguage(language);
+            return;
+        }
+
+        mutate(targetData,
+                data -> data.language = language,
+                data -> playerDataRepository.updateLanguage(data.uuid, language),
+                null,
+                false,
+                false);
+    }
+
+    public void updateTranslatorLanguage(PlayerData targetData, String language) {
+        Session targetSession = sessionService.get(targetData.uuid);
+        if (targetSession != null) {
+            targetSession.updateTranslatorLanguage(language);
+            return;
+        }
+
+        mutate(targetData,
+                data -> data.translatorLanguage = language,
+                data -> playerDataRepository.updateTranslatorLanguage(data.uuid, language),
+                null,
+                false,
+                false);
+    }
+
+    public void updateGlobalChatVisible(PlayerData targetData, boolean visible) {
+        Session targetSession = sessionService.get(targetData.uuid);
+        if (targetSession != null) {
+            targetSession.updateGlobalChatVisible(visible);
+            return;
+        }
+
+        mutate(targetData,
+                data -> data.globalChatVisible = visible,
+                data -> playerDataRepository.updateGlobalChatVisible(data.uuid, visible),
+                null,
+                false,
+                false);
+    }
+
+    public void updateDiscordRelayVisible(PlayerData targetData, boolean visible) {
+        Session targetSession = sessionService.get(targetData.uuid);
+        if (targetSession != null) {
+            targetSession.updateDiscordRelayVisible(visible);
+            return;
+        }
+
+        mutate(targetData,
+                data -> data.discordRelayVisible = visible,
+                data -> playerDataRepository.updateDiscordRelayVisible(data.uuid, visible),
+                null,
+                false,
+                false);
+    }
+
+    public void updateActiveBadge(PlayerData targetData, String badgeId, boolean refreshDisplay, boolean sync) {
+        mutate(targetData,
+                data -> data.activeBadge = badgeId,
+                data -> playerDataRepository.setActiveBadge(data.uuid, badgeId),
+                data -> new PlayerActiveBadgeChangedCommandV1(data.uuid, data.activeBadge, config.server),
+                refreshDisplay,
+                sync);
+    }
+
+    public void updateBadgeSymbolColorMode(PlayerData targetData, String mode, boolean refreshDisplay, boolean sync) {
+        mutate(targetData,
+                data -> data.badgeSymbolColorMode = mode,
+                data -> playerDataRepository.updateBadgeSymbolColorMode(data.uuid, mode),
+                data -> new PlayerBadgeSymbolColorModeChangedCommandV1(data.uuid, data.badgeSymbolColorMode, config.server),
+                refreshDisplay,
+                sync);
+    }
+
+    private void mutate(PlayerData targetData,
+                        Consumer<PlayerData> updater,
+                        Consumer<PlayerData> persist,
+                        Function<PlayerData, Object> syncFactory,
+                        boolean refreshDisplay,
+                        boolean sync) {
+        Session targetSession = sessionService.get(targetData.uuid);
+        if (targetSession != null) {
+            updater.accept(targetSession.data);
+            persist.accept(targetSession.data);
+            if (refreshDisplay) {
+                playerDisplayService.refresh(targetSession);
+            }
+            if (sync && syncFactory != null) {
+                network.post(syncFactory.apply(targetSession.data));
+            }
+        } else {
+            updater.accept(targetData);
+            persist.accept(targetData);
+            if (sync && syncFactory != null) {
+                network.post(syncFactory.apply(targetData));
+            }
+        }
+    }
+
+    private boolean containsBadgeLikeGlyphs(String input) {
+        return input.codePoints().anyMatch(cp -> cp >= BADGE_ICON_RANGE_START && cp <= BADGE_ICON_RANGE_END);
+    }
+}

--- a/src/main/java/org/xcore/plugin/session/Session.java
+++ b/src/main/java/org/xcore/plugin/session/Session.java
@@ -13,6 +13,8 @@ import org.xcore.plugin.localization.Localization;
 import org.xcore.plugin.model.PlayerData;
 import org.xcore.plugin.ui.MenuBuilder;
 import org.xcore.plugin.ui.MenuService;
+import org.xcore.plugin.ui.flow.ActiveMenuPrompt;
+import org.xcore.plugin.ui.flow.ActiveMenuScreen;
 
 import java.util.ArrayList;
 import java.util.*;
@@ -38,6 +40,10 @@ public class Session {
     public Consumer<String> textHandler;
     public Integer lastPrivateTargetPid;
     public long lastPrivateMessageAt;
+
+    private long uiVersion = 0L;
+    private ActiveMenuScreen activeScreen;
+    private ActiveMenuPrompt activePrompt;
 
     public Session(GlobalConfig globalConfig,
                    Bundle bundle,
@@ -74,8 +80,43 @@ public class Session {
     }
 
     public Session clear() {
-        actions.clear();
+        clearUiState();
         return this;
+    }
+
+    public long nextUiVersion() {
+        return ++uiVersion;
+    }
+
+    public void setActiveScreen(ActiveMenuScreen screen) {
+        this.activeScreen = screen;
+    }
+
+    public ActiveMenuScreen activeScreen() {
+        return activeScreen;
+    }
+
+    public void clearActiveScreen() {
+        this.activeScreen = null;
+    }
+
+    public void setActivePrompt(ActiveMenuPrompt prompt) {
+        this.activePrompt = prompt;
+    }
+
+    public ActiveMenuPrompt activePrompt() {
+        return activePrompt;
+    }
+
+    public void clearActivePrompt() {
+        this.activePrompt = null;
+    }
+
+    public void clearUiState() {
+        clearActiveScreen();
+        clearActivePrompt();
+        actions.clear();
+        textHandler = null;
     }
 
     public String add(String buttonName, Runnable action) {

--- a/src/main/java/org/xcore/plugin/ui/DefaultMindustryMenuGateway.java
+++ b/src/main/java/org/xcore/plugin/ui/DefaultMindustryMenuGateway.java
@@ -1,0 +1,45 @@
+package org.xcore.plugin.ui;
+
+import jakarta.inject.Singleton;
+import mindustry.gen.Call;
+import mindustry.gen.Player;
+
+@Singleton
+public class DefaultMindustryMenuGateway implements MindustryMenuGateway {
+
+    @Override
+    public void menu(Player player, int menuId, String title, String content, String[][] buttons) {
+        if (player == null || player.con == null) return;
+        Call.menu(player.con, menuId, title, content, buttons);
+    }
+
+    @Override
+    public void followUpMenu(Player player, int menuId, String title, String content, String[][] buttons) {
+        if (player == null || player.con == null) return;
+        Call.followUpMenu(player.con, menuId, title, content, buttons);
+    }
+
+    @Override
+    public void hideFollowUpMenu(Player player, int menuId) {
+        if (player == null || player.con == null) return;
+        Call.hideFollowUpMenu(player.con, menuId);
+    }
+
+    @Override
+    public void textInput(Player player, int textInputId, String title, String content, int length, String def, boolean numeric) {
+        if (player == null || player.con == null) return;
+        Call.textInput(player.con, textInputId, title, content, length, def, numeric);
+    }
+
+    @Override
+    public void openUri(Player player, String uri) {
+        if (player == null || player.con == null) return;
+        Call.openURI(player.con, uri);
+    }
+
+    @Override
+    public void copyToClipboard(Player player, String text) {
+        if (player == null || player.con == null) return;
+        Call.copyToClipboard(player.con, text);
+    }
+}

--- a/src/main/java/org/xcore/plugin/ui/MenuBuilder.java
+++ b/src/main/java/org/xcore/plugin/ui/MenuBuilder.java
@@ -1,13 +1,15 @@
 package org.xcore.plugin.ui;
 
-import mindustry.gen.Call;
 import org.xcore.plugin.common.StatusEnum;
 import org.xcore.plugin.localization.Localization;
 import org.xcore.plugin.session.Session;
+import org.xcore.plugin.ui.flow.MenuAction;
+import org.xcore.plugin.ui.flow.MenuMode;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.ospx.flubundle.Bundle.args;
 
@@ -21,6 +23,7 @@ public class MenuBuilder {
     public String content = "";
     public final List<List<String>> rows = new ArrayList<>();
     public final List<String> row = new ArrayList<>();
+    public MenuMode mode = MenuMode.NORMAL;
 
     public MenuBuilder(MenuService service, Session session) {
         this.service = service;
@@ -133,7 +136,7 @@ public class MenuBuilder {
             }));
         }
 
-        row.add(session.add(localization.format("close", args()), session.actions::clear));
+        row.add(session.add(localization.format("close", args()), () -> service.close(session)));
 
         end();
         return this;
@@ -159,8 +162,27 @@ public class MenuBuilder {
         return this;
     }
 
+    public MenuBuilder followUp() {
+        this.mode = MenuMode.FOLLOW_UP;
+        return this;
+    }
+
+    public boolean showFollowUp() {
+        this.mode = MenuMode.FOLLOW_UP;
+        return show();
+    }
+
     public boolean show() {
-        return show(service.getMenuId());
+        if (!row.isEmpty()) {
+            end();
+        }
+
+        List<MenuAction> actions = session.actions.stream()
+                .map(a -> (MenuAction) new MenuAction.CallbackAction(a))
+                .collect(Collectors.toList());
+
+        service.show(session, title, content, rows, actions, mode);
+        return true;
     }
 
     public boolean show(int menuId) {
@@ -168,7 +190,11 @@ public class MenuBuilder {
             end();
         }
 
-        Call.menu(session.player.con, menuId, title, content, service.convertListToArray(rows));
+        if (menuId == service.getMenuId()) {
+            return show();
+        }
+
+        service.showRaw(session, menuId, title, content, rows);
         return true;
     }
 

--- a/src/main/java/org/xcore/plugin/ui/MenuService.java
+++ b/src/main/java/org/xcore/plugin/ui/MenuService.java
@@ -6,37 +6,45 @@ import jakarta.inject.Singleton;
 import mindustry.ui.Menus;
 import org.xcore.plugin.session.SessionService;
 import org.xcore.plugin.session.Session;
+import org.xcore.plugin.ui.flow.ActiveMenuPrompt;
+import org.xcore.plugin.ui.flow.ActiveMenuScreen;
+import org.xcore.plugin.ui.flow.MenuAction;
+import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuFlow;
+import org.xcore.plugin.ui.flow.MenuMode;
+import org.xcore.plugin.ui.flow.MenuPrompt;
+import org.xcore.plugin.ui.flow.MenuRenderContext;
+import org.xcore.plugin.ui.flow.MenuScreen;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 @Singleton
 public class MenuService {
 
     private final Provider<SessionService> sessionService;
+    private final MindustryMenuGateway gateway;
 
     private int globalMenuId;
     private int globalTextId;
 
-    public MenuService(Provider<SessionService> sessionService) {
+    public MenuService(Provider<SessionService> sessionService, MindustryMenuGateway gateway) {
         this.sessionService = sessionService;
+        this.gateway = gateway;
     }
 
     @PostConstruct
     public void init() {
         this.globalMenuId = Menus.registerMenu((player, option) -> {
+            if (player == null) return;
             Session session = sessionService.get().get(player.uuid());
-            if (session == null || session.data == null) return;
-            if (option >= 0 && option < session.actions.size()) {
-                session.actions.get(option).run();
-            }
+            onMenuOption(session, option);
         });
 
         this.globalTextId = Menus.registerTextInput((player, text) -> {
+            if (player == null) return;
             Session session = sessionService.get().get(player.uuid());
-            if (session == null || session.data == null) return;
-            if (session.textHandler != null && text != null) {
-                session.textHandler.accept(text);
-            }
+            onTextInput(session, text);
         });
     }
 
@@ -58,5 +66,213 @@ public class MenuService {
 
     public String[][] convertListToArray(List<List<String>> rows) {
         return rows.stream().map(innerList -> innerList.toArray(new String[0])).toArray(String[][]::new);
+    }
+
+    public void show(Session session, String title, String content, List<List<String>> rows, List<MenuAction> actions, MenuMode mode) {
+        if (session == null || session.player == null || session.player.con == null) return;
+
+        long version = session.nextUiVersion();
+        var screen = ActiveMenuScreen.create(version, mode, actions);
+        session.setActiveScreen(screen);
+
+        String[][] buttons = convertListToArray(rows);
+        if (mode == MenuMode.FOLLOW_UP) {
+            gateway.followUpMenu(session.player, globalMenuId, title, content, buttons);
+        } else {
+            gateway.menu(session.player, globalMenuId, title, content, buttons);
+        }
+    }
+
+    public <TState> void show(Session session, MenuScreen screen, MenuFlow<TState> flow, TState state) {
+        if (session == null || session.player == null || session.player.con == null) return;
+
+        long version = session.nextUiVersion();
+        List<MenuAction> actions = screen.toActions();
+        List<String> actionIds = screen.rows().stream()
+                .flatMap(row -> row.stream().map(MenuButton::actionId))
+                .toList();
+        var active = ActiveMenuScreen.create(version, screen.mode(), actions, flow, state, actionIds);
+        session.setActiveScreen(active);
+
+        String[][] buttons = convertListToArray(screen.toTextRows());
+        if (screen.mode() == MenuMode.FOLLOW_UP) {
+            gateway.followUpMenu(session.player, globalMenuId, screen.title(), screen.content(), buttons);
+        } else {
+            gateway.menu(session.player, globalMenuId, screen.title(), screen.content(), buttons);
+        }
+    }
+
+    public <TState> void renderFlow(Session session, MenuFlow<TState> flow) {
+        TState state = session.getDraft(flow.stateType());
+        var context = new MenuRenderContext<>(this, session, flow, state);
+        MenuScreen screen = flow.render(context);
+        show(session, screen, flow, state);
+    }
+
+    public void hideFollowUp(Session session) {
+        if (session == null || session.player == null) return;
+        var screen = session.activeScreen();
+        if (screen != null && screen.mode() == MenuMode.FOLLOW_UP) {
+            gateway.hideFollowUpMenu(session.player, globalMenuId);
+        }
+        if (session.activeScreen() == screen) {
+            session.clearActiveScreen();
+        }
+    }
+
+    public void close(Session session) {
+        if (session == null) return;
+        var screen = session.activeScreen();
+
+        session.clearActivePrompt();
+        session.textHandler = null;
+        session.actions.clear();
+
+        if (screen != null && screen.mode() == MenuMode.FOLLOW_UP) {
+            if (session.player != null) {
+                gateway.hideFollowUpMenu(session.player, globalMenuId);
+            }
+        }
+        if (screen != null && screen.hasFlow()) {
+            dispatchFlowClose(screen, session);
+        }
+        if (session.activeScreen() == screen) {
+            session.clearActiveScreen();
+        }
+    }
+
+    public void openUri(Session session, String uri) {
+        if (session == null || session.player == null || session.player.con == null) return;
+        gateway.openUri(session.player, uri);
+    }
+
+    public void copyToClipboard(Session session, String text) {
+        if (session == null || session.player == null || session.player.con == null) return;
+        gateway.copyToClipboard(session.player, text);
+    }
+
+    void showRaw(Session session, int menuId, String title, String content, List<List<String>> rows) {
+        if (session == null || session.player == null || session.player.con == null) return;
+        gateway.menu(session.player, menuId, title, content, convertListToArray(rows));
+    }
+
+    public void openTextPrompt(Session session, String title, String content, int length, String def, boolean numeric, Consumer<String> onSubmit, Runnable onCancel) {
+        if (session == null || session.player == null || session.player.con == null) return;
+
+        long version = session.nextUiVersion();
+        var prompt = ActiveMenuPrompt.create(version, globalTextId, onSubmit, onCancel);
+        session.setActivePrompt(prompt);
+
+        gateway.textInput(session.player, globalTextId, title, content, length, def, numeric);
+    }
+
+    public void openPrompt(Session session, MenuPrompt prompt, Consumer<String> onSubmit, Runnable onCancel) {
+        openTextPrompt(session, prompt.title(), prompt.content(), prompt.length(), prompt.defaultValue(), prompt.numeric(), onSubmit, onCancel);
+    }
+
+    public <TState> void openPrompt(Session session, MenuFlow<TState> flow, TState state, MenuPrompt prompt) {
+        if (session == null || session.player == null || session.player.con == null) return;
+
+        long version = session.nextUiVersion();
+        var active = ActiveMenuPrompt.create(version, globalTextId, null, null, flow, state, prompt.promptId());
+        session.setActivePrompt(active);
+
+        gateway.textInput(session.player, globalTextId, prompt.title(), prompt.content(), prompt.length(), prompt.defaultValue(), prompt.numeric());
+    }
+
+    // Package-private for testing
+    void onMenuOption(Session session, int option) {
+        if (session == null || session.data == null) return;
+
+        var screen = session.activeScreen();
+        if (screen != null) {
+            if (option == -1) {
+                session.clearActivePrompt();
+                session.textHandler = null;
+                session.actions.clear();
+
+                if (screen.mode() == MenuMode.FOLLOW_UP) {
+                    gateway.hideFollowUpMenu(session.player, globalMenuId);
+                }
+                if (screen.hasFlow()) {
+                    dispatchFlowClose(screen, session);
+                }
+                if (session.activeScreen() == screen) {
+                    session.clearActiveScreen();
+                }
+                return;
+            }
+            if (option >= 0 && option < screen.actionCount()) {
+                if (screen.hasFlow()) {
+                    dispatchFlowAction(screen, session, option);
+                } else {
+                    screen.runAction(option);
+                }
+            }
+            return;
+        }
+
+        if (option >= 0 && option < session.actions.size()) {
+            session.actions.get(option).run();
+        }
+    }
+
+    // Package-private for testing
+    void onTextInput(Session session, String text) {
+        if (session == null || session.data == null) return;
+
+        var prompt = session.activePrompt();
+        if (prompt != null) {
+            session.clearActivePrompt();
+            if (prompt.hasFlow()) {
+                dispatchFlowPrompt(prompt, session, text);
+            } else {
+                if (text == null) {
+                    prompt.cancel();
+                } else {
+                    prompt.submit(text);
+                }
+            }
+            return;
+        }
+
+        if (text == null) {
+            session.textHandler = null;
+        } else if (session.textHandler != null) {
+            var handler = session.textHandler;
+            session.textHandler = null;
+            handler.accept(text);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void dispatchFlowClose(ActiveMenuScreen screen, Session session) {
+        var flow = (MenuFlow<Object>) screen.flow();
+        var state = screen.state();
+        var context = new MenuRenderContext<>(this, session, flow, state);
+        flow.onClose(context);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void dispatchFlowAction(ActiveMenuScreen screen, Session session, int option) {
+        var flow = (MenuFlow<Object>) screen.flow();
+        var state = screen.state();
+        var context = new MenuRenderContext<>(this, session, flow, state);
+        String actionId = screen.actionIdAt(option);
+        if (actionId != null) {
+            flow.onAction(context, actionId);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void dispatchFlowPrompt(ActiveMenuPrompt prompt, Session session, String text) {
+        var flow = (MenuFlow<Object>) prompt.flow();
+        var state = prompt.state();
+        var context = new MenuRenderContext<>(this, session, flow, state);
+        if (text == null) {
+            flow.onPromptCancel(context, prompt.promptIdString());
+        } else {
+            flow.onPromptSubmit(context, prompt.promptIdString(), text);
+        }
     }
 }

--- a/src/main/java/org/xcore/plugin/ui/MindustryMenuGateway.java
+++ b/src/main/java/org/xcore/plugin/ui/MindustryMenuGateway.java
@@ -1,0 +1,17 @@
+package org.xcore.plugin.ui;
+
+import mindustry.gen.Player;
+
+public interface MindustryMenuGateway {
+    void menu(Player player, int menuId, String title, String content, String[][] buttons);
+
+    void followUpMenu(Player player, int menuId, String title, String content, String[][] buttons);
+
+    void hideFollowUpMenu(Player player, int menuId);
+
+    void textInput(Player player, int textInputId, String title, String content, int length, String def, boolean numeric);
+
+    void openUri(Player player, String uri);
+
+    void copyToClipboard(Player player, String text);
+}

--- a/src/main/java/org/xcore/plugin/ui/flow/ActiveMenuPrompt.java
+++ b/src/main/java/org/xcore/plugin/ui/flow/ActiveMenuPrompt.java
@@ -1,0 +1,67 @@
+package org.xcore.plugin.ui.flow;
+
+import java.util.function.Consumer;
+
+public class ActiveMenuPrompt {
+    private final long version;
+    private final int promptId;
+    private final Consumer<String> onSubmit;
+    private final Runnable onCancel;
+    private final MenuFlow<?> flow;
+    private final Object state;
+    private final String promptIdString;
+
+    private ActiveMenuPrompt(long version, int promptId, Consumer<String> onSubmit, Runnable onCancel, MenuFlow<?> flow, Object state, String promptIdString) {
+        this.version = version;
+        this.promptId = promptId;
+        this.onSubmit = onSubmit;
+        this.onCancel = onCancel;
+        this.flow = flow;
+        this.state = state;
+        this.promptIdString = promptIdString;
+    }
+
+    public static ActiveMenuPrompt create(long version, int promptId, Consumer<String> onSubmit, Runnable onCancel) {
+        return new ActiveMenuPrompt(version, promptId, onSubmit, onCancel, null, null, null);
+    }
+
+    public static ActiveMenuPrompt create(long version, int promptId, Consumer<String> onSubmit, Runnable onCancel, MenuFlow<?> flow, Object state, String promptIdString) {
+        return new ActiveMenuPrompt(version, promptId, onSubmit, onCancel, flow, state, promptIdString);
+    }
+
+    public long version() {
+        return version;
+    }
+
+    public int promptId() {
+        return promptId;
+    }
+
+    public void submit(String text) {
+        if (onSubmit != null) {
+            onSubmit.accept(text);
+        }
+    }
+
+    public void cancel() {
+        if (onCancel != null) {
+            onCancel.run();
+        }
+    }
+
+    public boolean hasFlow() {
+        return flow != null;
+    }
+
+    public MenuFlow<?> flow() {
+        return flow;
+    }
+
+    public Object state() {
+        return state;
+    }
+
+    public String promptIdString() {
+        return promptIdString;
+    }
+}

--- a/src/main/java/org/xcore/plugin/ui/flow/ActiveMenuScreen.java
+++ b/src/main/java/org/xcore/plugin/ui/flow/ActiveMenuScreen.java
@@ -1,0 +1,74 @@
+package org.xcore.plugin.ui.flow;
+
+import java.util.List;
+
+public class ActiveMenuScreen {
+    private final long version;
+    private final MenuMode mode;
+    private final List<MenuAction> actions;
+    private final MenuFlow<?> flow;
+    private final Object state;
+    private final List<String> actionIds;
+
+    private ActiveMenuScreen(long version, MenuMode mode, List<MenuAction> actions, MenuFlow<?> flow, Object state, List<String> actionIds) {
+        this.version = version;
+        this.mode = mode;
+        this.actions = List.copyOf(actions);
+        this.flow = flow;
+        this.state = state;
+        this.actionIds = actionIds == null ? List.of() : List.copyOf(actionIds);
+    }
+
+    public static ActiveMenuScreen create(long version, MenuMode mode, List<MenuAction> actions) {
+        return new ActiveMenuScreen(version, mode, actions, null, null, null);
+    }
+
+    public static ActiveMenuScreen create(long version, MenuMode mode, List<MenuAction> actions, MenuFlow<?> flow, Object state, List<String> actionIds) {
+        return new ActiveMenuScreen(version, mode, actions, flow, state, actionIds);
+    }
+
+    public long version() {
+        return version;
+    }
+
+    public MenuMode mode() {
+        return mode;
+    }
+
+    public int actionCount() {
+        return actions.size();
+    }
+
+    public MenuAction actionAt(int index) {
+        if (index < 0 || index >= actions.size()) {
+            return null;
+        }
+        return actions.get(index);
+    }
+
+    public void runAction(int index) {
+        var action = actionAt(index);
+        if (action != null) {
+            action.run();
+        }
+    }
+
+    public boolean hasFlow() {
+        return flow != null;
+    }
+
+    public MenuFlow<?> flow() {
+        return flow;
+    }
+
+    public Object state() {
+        return state;
+    }
+
+    public String actionIdAt(int index) {
+        if (index < 0 || index >= actionIds.size()) {
+            return null;
+        }
+        return actionIds.get(index);
+    }
+}

--- a/src/main/java/org/xcore/plugin/ui/flow/MenuAction.java
+++ b/src/main/java/org/xcore/plugin/ui/flow/MenuAction.java
@@ -1,0 +1,19 @@
+package org.xcore.plugin.ui.flow;
+
+public sealed interface MenuAction {
+    void run();
+
+    record CallbackAction(Runnable callback) implements MenuAction {
+        @Override
+        public void run() {
+            if (callback != null) callback.run();
+        }
+    }
+
+    record NamedAction(String id, Runnable callback) implements MenuAction {
+        @Override
+        public void run() {
+            if (callback != null) callback.run();
+        }
+    }
+}

--- a/src/main/java/org/xcore/plugin/ui/flow/MenuButton.java
+++ b/src/main/java/org/xcore/plugin/ui/flow/MenuButton.java
@@ -1,0 +1,7 @@
+package org.xcore.plugin.ui.flow;
+
+public record MenuButton(String text, String actionId) {
+    public static MenuButton of(String text, String actionId) {
+        return new MenuButton(text, actionId);
+    }
+}

--- a/src/main/java/org/xcore/plugin/ui/flow/MenuFlow.java
+++ b/src/main/java/org/xcore/plugin/ui/flow/MenuFlow.java
@@ -1,0 +1,24 @@
+package org.xcore.plugin.ui.flow;
+
+public interface MenuFlow<TState> {
+
+    Class<TState> stateType();
+
+    MenuScreen render(MenuRenderContext<TState> context);
+
+    default void onAction(MenuRenderContext<TState> context, String actionId) {
+        // no-op
+    }
+
+    default void onPromptSubmit(MenuRenderContext<TState> context, String promptId, String text) {
+        // no-op
+    }
+
+    default void onPromptCancel(MenuRenderContext<TState> context, String promptId) {
+        // no-op
+    }
+
+    default void onClose(MenuRenderContext<TState> context) {
+        // no-op
+    }
+}

--- a/src/main/java/org/xcore/plugin/ui/flow/MenuMode.java
+++ b/src/main/java/org/xcore/plugin/ui/flow/MenuMode.java
@@ -1,0 +1,6 @@
+package org.xcore.plugin.ui.flow;
+
+public enum MenuMode {
+    NORMAL,
+    FOLLOW_UP
+}

--- a/src/main/java/org/xcore/plugin/ui/flow/MenuPrompt.java
+++ b/src/main/java/org/xcore/plugin/ui/flow/MenuPrompt.java
@@ -1,0 +1,4 @@
+package org.xcore.plugin.ui.flow;
+
+public record MenuPrompt(String promptId, String title, String content, int length, String defaultValue, boolean numeric) {
+}

--- a/src/main/java/org/xcore/plugin/ui/flow/MenuRenderContext.java
+++ b/src/main/java/org/xcore/plugin/ui/flow/MenuRenderContext.java
@@ -1,0 +1,43 @@
+package org.xcore.plugin.ui.flow;
+
+import org.xcore.plugin.localization.Localization;
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.ui.MenuService;
+
+public class MenuRenderContext<TState> {
+    private final MenuService menuService;
+    private final Session session;
+    private final MenuFlow<TState> flow;
+    private final TState state;
+
+    public MenuRenderContext(MenuService menuService, Session session, MenuFlow<TState> flow, TState state) {
+        this.menuService = menuService;
+        this.session = session;
+        this.flow = flow;
+        this.state = state;
+    }
+
+    public Session session() {
+        return session;
+    }
+
+    public TState state() {
+        return state;
+    }
+
+    public Localization locale() {
+        return session.locale();
+    }
+
+    public void render() {
+        menuService.renderFlow(session, flow);
+    }
+
+    public void openPrompt(MenuPrompt prompt) {
+        menuService.openPrompt(session, flow, state, prompt);
+    }
+
+    public void close() {
+        menuService.close(session);
+    }
+}

--- a/src/main/java/org/xcore/plugin/ui/flow/MenuScreen.java
+++ b/src/main/java/org/xcore/plugin/ui/flow/MenuScreen.java
@@ -1,0 +1,51 @@
+package org.xcore.plugin.ui.flow;
+
+import java.util.List;
+
+public record MenuScreen(MenuMode mode, String title, String content, List<List<MenuButton>> rows) {
+
+    public MenuScreen {
+        rows = rows == null
+                ? List.of()
+                : rows.stream()
+                .map(r -> r == null ? List.<MenuButton>of() : List.copyOf(r))
+                .toList();
+    }
+
+    public static MenuScreen normal(String title, String content, List<List<MenuButton>> rows) {
+        return new MenuScreen(MenuMode.NORMAL, title, content, rows);
+    }
+
+    public static MenuScreen followUp(String title, String content, List<List<MenuButton>> rows) {
+        return new MenuScreen(MenuMode.FOLLOW_UP, title, content, rows);
+    }
+
+    public List<List<String>> toTextRows() {
+        return rows.stream()
+                .map(row -> row.stream().map(MenuButton::text).toList())
+                .toList();
+    }
+
+    public List<MenuAction> toActions() {
+        return rows.stream()
+                .flatMap(row -> row.stream().map(b -> (MenuAction) new MenuAction.NamedAction(b.actionId(), null)))
+                .toList();
+    }
+
+    public String actionIdAt(int option) {
+        int idx = 0;
+        for (var row : rows) {
+            for (var btn : row) {
+                if (idx == option) {
+                    return btn.actionId();
+                }
+                idx++;
+            }
+        }
+        return null;
+    }
+
+    public int actionCount() {
+        return rows.stream().mapToInt(List::size).sum();
+    }
+}

--- a/src/main/java/org/xcore/plugin/ui/menu/AuditHistoryMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/AuditHistoryMenu.java
@@ -17,13 +17,26 @@ import org.xcore.plugin.session.SessionService;
 
 import java.time.Instant;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
+
+import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuFlow;
+import org.xcore.plugin.ui.flow.MenuRenderContext;
+import org.xcore.plugin.ui.flow.MenuScreen;
 
 import static com.ospx.flubundle.Bundle.args;
 
 @Singleton
 public class AuditHistoryMenu extends Menu {
+
+    private static final String ACTION_PREVIOUS = "previous";
+    private static final String ACTION_NEXT = "next";
+    private static final String ACTION_DETAILS_PREFIX = "details:";
+    private static final String ACTION_BACK = "back";
+    private static final String ACTION_CLOSE = "close";
+    private static final AuditCursor FIRST_PAGE_MARKER = new AuditCursor(Long.MIN_VALUE, "__first_page__");
 
     private final AuditService auditService;
 
@@ -64,36 +77,9 @@ public class AuditHistoryMenu extends Menu {
             state.currentCursor = null;
             state.nextCursor = null;
         }
-
-        var slice = switch (mode) {
-            case TARGET -> auditService.findSummaryByTargetUuid(targetData.uuid, cursor, globalConfig.eventsPerPage);
-            case ACTOR -> findSummaryByActor(AuditActorType.PLAYER_ADMIN, actorLookupIds(targetData), cursor, globalConfig.eventsPerPage);
-        };
         state.currentCursor = cursor;
-        state.nextCursor = slice.nextCursor();
 
-        String content = buildSummaryContent(session, targetData, mode, slice.items().size(), cursor, slice.hasNext());
-
-        var builder = session.builder()
-                .title(mode == AuditViewMode.TARGET ? "audit-menu-history-title" : "audit-menu-actions-title")
-                .rawContent(content)
-                .start()
-                .ifAddLocal(!state.backStack.isEmpty(), "previous", () -> {
-                    AuditCursor previous = state.backStack.pollLast();
-                    history(viewerUuid, targetData, mode, previous, false);
-                })
-                .ifAddLocal(slice.hasNext() && state.nextCursor != null, "next", () -> {
-                    state.backStack.addLast(state.currentCursor);
-                    history(viewerUuid, targetData, mode, state.nextCursor, false);
-                })
-                .end();
-
-        builder.addForEach(slice.items(), (menu, item) -> menu.addRow(formatSummaryRow(session.locale(), item, mode), () -> {
-            session.pushHistory(() -> history(viewerUuid, targetData, mode, state.currentCursor, false));
-            details(viewerUuid, targetData, item.auditId());
-        }));
-
-        builder.addNavigationRow().show();
+        session.menuService.renderFlow(session, new HistoryFlow(viewerUuid, targetData));
     }
 
     public void details(String viewerUuid, PlayerData targetData, String auditId) {
@@ -113,11 +99,20 @@ public class AuditHistoryMenu extends Menu {
             return;
         }
 
-        session.builder()
+        var builder = session.builder()
                 .title("audit-menu-details-title")
-                .rawContent(formatDetailsContent(session, targetData, record))
-                .addNavigationRow()
-                .show();
+                .rawContent(formatDetailsContent(session, targetData, record));
+
+        if (session.hasHistory()) {
+            builder.addLocal("back", () -> {
+                session.menuService.hideFollowUp(session);
+                Runnable previousMenu = session.popHistory();
+                if (previousMenu != null) previousMenu.run();
+            });
+        }
+
+        builder.addLocal("close", () -> session.menuService.close(session));
+        builder.showFollowUp();
     }
 
     static String formatSummaryRow(Localization local, AuditRecordSummary item) {
@@ -219,6 +214,109 @@ public class AuditHistoryMenu extends Menu {
         return local.t("audit-menu-action-" + action.toLowerCase());
     }
 
+    private final class HistoryFlow implements MenuFlow<AuditHistoryState> {
+        private final String viewerUuid;
+        private final PlayerData targetData;
+
+        HistoryFlow(String viewerUuid, PlayerData targetData) {
+            this.viewerUuid = viewerUuid;
+            this.targetData = targetData;
+        }
+
+        @Override
+        public Class<AuditHistoryState> stateType() {
+            return AuditHistoryState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<AuditHistoryState> context) {
+            Session session = context.session();
+            AuditHistoryState state = context.state();
+            Localization local = context.locale();
+
+            var slice = switch (state.mode) {
+                case TARGET -> auditService.findSummaryByTargetUuid(targetData.uuid, state.currentCursor, globalConfig.eventsPerPage);
+                case ACTOR -> findSummaryByActor(AuditActorType.PLAYER_ADMIN, actorLookupIds(targetData), state.currentCursor, globalConfig.eventsPerPage);
+            };
+            state.nextCursor = slice.nextCursor();
+
+            String content = buildSummaryContent(session, targetData, state.mode, slice.items().size(), state.currentCursor, slice.hasNext());
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+
+            List<MenuButton> paginationRow = new ArrayList<>();
+            if (!state.backStack.isEmpty()) {
+                paginationRow.add(MenuButton.of(local.t("previous"), ACTION_PREVIOUS));
+            }
+            if (slice.hasNext() && state.nextCursor != null) {
+                paginationRow.add(MenuButton.of(local.t("next"), ACTION_NEXT));
+            }
+            if (!paginationRow.isEmpty()) {
+                rows.add(paginationRow);
+            }
+
+            for (var item : slice.items()) {
+                rows.add(List.of(MenuButton.of(
+                        formatSummaryRow(local, item, state.mode),
+                        ACTION_DETAILS_PREFIX + item.auditId()
+                )));
+            }
+
+            List<MenuButton> navRow = new ArrayList<>();
+            if (session.hasHistory()) {
+                navRow.add(MenuButton.of(local.t("back"), ACTION_BACK));
+            }
+            navRow.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
+            rows.add(navRow);
+
+            return MenuScreen.normal(
+                    local.t(state.mode == AuditViewMode.TARGET ? "audit-menu-history-title" : "audit-menu-actions-title"),
+                    content,
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<AuditHistoryState> context, String actionId) {
+            AuditHistoryState state = context.state();
+            Session session = context.session();
+
+            switch (actionId) {
+                case ACTION_PREVIOUS -> {
+                    AuditCursor previous = state.backStack.pollLast();
+                    state.currentCursor = restoreCursor(previous);
+                    context.render();
+                }
+                case ACTION_NEXT -> {
+                    state.backStack.addLast(state.currentCursor == null ? FIRST_PAGE_MARKER : state.currentCursor);
+                    state.currentCursor = state.nextCursor;
+                    context.render();
+                }
+                case ACTION_BACK -> {
+                    Runnable previousMenu = session.popHistory();
+                    if (previousMenu != null) previousMenu.run();
+                }
+                case ACTION_CLOSE -> context.close();
+                default -> {
+                    if (actionId.startsWith(ACTION_DETAILS_PREFIX)) {
+                        String auditId = actionId.substring(ACTION_DETAILS_PREFIX.length());
+                        session.pushHistory(() -> {
+                            session.clear();
+                            AuditHistoryState histState = session.getDraft(AuditHistoryState.class);
+                            histState.targetUuid = state.targetUuid;
+                            histState.mode = state.mode;
+                            histState.backStack = new ArrayDeque<>(state.backStack);
+                            histState.currentCursor = state.currentCursor;
+                            histState.nextCursor = state.nextCursor;
+                            session.menuService.renderFlow(session, new HistoryFlow(viewerUuid, targetData));
+                        });
+                        details(viewerUuid, targetData, auditId);
+                    }
+                }
+            }
+        }
+    }
+
     public static final class AuditHistoryState {
         public String targetUuid;
         public AuditViewMode mode = AuditViewMode.TARGET;
@@ -230,6 +328,10 @@ public class AuditHistoryMenu extends Menu {
     enum AuditViewMode {
         TARGET,
         ACTOR
+    }
+
+    private static AuditCursor restoreCursor(AuditCursor cursor) {
+        return FIRST_PAGE_MARKER.equals(cursor) ? null : cursor;
     }
 
     private Slice<AuditRecordSummary> findSummaryByActor(AuditActorType actorType,

--- a/src/main/java/org/xcore/plugin/ui/menu/BanMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/BanMenu.java
@@ -2,7 +2,6 @@ package org.xcore.plugin.ui.menu;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
-import mindustry.gen.Call;
 import mindustry.gen.Player;
 import org.xcore.plugin.config.Config;
 import org.xcore.plugin.config.GlobalConfig;
@@ -12,6 +11,7 @@ import org.xcore.plugin.service.TimeService;
 import org.xcore.plugin.service.moderation.ModerationService;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.flow.MenuPrompt;
 
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -20,6 +20,9 @@ import static com.ospx.flubundle.Bundle.args;
 
 @Singleton
 public class BanMenu extends Menu {
+
+    private static final String PROMPT_DURATION = "ban-duration";
+    private static final String PROMPT_REASON = "ban-reason";
 
     private final ModerationService moderationService;
     private final TimeService timeService;
@@ -56,7 +59,16 @@ public class BanMenu extends Menu {
             return;
         }
 
-        session.setTextHandler(text -> {
+        var prompt = new MenuPrompt(
+                PROMPT_DURATION,
+                session.locale().t("ban-menu-duration-title"),
+                session.locale().t("ban-menu-duration-message", args("nickname", draft.targetColoredName)),
+                64,
+                draft.durationInput,
+                false
+        );
+
+        session.menuService.openPrompt(session, prompt, text -> {
             String durationInput = text == null ? "" : text.trim();
             var parsed = timeService.parsePeriod(durationInput, TimeUnit.DAYS);
             if (parsed == null || parsed.toEpochMilli() <= 0) {
@@ -68,15 +80,7 @@ public class BanMenu extends Menu {
             draft.durationInput = durationInput;
             draft.duration = Duration.ofMillis(parsed.toEpochMilli());
             askReason(session);
-        });
-
-        Call.textInput(session.player.con,
-                session.menuService.getTextId(),
-                session.locale().t("ban-menu-duration-title"),
-                session.locale().t("ban-menu-duration-message", args("nickname", draft.targetColoredName)),
-                64,
-                draft.durationInput,
-                false);
+        }, () -> cancel(session));
     }
 
     private void askReason(Session session) {
@@ -86,18 +90,19 @@ public class BanMenu extends Menu {
             return;
         }
 
-        session.setTextHandler(text -> {
-            draft.reason = (text == null || text.trim().isEmpty()) ? null : text.trim();
-            confirm(session);
-        });
-
-        Call.textInput(session.player.con,
-                session.menuService.getTextId(),
+        var prompt = new MenuPrompt(
+                PROMPT_REASON,
                 session.locale().t("ban-menu-reason-title"),
                 session.locale().t("ban-menu-reason-message", args("nickname", draft.targetColoredName)),
                 256,
                 draft.reason == null ? "" : draft.reason,
-                false);
+                false
+        );
+
+        session.menuService.openPrompt(session, prompt, text -> {
+            draft.reason = (text == null || text.trim().isEmpty()) ? null : text.trim();
+            confirm(session);
+        }, () -> askDuration(session));
     }
 
     private void confirm(Session session) {
@@ -116,13 +121,14 @@ public class BanMenu extends Menu {
                         "reason", draft.reason == null ? session.locale().t("none") : draft.reason
                 ))
                 .addLocalRow("ban-menu-confirm-action", () -> applyBan(session), "cancel", () -> cancel(session))
-                .show();
+                .showFollowUp();
     }
 
     private void applyBan(Session session) {
         var draft = session.getDraft(BanDraft.class);
         if (draft == null || draft.duration == null) {
             session.locale().send("error-internal", args());
+            session.menuService.close(session);
             return;
         }
 
@@ -131,6 +137,7 @@ public class BanMenu extends Menu {
 
         if (!result.isSuccess() || result.getData().isEmpty()) {
             session.locale().send("error-player-not-found", args());
+            session.menuService.close(session);
             return;
         }
 
@@ -141,6 +148,7 @@ public class BanMenu extends Menu {
         ));
         arc.util.Log.info("@ banned @ (@) for @", session.player.plainName(), draft.targetPlainName, draft.targetUuid, draft.durationInput);
         session.locale().send("commands-ban-success", args("nickname", ban.name));
+        session.menuService.close(session);
     }
 
     private void cancel(Session session) {
@@ -148,6 +156,7 @@ public class BanMenu extends Menu {
         String nickname = draft == null ? session.locale().t("none") : draft.targetColoredName;
         session.clearDraft(BanDraft.class);
         session.locale().send("ban-cancelled", args("nickname", nickname));
+        session.menuService.close(session);
     }
 
     private static final class BanDraft {

--- a/src/main/java/org/xcore/plugin/ui/menu/DiscordMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/DiscordMenu.java
@@ -2,7 +2,6 @@ package org.xcore.plugin.ui.menu;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
-import mindustry.gen.Call;
 import org.xcore.plugin.config.Config;
 import org.xcore.plugin.config.GlobalConfig;
 import org.xcore.plugin.service.DiscordLinkService;
@@ -45,7 +44,7 @@ public class DiscordMenu extends Menu {
                         "status", statusText,
                         "discordUrl", globalConfig.discordUrl
                 ))
-                .addLocal("discord-menu-open", () -> Call.openURI(session.player.con, globalConfig.discordUrl))
+                .addLocal("discord-menu-open", () -> session.menuService.openUri(session, globalConfig.discordUrl))
                 .addLocal("discord-menu-status", () -> main(uuid))
                 .end()
                 .ifAddLocal(!status.linked(), "discord-menu-link", () -> {
@@ -81,6 +80,7 @@ public class DiscordMenu extends Menu {
             } else {
                 local.send("commands-discord-link-error", args());
             }
+            session.menuService.close(session);
             main(uuid);
             return;
         }
@@ -92,14 +92,17 @@ public class DiscordMenu extends Menu {
                         "expireMinutes", result.remainingMinutes(System.currentTimeMillis()),
                         "discordUrl", globalConfig.discordUrl
                 ))
-                .addLocal("discord-menu-open", () -> Call.openURI(session.player.con, globalConfig.discordUrl))
-                .addLocal("discord-link-menu-copy", () -> Call.copyToClipboard(session.player.con, result.code()))
+                .addLocal("discord-menu-open", () -> session.menuService.openUri(session, globalConfig.discordUrl))
+                .addLocal("discord-link-menu-copy", () -> session.menuService.copyToClipboard(session, result.code()))
                 .addLocal("discord-link-menu-refresh", () -> linking(uuid, false))
                 .end()
                 .addLocal("discord-link-menu-regenerate", () -> linking(uuid, true))
-                .addLocal("discord-link-menu-status", () -> main(uuid))
+                .addLocal("discord-link-menu-status", () -> {
+                    session.menuService.close(session);
+                    main(uuid);
+                })
                 .end()
                 .addNavigationRow()
-                .show();
+                .showFollowUp();
     }
 }

--- a/src/main/java/org/xcore/plugin/ui/menu/DiscordMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/DiscordMenu.java
@@ -102,7 +102,16 @@ public class DiscordMenu extends Menu {
                     main(uuid);
                 })
                 .end()
-                .addNavigationRow()
+                .apply(builder -> {
+                    if (session.hasHistory()) {
+                        builder.addLocal("back", () -> {
+                            session.menuService.close(session);
+                            Runnable previousMenu = session.popHistory();
+                            if (previousMenu != null) previousMenu.run();
+                        });
+                    }
+                    builder.addLocal("close", () -> session.menuService.close(session));
+                })
                 .showFollowUp();
     }
 }

--- a/src/main/java/org/xcore/plugin/ui/menu/EventMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/EventMenu.java
@@ -2,7 +2,7 @@ package org.xcore.plugin.ui.menu;
 
 import arc.struct.Seq;
 import mindustry.Vars;
-import mindustry.gen.Call;
+import org.xcore.plugin.ui.flow.MenuPrompt;
 import mindustry.maps.Map;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
@@ -11,13 +11,12 @@ import org.xcore.plugin.common.CustomGatherers;
 import org.xcore.plugin.common.SeqStream;
 import org.xcore.plugin.config.Config;
 import org.xcore.plugin.config.GlobalConfig;
-import org.xcore.plugin.database.repository.EventDataRepository;
-import org.xcore.plugin.database.repository.MapDataRepository;
-import org.xcore.plugin.database.repository.PlayerDataRepository;
 import org.xcore.plugin.model.EventData;
 import org.xcore.plugin.model.MapData;
 import org.xcore.plugin.model.PlayerData;
+import org.xcore.plugin.service.EventEditorService;
 import org.xcore.plugin.service.EventService;
+import org.xcore.plugin.service.EventViewService;
 import org.xcore.plugin.service.MapService;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
@@ -31,25 +30,28 @@ import static com.ospx.flubundle.Bundle.args;
 @Singleton
 public class EventMenu extends Menu {
 
-    private final EventDataRepository eventDataRepository;
-    private final MapDataRepository mapDataRepository;
-    private final PlayerDataRepository playerDataRepository;
     private final MapService mapService;
     private final EventService eventService;
+    private final EventEditorService eventEditorService;
+    private final EventViewService eventViewService;
     private final VoteService voteService;
     private final Provider<MapMenu> mapMenu;
 
+    private static final String PROMPT_CREATE_NAME = "event-create-name";
+    private static final String PROMPT_EDIT_NAME = "event-edit-name";
+    private static final String PROMPT_EDIT_DESCRIPTION = "event-edit-description";
+    private static final String PROMPT_EDIT_PLANNED_START = "event-edit-planned-start";
+    private static final String PROMPT_EDIT_PLANNED_END = "event-edit-planned-end";
+
     @Inject
     public EventMenu(Config config, GlobalConfig globalConfig, SessionService sessionService,
-                     EventDataRepository eventDataRepository, MapDataRepository mapDataRepository,
-                     PlayerDataRepository playerDataRepository, MapService mapService, EventService eventService,
-                     VoteService voteService, Provider<MapMenu> mapMenu) {
+                     MapService mapService, EventService eventService, EventEditorService eventEditorService,
+                     EventViewService eventViewService, VoteService voteService, Provider<MapMenu> mapMenu) {
         super(config, globalConfig, sessionService);
-        this.eventDataRepository = eventDataRepository;
-        this.mapDataRepository = mapDataRepository;
-        this.playerDataRepository = playerDataRepository;
         this.mapService = mapService;
         this.eventService = eventService;
+        this.eventEditorService = eventEditorService;
+        this.eventViewService = eventViewService;
         this.voteService = voteService;
         this.mapMenu = mapMenu;
     }
@@ -58,7 +60,7 @@ public class EventMenu extends Menu {
         Session session = sessionService.get(uuid);
         if (session == null || session.data == null) return;
         session.clear();
-        EventData active = eventDataRepository.findActive().orElse(null);
+        EventData active = eventViewService.activeEvent();
 
         var builder = session.builder()
                 .title("event-menu-main-title")
@@ -87,7 +89,7 @@ public class EventMenu extends Menu {
                 builder.addLocal(session.locale().t("event-menu-vote-stop"), voteService::endVote);
             }
             if (active != null && active.isActive) {
-                builder.addLocal(session.locale().t("event-menu-stop"), eventDataRepository::finishActiveEvent);
+                builder.addLocal(session.locale().t("event-menu-stop"), eventService::finishActiveEvent);
             }
             builder.end();
         }
@@ -99,19 +101,23 @@ public class EventMenu extends Menu {
         Session session = sessionService.get(uuid);
         if (session == null || session.data == null) return;
         session.clear();
-        EventData draft = session.getDraft(EventData.class);
-        draft.author = session.data.id;
-        if (map != null) draft.map = map.id;
+        EventData draft = eventEditorService.initializeDraft(session, map);
 
-        session.setTextHandler((text) -> {
-            draft.name = text;
-            edit(uuid);
-        });
-
-        Call.textInput(session.player.con, session.menuService.getTextId(),
-                session.locale().t("event-menu-create-start-title"),
-                session.locale().t("event-menu-create-start-message"),
-                20, session.locale().t("event-menu-create-start-default", args("playerName", session.player.name)), false);
+        session.menuService.openPrompt(session,
+                new MenuPrompt(PROMPT_CREATE_NAME,
+                        session.locale().t("event-menu-create-start-title"),
+                        session.locale().t("event-menu-create-start-message"),
+                        20,
+                        session.locale().t("event-menu-create-start-default", args("playerName", session.player.name)),
+                        false),
+                text -> {
+                    eventEditorService.updateName(draft, text);
+                    edit(uuid);
+                },
+                () -> {
+                    eventEditorService.cancelDraft(session);
+                    main(uuid);
+                });
     }
 
     public void edit(String uuid) {
@@ -121,8 +127,8 @@ public class EventMenu extends Menu {
         if (!session.hasDraft(EventData.class)) { main(uuid); return; }
 
         EventData draft = session.getDraft(EventData.class);
-        MapData mapData = mapDataRepository.findById(draft.map);
-        PlayerData authorData = playerDataRepository.findById(draft.author);
+        MapData mapData = eventEditorService.findMapForDraft(draft);
+        PlayerData authorData = eventEditorService.findAuthorForDraft(draft);
 
         String yes = session.locale().t("yes");
         String no = session.locale().t("no");
@@ -140,16 +146,30 @@ public class EventMenu extends Menu {
                 ))
                 .start()
                     .addLocal(session.locale().t("event-menu-edit-name"), () -> {
-                        session.setTextHandler(t -> { draft.name = t; edit(uuid); });
-                        Call.textInput(session.player.con, session.menuService.getTextId(), session.locale().t("event-menu-edit-name-title"), "", 24, draft.name, false);
+                        session.menuService.openPrompt(session,
+                                new MenuPrompt(PROMPT_EDIT_NAME,
+                                        session.locale().t("event-menu-edit-name-title"),
+                                        "",
+                                        24,
+                                        draft.name,
+                                        false),
+                                t -> { eventEditorService.updateName(draft, t); edit(uuid); },
+                                () -> edit(uuid));
                     })
                     .addLocal(session.locale().t("event-menu-edit-name-reset"), () -> {
-                        draft.name = new EventData().name;
+                        eventEditorService.resetName(draft);
                         edit(uuid);
                     })
                     .addLocal(session.locale().t("event-menu-edit-description"), () -> {
-                        session.setTextHandler(t -> { draft.description = t; edit(uuid); });
-                        Call.textInput(session.player.con, session.menuService.getTextId(), session.locale().t("event-menu-edit-description-title"), "", 1000, draft.description, false);
+                        session.menuService.openPrompt(session,
+                                new MenuPrompt(PROMPT_EDIT_DESCRIPTION,
+                                        session.locale().t("event-menu-edit-description-title"),
+                                        "",
+                                        1000,
+                                        draft.description,
+                                        false),
+                                t -> { eventEditorService.updateDescription(draft, t); edit(uuid); },
+                                () -> edit(uuid));
                     })
                 .end()
                 .start()
@@ -158,35 +178,48 @@ public class EventMenu extends Menu {
                         mapSelection(uuid, 1);
                     })
                     .addLocal(draft.isTemporary ? session.locale().t("event-menu-edit-temporary-active") : session.locale().t("event-menu-edit-temporary-inactive"), () -> {
-                        draft.isTemporary = !draft.isTemporary; edit(uuid);
+                        eventEditorService.toggleTemporary(draft); edit(uuid);
                     })
                 .end()
                 .start()
                     .addLocal(session.locale().t("event-menu-edit-planned-start"), () -> {
-                        session.setTextHandler(t -> { draft.plannedStartTime = parseTime(t); edit(uuid); });
-                        Call.textInput(session.player.con, session.menuService.getTextId(), session.locale().t("event-menu-edit-planned-start-title"), "", 64, "", false);
+                        session.menuService.openPrompt(session,
+                                new MenuPrompt(PROMPT_EDIT_PLANNED_START,
+                                        session.locale().t("event-menu-edit-planned-start-title"),
+                                        "",
+                                        64,
+                                        "",
+                                        false),
+                                t -> { eventEditorService.updatePlannedStartTime(draft, t); edit(uuid); },
+                                () -> edit(uuid));
                     })
                     .addLocal(session.locale().t("event-menu-edit-planned-end"), () -> {
-                        session.setTextHandler(t -> { draft.plannedEndTime = parseTime(t); edit(uuid); });
-                        Call.textInput(session.player.con, session.menuService.getTextId(), session.locale().t("event-menu-edit-planned-end-title"), "", 10, "", false);
+                        session.menuService.openPrompt(session,
+                                new MenuPrompt(PROMPT_EDIT_PLANNED_END,
+                                        session.locale().t("event-menu-edit-planned-end-title"),
+                                        "",
+                                        10,
+                                        "",
+                                        false),
+                                t -> { eventEditorService.updatePlannedEndTime(draft, t); edit(uuid); },
+                                () -> edit(uuid));
                     })
                 .end()
                 .start()
                     .addLocal("[green]" + session.locale().t("save"), () -> {
-                        if (draft.map == null) { session.locale().send("error-no-map"); return; }
-                        eventDataRepository.save(draft);
-                        session.clearDraft(EventData.class);
-                        events(uuid, 1);
+                        if (eventEditorService.saveDraft(session)) {
+                            events(uuid, 1);
+                        }
                     })
                     .addLocal("[red]" + session.locale().t("cancel"), () -> {
-                        session.clearDraft(EventData.class);
+                        eventEditorService.cancelDraft(session);
                         main(uuid);
                     })
                 .end()
                 .apply(b -> {
                     if (session.player.admin) {
                         b.addRow(draft.isMajor ? session.locale().t("event-menu-edit-major-active") : session.locale().t("event-menu-edit-major-inactive"), () -> {
-                            draft.isMajor = !draft.isMajor; edit(uuid);
+                            eventEditorService.toggleMajor(draft); edit(uuid);
                         });
                     }
                 })
@@ -197,8 +230,9 @@ public class EventMenu extends Menu {
         Session session = sessionService.get(uuid);
         if (session == null || session.data == null) return;
         session.clear();
-        MapData mapData = mapDataRepository.findById(event.map);
-        PlayerData authorData = playerDataRepository.findById(event.author);
+        EventViewService.EventDetails details = eventViewService.details(event);
+        MapData mapData = details.map();
+        PlayerData authorData = details.author();
 
         String yes = session.locale().t("yes");
         String no = session.locale().t("no");
@@ -256,21 +290,16 @@ public class EventMenu extends Menu {
         Session session = sessionService.get(uuid);
         if (session == null || session.data == null) return;
         session.clear();
-        int total = (int) eventDataRepository.count(session.sortStatus);
         int perPage = globalConfig.eventsPerPage;
-        var pagination = CustomGatherers.calculatePagination(total, perPage);
-
-        int validPage = pagination.clampPage(page);
-        int skip = (validPage - 1) * perPage;
-        List<EventData> events = eventDataRepository.findPage(skip, perPage, session.sortStatus);
+        EventViewService.EventPage eventPage = eventViewService.page(page, perPage, session.sortStatus);
 
         String menuContent;
-        if (total == 0) {
+        if (eventPage.isEmpty()) {
             menuContent = session.locale().t("event-menu-events-empty");
         } else {
             menuContent = session.locale().t("event-menu-events-content", args(
-                "page", validPage,
-                "total", pagination.totalPages()
+                "page", eventPage.page(),
+                "total", eventPage.totalPages()
             ));
         }
 
@@ -283,11 +312,11 @@ public class EventMenu extends Menu {
                     .addStatusButton("active", () -> events(uuid, 1))
                 .end()
                 .start()
-                    .ifAddLocal(validPage > 1, "previous", () -> events(uuid, validPage - 1))
-                    .ifAddLocal(validPage < pagination.totalPages(), "next", () -> events(uuid, validPage + 1))
+                    .ifAddLocal(eventPage.hasPrevious(), "previous", () -> events(uuid, eventPage.page() - 1))
+                    .ifAddLocal(eventPage.hasNext(), "next", () -> events(uuid, eventPage.page() + 1))
                 .end()
-                .addForEach(events, (b, e) -> b.addRow(e.isActive ? session.locale().t("event-menu-events-selected", args("name", e.name)) : e.name, () -> {
-                    session.pushHistory(() -> events(uuid, validPage));
+                .addForEach(eventPage.events(), (b, e) -> b.addRow(e.isActive ? session.locale().t("event-menu-events-selected", args("name", e.name)) : e.name, () -> {
+                    session.pushHistory(() -> events(uuid, eventPage.page()));
                     event(uuid, e);
                 }))
                 .addLocalRow("event-menu-main", () -> { session.clearHistory(); main(uuid); })
@@ -311,30 +340,11 @@ public class EventMenu extends Menu {
                     .ifAddLocal(validPage < pagination.totalPages(), "next", () -> mapSelection(uuid, validPage + 1))
                 .end()
                 .addForEach(SeqStream.of(maps).gather(CustomGatherers.page(globalConfig.mapsPerPage, validPage)).flatMap(List::stream)::iterator, (b, m) -> b.addRow(m.name(), () -> {
-                    MapData data = mapDataRepository.findOrCreate(m.plainName(), m.file.name(), m.author(), Vars.state.rules.mode().name());
-                    session.getDraft(EventData.class).map = data.id;
+                    eventEditorService.selectMapForDraft(session, m.plainName(), m.file.name(), m.author(), Vars.state.rules.mode().name());
                     edit(uuid);
                 }))
                 .addNavigationRow()
                 .show();
     }
 
-    private long parseTime(String input) {
-        if (input == null || input.isEmpty()) return 0;
-        try {
-            if (input.startsWith("+")) {
-                long now = System.currentTimeMillis();
-                String valueStr = input.substring(1, input.length() - 1);
-                char unit = input.charAt(input.length() - 1);
-                long value = Long.parseLong(valueStr);
-                return now + switch (unit) {
-                    case 'm' -> value * 60_000L;
-                    case 'h' -> value * 3_600_000L;
-                    case 'd' -> value * 86_400_000L;
-                    default -> 0;
-                };
-            }
-            return Long.parseLong(input);
-        } catch (Exception e) { return 0; }
-    }
 }

--- a/src/main/java/org/xcore/plugin/ui/menu/InformationMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/InformationMenu.java
@@ -3,17 +3,31 @@ package org.xcore.plugin.ui.menu;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
-import mindustry.gen.Call;
 import org.xcore.plugin.common.BuildInfo;
 import org.xcore.plugin.config.Config;
 import org.xcore.plugin.config.GlobalConfig;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuFlow;
+import org.xcore.plugin.ui.flow.MenuRenderContext;
+import org.xcore.plugin.ui.flow.MenuScreen;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.ospx.flubundle.Bundle.args;
 
 @Singleton
 public class InformationMenu extends Menu {
+    private static final String ACTION_DISCORD = "discord";
+    private static final String ACTION_GITHUB = "github";
+    private static final String ACTION_DONATELLO = "donatello";
+    private static final String ACTION_WEBLATE = "weblate";
+    private static final String ACTION_DISCORD_RED_VS_BLUE = "discord-red-vs-blue";
+    private static final String ACTION_BACK = "back";
+    private static final String ACTION_CLOSE = "close";
+
     private final BuildInfo buildInfo;
 
     private final Provider<MapMenu> map;
@@ -59,16 +73,71 @@ public class InformationMenu extends Menu {
         if (session == null || session.data == null) return;
         session.clear();
 
-        session.builder().title("commands-info-title", args("server-name", config.server))
-                .content("commands-info-text", args("version", buildInfo.getVersion()))
-                .addLocal("discord", () -> Call.openURI(session.player.con, globalConfig.discordUrl))
-                .addLocal("github", () -> Call.openURI(session.player.con, globalConfig.githubUrl))
-                .end()
-                .addLocal("donatello", () -> Call.openURI(session.player.con, globalConfig.donatelloUrl))
-                .addLocal("weblate", () -> Call.openURI(session.player.con, globalConfig.weblateUrl))
-                .end()
-                .addLocalRow("discord-red-vs-blue", () -> Call.openURI(session.player.con, globalConfig.discordRedVSBlueUrl))
-                .addNavigationRow()
-                .show();
+        session.menuService.renderFlow(session, new InformationFlow());
+    }
+
+    private final class InformationFlow implements MenuFlow<InformationState> {
+        @Override
+        public Class<InformationState> stateType() {
+            return InformationState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<InformationState> context) {
+            Session session = context.session();
+            var local = context.locale();
+            List<List<MenuButton>> rows = new ArrayList<>();
+            rows.add(List.of(
+                    MenuButton.of(local.t("discord"), ACTION_DISCORD),
+                    MenuButton.of(local.t("github"), ACTION_GITHUB)
+            ));
+            rows.add(List.of(
+                    MenuButton.of(local.t("donatello"), ACTION_DONATELLO),
+                    MenuButton.of(local.t("weblate"), ACTION_WEBLATE)
+            ));
+            rows.add(List.of(MenuButton.of(local.t("discord-red-vs-blue"), ACTION_DISCORD_RED_VS_BLUE)));
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.hasHistory()) {
+                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.followUp(
+                    local.t("commands-info-title", args("server-name", config.server)),
+                    local.t("commands-info-text", args("version", buildInfo.getVersion())),
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<InformationState> context, String actionId) {
+            Session session = context.session();
+            switch (actionId) {
+                case ACTION_DISCORD -> openUrl(session, globalConfig.discordUrl);
+                case ACTION_GITHUB -> openUrl(session, globalConfig.githubUrl);
+                case ACTION_DONATELLO -> openUrl(session, globalConfig.donatelloUrl);
+                case ACTION_WEBLATE -> openUrl(session, globalConfig.weblateUrl);
+                case ACTION_DISCORD_RED_VS_BLUE -> openUrl(session, globalConfig.discordRedVSBlueUrl);
+                case ACTION_BACK -> {
+                    Runnable previousMenu = session.popHistory();
+                    if (previousMenu != null) {
+                        session.menuService.close(session);
+                        previousMenu.run();
+                    }
+                }
+                case ACTION_CLOSE -> context.close();
+                default -> {
+                }
+            }
+        }
+
+        private void openUrl(Session session, String url) {
+            session.menuService.openUri(session, url);
+        }
+    }
+
+    public static final class InformationState {
     }
 }

--- a/src/main/java/org/xcore/plugin/ui/menu/MessageMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/MessageMenu.java
@@ -1,9 +1,7 @@
 package org.xcore.plugin.ui.menu;
 
-import arc.struct.Seq;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
-import mindustry.gen.Call;
 import org.bson.types.ObjectId;
 import org.xcore.plugin.common.CustomGatherers;
 import org.xcore.plugin.config.Config;
@@ -13,6 +11,7 @@ import org.xcore.plugin.model.PrivateMessage;
 import org.xcore.plugin.service.PrivateMessageService;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.flow.MenuPrompt;
 
 import java.util.List;
 
@@ -20,6 +19,10 @@ import static com.ospx.flubundle.Bundle.args;
 
 @Singleton
 public class MessageMenu extends Menu {
+
+    private static final String PROMPT_REPLY = "private-message-reply";
+    private static final String PROMPT_COMPOSE_TARGET = "private-message-compose-target";
+    private static final String PROMPT_COMPOSE_BODY = "private-message-compose-body";
 
     private final PrivateMessageService privateMessageService;
 
@@ -175,53 +178,61 @@ public class MessageMenu extends Menu {
         Session session = sessionService.get(uuid);
         if (session == null || session.data == null) return;
 
-        session.setTextHandler(text -> {
-            privateMessageService.send(session, message.fromPid, text);
-            details(uuid, message.id, returnPage);
-        });
-
-        Call.textInput(session.player.con,
-                session.menuService.getTextId(),
-                session.locale().t("private-message-reply-title"),
-                session.locale().t("private-message-reply-message", args("pid", message.fromPid)),
-                globalConfig.privateMessageMaxLength,
-                "",
-                false);
+        session.menuService.openPrompt(session,
+                new MenuPrompt(
+                        PROMPT_REPLY,
+                        session.locale().t("private-message-reply-title"),
+                        session.locale().t("private-message-reply-message", args("pid", message.fromPid)),
+                        globalConfig.privateMessageMaxLength,
+                        "",
+                        false),
+                text -> {
+                    privateMessageService.send(session, message.fromPid, text);
+                    details(uuid, message.id, returnPage);
+                },
+                () -> details(uuid, message.id, returnPage));
     }
 
     private void promptCompose(String uuid, Runnable onBack) {
         Session session = sessionService.get(uuid);
         if (session == null || session.data == null) return;
 
-        session.setTextHandler(pidText -> {
-            Integer targetPid = privateMessageService.parseMenuPid(pidText);
-            if (targetPid == null) {
-                session.locale().send("error-private-message-invalid-pid", args());
-                onBack.run();
-                return;
-            }
+        session.menuService.openPrompt(session,
+                new MenuPrompt(
+                        PROMPT_COMPOSE_TARGET,
+                        session.locale().t("private-message-compose-target-title"),
+                        session.locale().t("private-message-compose-target-message"),
+                        32,
+                        session.lastPrivateTargetPid == null ? "" : "#" + session.lastPrivateTargetPid,
+                        false),
+                pidText -> handleComposeTarget(uuid, onBack, pidText),
+                onBack);
+    }
 
-            session.setTextHandler(message -> {
-                privateMessageService.send(session, targetPid, message);
-                onBack.run();
-            });
+    private void handleComposeTarget(String uuid, Runnable onBack, String pidText) {
+        Session session = sessionService.get(uuid);
+        if (session == null || session.data == null) return;
 
-            Call.textInput(session.player.con,
-                    session.menuService.getTextId(),
-                    session.locale().t("private-message-compose-body-title"),
-                    session.locale().t("private-message-compose-body-message", args("pid", "#" + targetPid)),
-                    globalConfig.privateMessageMaxLength,
-                    "",
-                    false);
-        });
+        Integer targetPid = privateMessageService.parseMenuPid(pidText);
+        if (targetPid == null) {
+            session.locale().send("error-private-message-invalid-pid", args());
+            onBack.run();
+            return;
+        }
 
-        Call.textInput(session.player.con,
-                session.menuService.getTextId(),
-                session.locale().t("private-message-compose-target-title"),
-                session.locale().t("private-message-compose-target-message"),
-                32,
-                session.lastPrivateTargetPid == null ? "" : "#" + session.lastPrivateTargetPid,
-                false);
+        session.menuService.openPrompt(session,
+                new MenuPrompt(
+                        PROMPT_COMPOSE_BODY,
+                        session.locale().t("private-message-compose-body-title"),
+                        session.locale().t("private-message-compose-body-message", args("pid", "#" + targetPid)),
+                        globalConfig.privateMessageMaxLength,
+                        "",
+                        false),
+                message -> {
+                    privateMessageService.send(session, targetPid, message);
+                    onBack.run();
+                },
+                onBack);
     }
 
     private String preview(String message) {

--- a/src/main/java/org/xcore/plugin/ui/menu/PlayerMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/PlayerMenu.java
@@ -5,66 +5,52 @@ import arc.util.Strings;
 import com.ospx.flubundle.Bundle;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
-import mindustry.gen.Call;
 import org.xcore.plugin.common.CustomGatherers;
 import org.xcore.plugin.config.Config;
 import org.xcore.plugin.config.GlobalConfig;
 import org.xcore.plugin.database.repository.GameDataRepository;
-import org.xcore.plugin.database.repository.PlayerDataRepository;
 import org.xcore.plugin.localization.Localization;
 import org.xcore.plugin.model.ModeStatsSummary;
 import org.xcore.plugin.model.PlayerData;
 import org.xcore.plugin.model.PlayerStatsOverview;
 import org.xcore.plugin.player.Badge;
-import org.xcore.plugin.service.NetworkService;
 import org.xcore.plugin.service.PlayerDisplayService;
+import org.xcore.plugin.service.PlayerProfileSettingsService;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
-import org.xcore.protocol.generated.messages.chat.ChatMessages.PlayerActiveBadgeChangedCommandV1;
-import org.xcore.protocol.generated.messages.chat.ChatMessages.PlayerBadgeSymbolColorModeChangedCommandV1;
-import org.xcore.protocol.generated.messages.chat.ChatMessages.PlayerCustomNicknameChangedCommandV1;
+import org.xcore.plugin.ui.flow.MenuPrompt;
 
-import java.nio.charset.StandardCharsets;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.function.Consumer;
 
 import static com.ospx.flubundle.Bundle.args;
 @Singleton
 public class PlayerMenu extends Menu {
 
-    /** Vanilla Mindustry name length limit in UTF-8 bytes (see Vars.maxNameLength). */
-    private static final int MAX_PLAIN_NAME_BYTES = 40;
-    private static final int BADGE_ICON_RANGE_START = 0xE800;
-    private static final int BADGE_ICON_RANGE_END = 0xF8FF;
-
-    private final PlayerDataRepository playerDataRepository;
     private final GameDataRepository gameDataRepository;
     private final Bundle bundle;
-    private final NetworkService network;
     private final PlayerDisplayService playerDisplayService;
+    private final PlayerProfileSettingsService profileSettings;
     private final AuditHistoryMenu auditHistoryMenu;
 
     @Inject
     public PlayerMenu(Config config,
                       GlobalConfig globalConfig,
                       SessionService sessionService,
-                      PlayerDataRepository playerDataRepository,
                       GameDataRepository gameDataRepository,
                       Bundle bundle,
-                      NetworkService network,
                       PlayerDisplayService playerDisplayService,
+                      PlayerProfileSettingsService profileSettings,
                       AuditHistoryMenu auditHistoryMenu) {
         super(config, globalConfig, sessionService);
-        this.playerDataRepository = playerDataRepository;
         this.gameDataRepository = gameDataRepository;
         this.bundle = bundle;
-        this.network = network;
         this.playerDisplayService = playerDisplayService;
+        this.profileSettings = profileSettings;
         this.auditHistoryMenu = auditHistoryMenu;
     }
 
@@ -315,45 +301,43 @@ public class PlayerMenu extends Menu {
                 ))
                 .start()
                     .addLocal("player-menu-settings-customNickname", () -> {
-                        session.textHandler = t -> {
-                            boolean isReset = (t == null || t.trim().isEmpty());
-                            String newNick = isReset ? "" : t;
-
-                            if (!isReset) {
-                                String plain = Strings.stripColors(newNick);
-                                if (plain.getBytes(StandardCharsets.UTF_8).length > MAX_PLAIN_NAME_BYTES) {
-                                    local.send("error-nickname-too-long", args("max", MAX_PLAIN_NAME_BYTES));
+                        var prompt = new MenuPrompt(
+                                "custom-nickname",
+                                local.t("player-menu-settings-customNickname-title"),
+                                local.t("player-menu-settings-customNickname-message"),
+                                256, targetData.customNickname, false);
+                        session.menuService.openPrompt(session, prompt,
+                                text -> {
+                                    String newNick = text == null || text.trim().isEmpty() ? "" : text;
+                                    if (!newNick.isEmpty()) {
+                                        var result = profileSettings.validateCustomNickname(newNick);
+                                        if (!result.valid()) {
+                                            local.send(result.errorKey(), args("max", result.maxBytes()));
+                                            settings(uuid, targetData);
+                                            return;
+                                        }
+                                    }
+                                    profileSettings.updateCustomNickname(targetData, newNick, true, true);
                                     settings(uuid, targetData);
-                                    return;
-                                }
-
-                                if (containsBadgeLikeGlyphs(plain)) {
-                                    local.send("error-nickname-badge-glyph", args());
-                                    settings(uuid, targetData);
-                                    return;
-                                }
-                            }
-
-                            updateCustomNickname(targetData, newNick, true, true);
-
-                            settings(uuid, targetData);
-                        };
-
-                        Call.textInput(session.player.con, session.menuService.getTextId(),
-                            local.t("player-menu-settings-customNickname-title"),
-                            local.t("player-menu-settings-customNickname-message"),
-                            256, targetData.customNickname, false);
+                                },
+                                () -> settings(uuid, targetData));
                     })
                     .addLocal("player-menu-settings-customNickname-reset", () -> {
-                        updateCustomNickname(targetData, "", true, true);
+                        profileSettings.updateCustomNickname(targetData, "", true, true);
                         settings(uuid, targetData);
                     })
                     .addLocal("player-menu-settings-description", () -> {
-                        session.textHandler = t -> {
-                            updateDescription(targetData, t);
-                            settings(uuid, targetData);
-                        };
-                        Call.textInput(session.player.con, session.menuService.getTextId(), local.t("player-menu-settings-description-title"), "", 1000, targetData.description, false);
+                        var prompt = new MenuPrompt(
+                                "description",
+                                local.t("player-menu-settings-description-title"),
+                                "",
+                                1000, targetData.description, false);
+                        session.menuService.openPrompt(session, prompt,
+                                text -> {
+                                    profileSettings.updateDescription(targetData, text);
+                                    settings(uuid, targetData);
+                                },
+                                () -> settings(uuid, targetData));
                     })
                 .end()
                 .addLocalRow("player-menu-settings-chat", () -> {
@@ -365,7 +349,7 @@ public class PlayerMenu extends Menu {
                     badges(uuid, targetData);
                 })
                 .addLocalRow(targetData.leaderboard ? "player-leaderboard-active" : "player-leaderboard-inactive", () -> {
-                    updateLeaderboard(targetData, !targetData.leaderboard);
+                    profileSettings.updateLeaderboard(targetData, !targetData.leaderboard);
                     settings(uuid, targetData);
                 })
                 .start()
@@ -402,11 +386,11 @@ public class PlayerMenu extends Menu {
                         "translatorLanguage", local.getLanguageName(targetData.translatorLanguage, "off")
                 ))
                 .addLocalRow(targetData.globalChatVisible ? "player-menu-settings-global-chat-on" : "player-menu-settings-global-chat-off", () -> {
-                    updateGlobalChatVisible(targetData, !targetData.globalChatVisible);
+                    profileSettings.updateGlobalChatVisible(targetData, !targetData.globalChatVisible);
                     chatSettings(uuid, targetData);
                 })
                 .addLocalRow(targetData.discordRelayVisible ? "player-menu-settings-discord-relay-on" : "player-menu-settings-discord-relay-off", () -> {
-                    updateDiscordRelayVisible(targetData, !targetData.discordRelayVisible);
+                    profileSettings.updateDiscordRelayVisible(targetData, !targetData.discordRelayVisible);
                     chatSettings(uuid, targetData);
                 })
                 .addRow(local.t("settings-translator-label", args("lang", local.getLanguageName(targetData.translatorLanguage, "off"))), () -> {
@@ -429,9 +413,9 @@ public class PlayerMenu extends Menu {
                 .start()
                     .addLocal(isTranslator ? "default" : "auto", () -> {
                         if (isTranslator) {
-                            updateTranslatorLanguage(targetData, "off");
+                            profileSettings.updateTranslatorLanguage(targetData, "off");
                         } else {
-                            updateLanguage(targetData, "auto");
+                            profileSettings.updateLanguage(targetData, "auto");
                         }
                         session.popHistory().run();
                     })
@@ -443,9 +427,9 @@ public class PlayerMenu extends Menu {
 
             b.addRow(langName, () -> {
                         if (isTranslator) {
-                            updateTranslatorLanguage(targetData, code);
+                            profileSettings.updateTranslatorLanguage(targetData, code);
                         } else {
-                            updateLanguage(targetData, code);
+                            profileSettings.updateLanguage(targetData, code);
                         }
                         session.popHistory().run();
                     });
@@ -485,7 +469,7 @@ public class PlayerMenu extends Menu {
                     "badge", badgeLabel(local, badge),
                     "description", local.t(badge.descriptionKey())
             )), () -> {
-                updateActiveBadge(targetData, badge.id(), true, true);
+                profileSettings.updateActiveBadge(targetData, badge.id(), true, true);
                 badges(uuid, targetData);
             }));
         }
@@ -502,7 +486,7 @@ public class PlayerMenu extends Menu {
                     allBadges(uuid, targetData);
                 })
                 .addLocal("badge-clear-button", () -> {
-                    updateActiveBadge(targetData, "", true, true);
+                    profileSettings.updateActiveBadge(targetData, "", true, true);
                     badges(uuid, targetData);
                 })
                 .end()
@@ -532,11 +516,11 @@ public class PlayerMenu extends Menu {
                         "mode", badgeSymbolColorModeLabel(local, targetData)
                 ))
                 .addLocalRow("badge-menu-symbol-color-default", () -> {
-                    updateBadgeSymbolColorMode(targetData, "default", true, true);
+                    profileSettings.updateBadgeSymbolColorMode(targetData, "default", true, true);
                     badgeSymbolColorMode(uuid, targetData);
                 })
                 .addLocalRow("badge-menu-symbol-color-player-color", () -> {
-                    updateBadgeSymbolColorMode(targetData, "player-color", true, true);
+                    profileSettings.updateBadgeSymbolColorMode(targetData, "player-color", true, true);
                     badgeSymbolColorMode(uuid, targetData);
                 })
                 .addNavigationRow()
@@ -568,142 +552,12 @@ public class PlayerMenu extends Menu {
                 "description", local.t(badge.descriptionKey())
         )), () -> {
             if (badge.selectable() && !badge.system() && ownsBadge(targetData, badge)) {
-                updateActiveBadge(targetData, badge.id(), true, true);
+                profileSettings.updateActiveBadge(targetData, badge.id(), true, true);
             }
             allBadges(uuid, targetData);
         }));
 
         builder.addNavigationRow().show();
-    }
-
-    private void updateCustomNickname(PlayerData targetData, String customNickname, boolean refreshDisplay, boolean sync) {
-        updatePlayerData(targetData,
-                data -> data.customNickname = customNickname,
-                data -> playerDataRepository.updateCustomNickname(data.uuid, customNickname),
-                data -> new PlayerCustomNicknameChangedCommandV1(data.uuid, data.customNickname, config.server),
-                refreshDisplay,
-                sync);
-    }
-
-    private void updateDescription(PlayerData targetData, String description) {
-        updatePlayerData(targetData,
-                data -> data.description = description,
-                data -> playerDataRepository.updateDescription(data.uuid, description),
-                null,
-                false,
-                false);
-    }
-
-    private void updateLeaderboard(PlayerData targetData, boolean leaderboard) {
-        updatePlayerData(targetData,
-                data -> data.leaderboard = leaderboard,
-                data -> playerDataRepository.updateLeaderboard(data.uuid, leaderboard),
-                null,
-                false,
-                false);
-    }
-
-    private void updateLanguage(PlayerData targetData, String language) {
-        Session targetSession = sessionService.get(targetData.uuid);
-        if (targetSession != null) {
-            targetSession.updateLanguage(language);
-            return;
-        }
-
-        updatePlayerData(targetData,
-                data -> data.language = language,
-                data -> playerDataRepository.updateLanguage(data.uuid, language),
-                null,
-                false,
-                false);
-    }
-
-    private void updateTranslatorLanguage(PlayerData targetData, String language) {
-        Session targetSession = sessionService.get(targetData.uuid);
-        if (targetSession != null) {
-            targetSession.updateTranslatorLanguage(language);
-            return;
-        }
-
-        updatePlayerData(targetData,
-                data -> data.translatorLanguage = language,
-                data -> playerDataRepository.updateTranslatorLanguage(data.uuid, language),
-                null,
-                false,
-                false);
-    }
-
-    private void updateGlobalChatVisible(PlayerData targetData, boolean visible) {
-        Session targetSession = sessionService.get(targetData.uuid);
-        if (targetSession != null) {
-            targetSession.updateGlobalChatVisible(visible);
-            return;
-        }
-
-        updatePlayerData(targetData,
-                data -> data.globalChatVisible = visible,
-                data -> playerDataRepository.updateGlobalChatVisible(data.uuid, visible),
-                null,
-                false,
-                false);
-    }
-
-    private void updateDiscordRelayVisible(PlayerData targetData, boolean visible) {
-        Session targetSession = sessionService.get(targetData.uuid);
-        if (targetSession != null) {
-            targetSession.updateDiscordRelayVisible(visible);
-            return;
-        }
-
-        updatePlayerData(targetData,
-                data -> data.discordRelayVisible = visible,
-                data -> playerDataRepository.updateDiscordRelayVisible(data.uuid, visible),
-                null,
-                false,
-                false);
-    }
-
-    private void updateActiveBadge(PlayerData targetData, String badgeId, boolean refreshDisplay, boolean sync) {
-        updatePlayerData(targetData,
-                data -> data.activeBadge = badgeId,
-                data -> playerDataRepository.setActiveBadge(data.uuid, badgeId),
-                data -> new PlayerActiveBadgeChangedCommandV1(data.uuid, data.activeBadge, config.server),
-                refreshDisplay,
-                sync);
-    }
-
-    private void updateBadgeSymbolColorMode(PlayerData targetData, String mode, boolean refreshDisplay, boolean sync) {
-        updatePlayerData(targetData,
-                data -> data.badgeSymbolColorMode = mode,
-                data -> playerDataRepository.updateBadgeSymbolColorMode(data.uuid, mode),
-                data -> new PlayerBadgeSymbolColorModeChangedCommandV1(data.uuid, data.badgeSymbolColorMode, config.server),
-                refreshDisplay,
-                sync);
-    }
-
-    private void updatePlayerData(PlayerData targetData,
-                                  Consumer<PlayerData> updater,
-                                  Consumer<PlayerData> partialUpdater,
-                                  java.util.function.Function<PlayerData, Object> syncEventFactory,
-                                  boolean refreshDisplay,
-                                  boolean sync) {
-        Session targetSession = sessionService.get(targetData.uuid);
-        if (targetSession != null) {
-            updater.accept(targetSession.data);
-            partialUpdater.accept(targetSession.data);
-            if (refreshDisplay) {
-                playerDisplayService.refresh(targetSession);
-            }
-            if (sync && syncEventFactory != null) {
-                network.post(syncEventFactory.apply(targetSession.data));
-            }
-        } else {
-            updater.accept(targetData);
-            partialUpdater.accept(targetData);
-            if (sync && syncEventFactory != null) {
-                network.post(syncEventFactory.apply(targetData));
-            }
-        }
     }
 
     private String activeBadgeName(Localization local, PlayerData targetData) {
@@ -760,7 +614,4 @@ public class PlayerMenu extends Menu {
                 && targetData.badgeSymbolColorMode.equalsIgnoreCase("player-color");
     }
 
-    private boolean containsBadgeLikeGlyphs(String input) {
-        return input.codePoints().anyMatch(cp -> cp >= BADGE_ICON_RANGE_START && cp <= BADGE_ICON_RANGE_END);
-    }
 }

--- a/src/main/java/org/xcore/plugin/ui/menu/TopMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/TopMenu.java
@@ -11,10 +11,16 @@ import org.xcore.plugin.model.enums.TopCategory;
 import org.xcore.plugin.service.TopMenuService;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuFlow;
+import org.xcore.plugin.ui.flow.MenuRenderContext;
+import org.xcore.plugin.ui.flow.MenuScreen;
 
 import java.text.NumberFormat;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
+import java.util.List;
 
 import static com.ospx.flubundle.Bundle.args;
 
@@ -23,6 +29,13 @@ public class TopMenu extends Menu {
 
     private static final int PLAYERS_PER_PAGE = 10;
     private static final LeaderboardCursor FIRST_PAGE_MARKER = new LeaderboardCursor(0, 0, -2);
+
+    private static final String ACTION_PREVIOUS = "previous";
+    private static final String ACTION_NEXT = "next";
+    private static final String ACTION_CATEGORY = "category";
+    private static final String ACTION_CLOSE = "close";
+    private static final String ACTION_BACK = "back";
+    private static final String ACTION_PROFILE_PREFIX = "profile:";
 
     private final TopMenuService topMenuService;
     private final PlayerMenu playerMenu;
@@ -64,66 +77,16 @@ public class TopMenu extends Menu {
         TopCategory resolvedCategory = category == null ? topMenuService.resolveDefaultCategory() : category;
         if (resetState || state.category != resolvedCategory) {
             state.category = resolvedCategory;
-            state.currentPage = 1;
-            state.currentCursor = null;
+            state.currentPage = page;
+            state.currentCursor = cursor;
             state.nextCursor = null;
             state.backStack.clear();
-        }
-
-        var topPage = topMenuService.loadCursorPage(resolvedCategory, cursor, page, PLAYERS_PER_PAGE, session.data);
-        state.category = resolvedCategory;
-        state.currentPage = topPage.currentPage();
-        state.currentCursor = topPage.currentCursor();
-        state.nextCursor = topPage.nextCursor();
-
-        renderCursorPage(uuid, session, topPage, state);
-    }
-
-    private void renderCursorPage(String uuid,
-                                  Session session,
-                                  TopMenuService.TopCursorPage topPage,
-                                  TopMenuState state) {
-        TopCategory resolvedCategory = topPage.category();
-        Localization local = session.locale();
-        String categoryName = local.t(resolvedCategory.bundleKey());
-
-        var builder = session.builder()
-                .title("top-menu-title", args("category", categoryName));
-
-        if (topPage.totalEntries() <= 0) {
-            builder.content("top-menu-empty", args("category", categoryName));
         } else {
-            builder.content("top-menu-content", args(
-                    "page", topPage.currentPage(),
-                    "totalPages", topPage.totalPages(),
-                    "totalEntries", topPage.totalEntries(),
-                    "category", categoryName,
-                    "selfRankLine", selfRankLine(local, topPage.selfRank())
-            ));
-
-            addCursorPlayerRows(builder, session, topPage, resolvedCategory);
+            state.currentCursor = cursor;
+            state.currentPage = page;
         }
 
-        builder.start()
-                .ifAddLocal(!state.backStack.isEmpty(), "previous", () -> {
-                    LeaderboardCursor previous = state.backStack.pollLast();
-                    LeaderboardCursor previousCursor = previous == FIRST_PAGE_MARKER ? null : previous;
-                    top(uuid, resolvedCategory, previousCursor, Math.max(1, state.currentPage - 1), false);
-                })
-                .add(local.t("top-menu-category-button", args("category", categoryName)), () -> {
-                    TopCategory savedCategory = resolvedCategory;
-                    LeaderboardCursor savedCursor = state.currentCursor;
-                    int savedPage = state.currentPage;
-                    session.pushHistory(() -> top(uuid, savedCategory, savedCursor, savedPage, false));
-                    categories(uuid, resolvedCategory);
-                })
-                .ifAddLocal(topPage.hasNext() && state.nextCursor != null, "next", () -> {
-                    state.backStack.addLast(state.currentCursor == null ? FIRST_PAGE_MARKER : state.currentCursor);
-                    top(uuid, resolvedCategory, state.nextCursor, state.currentPage + 1, false);
-                })
-                .end()
-                .addNavigationRow()
-                .show();
+        session.menuService.renderFlow(session, new TopMenuFlow());
     }
 
     public void categories(String uuid, TopCategory currentCategory) {
@@ -149,27 +112,150 @@ public class TopMenu extends Menu {
                 .show();
     }
 
-    private void addCursorPlayerRows(org.xcore.plugin.ui.MenuBuilder builder,
-                                     Session session,
-                                     TopMenuService.TopCursorPage topPage,
-                                     TopCategory category) {
-        for (int i = 0; i < topPage.players().size(); i++) {
-            PlayerData player = topPage.players().get(i);
-            int indexOnPage = i;
+    private final class TopMenuFlow implements MenuFlow<TopMenuState> {
+        @Override
+        public Class<TopMenuState> stateType() {
+            return TopMenuState.class;
+        }
 
-            builder.addRow(
-                    cursorPlayerButton(session, topPage, category, player, indexOnPage),
-                    () -> openCursorPlayerProfile(session, topPage, category, player)
+        @Override
+        public MenuScreen render(MenuRenderContext<TopMenuState> context) {
+            Session session = context.session();
+            TopMenuState state = context.state();
+            Localization local = context.locale();
+
+            TopCategory resolvedCategory = state.category == null ? topMenuService.resolveDefaultCategory() : state.category;
+            var topPage = topMenuService.loadCursorPage(resolvedCategory, state.currentCursor, state.currentPage, PLAYERS_PER_PAGE, session.data);
+            state.category = resolvedCategory;
+            state.currentPage = topPage.currentPage();
+            state.currentCursor = topPage.currentCursor();
+            state.nextCursor = topPage.nextCursor();
+
+            String categoryName = local.t(resolvedCategory.bundleKey());
+            List<List<MenuButton>> rows = new ArrayList<>();
+
+            if (topPage.totalEntries() > 0) {
+                for (int i = 0; i < topPage.players().size(); i++) {
+                    PlayerData player = topPage.players().get(i);
+                    String buttonText = cursorPlayerButton(session, topPage, resolvedCategory, player, i);
+                    rows.add(List.of(MenuButton.of(buttonText, ACTION_PROFILE_PREFIX + player.uuid)));
+                }
+            }
+
+            List<MenuButton> navRow = new ArrayList<>();
+            if (!state.backStack.isEmpty()) {
+                navRow.add(MenuButton.of(local.t("previous"), ACTION_PREVIOUS));
+            }
+            navRow.add(MenuButton.of(local.t("top-menu-category-button", args("category", categoryName)), ACTION_CATEGORY));
+            if (topPage.hasNext() && state.nextCursor != null) {
+                navRow.add(MenuButton.of(local.t("next"), ACTION_NEXT));
+            }
+            if (!navRow.isEmpty()) {
+                rows.add(navRow);
+            }
+
+            List<MenuButton> bottomNav = new ArrayList<>();
+            if (session.hasHistory()) {
+                bottomNav.add(MenuButton.of(local.t("back"), ACTION_BACK));
+            }
+            bottomNav.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
+            rows.add(bottomNav);
+
+            return MenuScreen.followUp(
+                    local.t("top-menu-title", args("category", categoryName)),
+                    topPage.totalEntries() <= 0
+                            ? local.t("top-menu-empty", args("category", categoryName))
+                            : local.t("top-menu-content", args(
+                                    "page", topPage.currentPage(),
+                                    "totalPages", topPage.totalPages(),
+                                    "totalEntries", topPage.totalEntries(),
+                                    "category", categoryName,
+                                    "selfRankLine", selfRankLine(local, topPage.selfRank())
+                            )),
+                    rows
             );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<TopMenuState> context, String actionId) {
+            TopMenuState state = context.state();
+            Session session = context.session();
+
+            switch (actionId) {
+                case ACTION_PREVIOUS -> {
+                    LeaderboardCursor previous = state.backStack.pollLast();
+                    LeaderboardCursor previousCursor = previous == FIRST_PAGE_MARKER ? null : previous;
+                    state.currentCursor = previousCursor;
+                    state.currentPage = Math.max(1, state.currentPage - 1);
+                    context.render();
+                }
+                case ACTION_NEXT -> {
+                    state.backStack.addLast(state.currentCursor == null ? FIRST_PAGE_MARKER : state.currentCursor);
+                    state.currentCursor = state.nextCursor;
+                    state.currentPage = state.currentPage + 1;
+                    context.render();
+                }
+                case ACTION_CATEGORY -> {
+                    TopCategory savedCategory = state.category;
+                    LeaderboardCursor savedCursor = state.currentCursor;
+                    int savedPage = state.currentPage;
+                    Deque<LeaderboardCursor> savedBackStack = new ArrayDeque<>(state.backStack);
+                    LeaderboardCursor savedNextCursor = state.nextCursor;
+                    session.pushHistory(() -> {
+                        session.clear();
+                        TopMenuState histState = session.getDraft(TopMenuState.class);
+                        histState.category = savedCategory;
+                        histState.currentCursor = savedCursor;
+                        histState.currentPage = savedPage;
+                        histState.backStack = savedBackStack;
+                        histState.nextCursor = savedNextCursor;
+                        session.menuService.renderFlow(session, new TopMenuFlow());
+                    });
+                    session.menuService.hideFollowUp(session);
+                    categories(session.data.uuid, state.category);
+                }
+                case ACTION_BACK -> {
+                    Runnable previousMenu = session.popHistory();
+                    if (previousMenu != null) {
+                        session.menuService.hideFollowUp(session);
+                        previousMenu.run();
+                    }
+                }
+                case ACTION_CLOSE -> context.close();
+                default -> {
+                    if (actionId.startsWith(ACTION_PROFILE_PREFIX)) {
+                        String targetUuid = actionId.substring(ACTION_PROFILE_PREFIX.length());
+                        PlayerData target = session.playerDataRepository.findByUuid(targetUuid);
+                        if (target != null) {
+                            session.pushHistory(() -> {
+                                session.clear();
+                                TopMenuState histState = session.getDraft(TopMenuState.class);
+                                histState.category = state.category;
+                                histState.currentCursor = state.currentCursor;
+                                histState.currentPage = state.currentPage;
+                                histState.backStack = new ArrayDeque<>(state.backStack);
+                                histState.nextCursor = state.nextCursor;
+                                session.menuService.renderFlow(session, new TopMenuFlow());
+                            });
+                            session.menuService.hideFollowUp(session);
+                            playerMenu.player(session.data.uuid, target);
+                        }
+                    }
+                }
+            }
         }
     }
 
-    private void openCursorPlayerProfile(Session session,
-                                         TopMenuService.TopCursorPage topPage,
-                                         TopCategory category,
-                                         PlayerData playerData) {
-        session.pushHistory(() -> top(session.data.uuid, category, topPage.currentCursor(), topPage.currentPage(), false));
-        playerMenu.player(session.data.uuid, playerData);
+    private String categoryButton(Session session, TopCategory category, TopCategory currentCategory) {
+        String label = session.locale().t(category.bundleKey());
+        return category == currentCategory ? "[accent]●[] " + label : label;
+    }
+
+    private String selfRankLine(Localization local, Integer selfRank) {
+        if (selfRank == null) {
+            return local.t("top-menu-self-rank-unknown");
+        }
+        return local.t("top-menu-self-rank-known", args("rank", selfRank));
     }
 
     private String cursorPlayerButton(Session session,
@@ -200,19 +286,6 @@ public class TopMenu extends Menu {
                     "value", numberFormat.format(playerData.hexedPoints)
             ));
         };
-    }
-
-    private String categoryButton(Session session, TopCategory category, TopCategory currentCategory) {
-        String label = session.locale().t(category.bundleKey());
-        return category == currentCategory ? "[accent]●[] " + label : label;
-    }
-
-    private String selfRankLine(Localization local, Integer selfRank) {
-        if (selfRank == null) {
-            return local.t("top-menu-self-rank-unknown");
-        }
-
-        return local.t("top-menu-self-rank-known", args("rank", selfRank));
     }
 
     private String rankLabel(int displayRank) {

--- a/src/test/java/org/xcore/plugin/service/EventEditorServiceTest.java
+++ b/src/test/java/org/xcore/plugin/service/EventEditorServiceTest.java
@@ -1,0 +1,238 @@
+package org.xcore.plugin.service;
+
+import com.ospx.flubundle.Bundle;
+import jakarta.inject.Provider;
+import mindustry.gen.Player;
+import mindustry.net.NetConnection;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.xcore.plugin.config.GlobalConfig;
+import org.xcore.plugin.database.repository.EventDataRepository;
+import org.xcore.plugin.database.repository.MapDataRepository;
+import org.xcore.plugin.database.repository.PlayerDataRepository;
+import org.xcore.plugin.localization.Localization;
+import org.xcore.plugin.model.EventData;
+import org.xcore.plugin.model.MapData;
+import org.xcore.plugin.model.PlayerData;
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.MenuService;
+import org.xcore.plugin.ui.MindustryMenuGateway;
+
+import java.util.Locale;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class EventEditorServiceTest {
+
+    private EventDataRepository eventDataRepository;
+    private MapDataRepository mapDataRepository;
+    private PlayerDataRepository playerDataRepository;
+    private EventEditorService eventEditorService;
+    private Session session;
+
+    @BeforeEach
+    void setUp() {
+        eventDataRepository = mock(EventDataRepository.class);
+        mapDataRepository = mock(MapDataRepository.class);
+        playerDataRepository = mock(PlayerDataRepository.class);
+        eventEditorService = new EventEditorService(eventDataRepository, mapDataRepository, playerDataRepository);
+
+        session = createSession();
+    }
+
+    @Test
+    @DisplayName("initializeDraft sets author and optional map")
+    void initializeDraft_setsAuthorAndMap() {
+        MapData map = new MapData();
+        map.id = new ObjectId();
+
+        EventData draft = eventEditorService.initializeDraft(session, map);
+
+        assertThat(draft.author).isEqualTo(session.data.id);
+        assertThat(draft.map).isEqualTo(map.id);
+    }
+
+    @Test
+    @DisplayName("initializeDraft sets author only when map is null")
+    void initializeDraft_setsAuthorOnlyWhenMapNull() {
+        EventData draft = eventEditorService.initializeDraft(session, null);
+
+        assertThat(draft.author).isEqualTo(session.data.id);
+        assertThat(draft.map).isNull();
+    }
+
+    @Test
+    @DisplayName("resetName resets draft name to default")
+    void resetName_resetsToDefault() {
+        EventData draft = new EventData();
+        draft.name = "Custom";
+        eventEditorService.resetName(draft);
+        assertThat(draft.name).isEqualTo(new EventData().name);
+    }
+
+    @Test
+    @DisplayName("updateName mutates draft name")
+    void updateName_mutatesDraftName() {
+        EventData draft = new EventData();
+        eventEditorService.updateName(draft, "New Name");
+        assertThat(draft.name).isEqualTo("New Name");
+    }
+
+    @Test
+    @DisplayName("updateDescription mutates draft description")
+    void updateDescription_mutatesDraftDescription() {
+        EventData draft = new EventData();
+        eventEditorService.updateDescription(draft, "Desc");
+        assertThat(draft.description).isEqualTo("Desc");
+    }
+
+    @Test
+    @DisplayName("toggleTemporary flips draft flag")
+    void toggleTemporary_flipsFlag() {
+        EventData draft = new EventData();
+        assertThat(draft.isTemporary).isFalse();
+        eventEditorService.toggleTemporary(draft);
+        assertThat(draft.isTemporary).isTrue();
+        eventEditorService.toggleTemporary(draft);
+        assertThat(draft.isTemporary).isFalse();
+    }
+
+    @Test
+    @DisplayName("toggleMajor flips draft flag")
+    void toggleMajor_flipsFlag() {
+        EventData draft = new EventData();
+        assertThat(draft.isMajor).isFalse();
+        eventEditorService.toggleMajor(draft);
+        assertThat(draft.isMajor).isTrue();
+        eventEditorService.toggleMajor(draft);
+        assertThat(draft.isMajor).isFalse();
+    }
+
+    @Test
+    @DisplayName("updatePlannedStartTime parses absolute timestamp")
+    void updatePlannedStartTime_parsesAbsolute() {
+        EventData draft = new EventData();
+        eventEditorService.updatePlannedStartTime(draft, "12345");
+        assertThat(draft.plannedStartTime).isEqualTo(12345L);
+    }
+
+    @Test
+    @DisplayName("updatePlannedEndTime parses invalid input as zero")
+    void updatePlannedEndTime_parsesInvalidAsZero() {
+        EventData draft = new EventData();
+        eventEditorService.updatePlannedEndTime(draft, "bad");
+        assertThat(draft.plannedEndTime).isEqualTo(0L);
+    }
+
+    @Test
+    @DisplayName("parseTime handles empty and null as zero")
+    void parseTime_emptyAndNullAsZero() {
+        assertThat(eventEditorService.parseTime("")).isEqualTo(0L);
+        assertThat(eventEditorService.parseTime(null)).isEqualTo(0L);
+    }
+
+    @Test
+    @DisplayName("parseTime handles relative offsets")
+    void parseTime_relativeOffsets() {
+        long before = System.currentTimeMillis();
+        long result = eventEditorService.parseTime("+5m");
+        long after = System.currentTimeMillis();
+        assertThat(result).isGreaterThanOrEqualTo(before + 5 * 60_000L);
+        assertThat(result).isLessThanOrEqualTo(after + 5 * 60_000L);
+    }
+
+    @Test
+    @DisplayName("saveDraft without map sends error and returns false without saving")
+    void saveDraft_withoutMap_sendsError() {
+        EventData draft = session.getDraft(EventData.class);
+        draft.map = null;
+
+        boolean result = eventEditorService.saveDraft(session);
+
+        assertThat(result).isFalse();
+        verify(eventDataRepository, never()).save(any());
+        verify(session.localization).send("error-no-map");
+    }
+
+    @Test
+    @DisplayName("saveDraft with map saves and clears draft")
+    void saveDraft_withMap_savesAndClears() {
+        MapData map = new MapData();
+        map.id = new ObjectId();
+        EventData draft = session.getDraft(EventData.class);
+        draft.map = map.id;
+
+        boolean result = eventEditorService.saveDraft(session);
+
+        assertThat(result).isTrue();
+        verify(eventDataRepository).save(draft);
+        assertThat(session.hasDraft(EventData.class)).isFalse();
+    }
+
+    @Test
+    @DisplayName("cancelDraft clears draft")
+    void cancelDraft_clearsDraft() {
+        session.getDraft(EventData.class);
+        assertThat(session.hasDraft(EventData.class)).isTrue();
+
+        eventEditorService.cancelDraft(session);
+
+        assertThat(session.hasDraft(EventData.class)).isFalse();
+    }
+
+    @Test
+    @DisplayName("selectMapForDraft assigns persisted map id")
+    void selectMapForDraft_assignsMapId() {
+        MapData persisted = new MapData();
+        persisted.id = new ObjectId();
+        when(mapDataRepository.findOrCreate("Name", "file.msav", "Author", "survival")).thenReturn(persisted);
+
+        MapData result = eventEditorService.selectMapForDraft(session, "Name", "file.msav", "Author", "survival");
+
+        assertThat(result).isEqualTo(persisted);
+        EventData draft = session.getDraft(EventData.class);
+        assertThat(draft.map).isEqualTo(persisted.id);
+    }
+
+    private Session createSession() {
+        Player player = Player.create();
+        player.con = mock(NetConnection.class);
+        PlayerData data = new PlayerData("test-uuid", true);
+        data.uuid = "test-uuid";
+        data.id = new ObjectId();
+
+        MindustryMenuGateway gateway = mock(MindustryMenuGateway.class);
+        SessionService sessionService = mock(SessionService.class);
+        Provider<SessionService> sessionProvider = mock(Provider.class);
+        when(sessionProvider.get()).thenReturn(sessionService);
+        MenuService menuService = new MenuService(sessionProvider, gateway);
+
+        Session session = new Session(
+                new GlobalConfig(),
+                mock(Bundle.class),
+                menuService,
+                mock(PlayerDataRepository.class),
+                player,
+                data
+        );
+        Localization localization = mock(Localization.class);
+        when(localization.t(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.t(anyString(), anyMap())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.format(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.format(anyString(), anyMap())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.getLocale()).thenReturn(Locale.US);
+        session.localization = localization;
+        return session;
+    }
+}

--- a/src/test/java/org/xcore/plugin/service/EventViewServiceTest.java
+++ b/src/test/java/org/xcore/plugin/service/EventViewServiceTest.java
@@ -1,0 +1,118 @@
+package org.xcore.plugin.service;
+
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.xcore.plugin.common.StatusEnum;
+import org.xcore.plugin.database.repository.EventDataRepository;
+import org.xcore.plugin.database.repository.MapDataRepository;
+import org.xcore.plugin.database.repository.PlayerDataRepository;
+import org.xcore.plugin.model.EventData;
+import org.xcore.plugin.model.MapData;
+import org.xcore.plugin.model.PlayerData;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class EventViewServiceTest {
+
+    private EventDataRepository eventDataRepository;
+    private MapDataRepository mapDataRepository;
+    private PlayerDataRepository playerDataRepository;
+    private EventViewService eventViewService;
+
+    @BeforeEach
+    void setUp() {
+        eventDataRepository = mock(EventDataRepository.class);
+        mapDataRepository = mock(MapDataRepository.class);
+        playerDataRepository = mock(PlayerDataRepository.class);
+        eventViewService = new EventViewService(eventDataRepository, mapDataRepository, playerDataRepository);
+    }
+
+    @Test
+    @DisplayName("activeEvent returns active event or null")
+    void activeEvent_returnsActiveOrNull() {
+        EventData active = new EventData();
+        when(eventDataRepository.findActive()).thenReturn(Optional.of(active), Optional.empty());
+
+        assertThat(eventViewService.activeEvent()).isEqualTo(active);
+        assertThat(eventViewService.activeEvent()).isNull();
+    }
+
+    @Test
+    @DisplayName("details resolves map and author")
+    void details_resolvesMapAndAuthor() {
+        ObjectId mapId = new ObjectId();
+        ObjectId authorId = new ObjectId();
+        EventData event = new EventData();
+        event.map = mapId;
+        event.author = authorId;
+        MapData map = new MapData();
+        PlayerData author = new PlayerData("author-uuid", true);
+        when(mapDataRepository.findById(mapId)).thenReturn(map);
+        when(playerDataRepository.findById(authorId)).thenReturn(author);
+
+        EventViewService.EventDetails details = eventViewService.details(event);
+
+        assertThat(details.event()).isEqualTo(event);
+        assertThat(details.map()).isEqualTo(map);
+        assertThat(details.author()).isEqualTo(author);
+    }
+
+    @Test
+    @DisplayName("details tolerates null event and missing references")
+    void details_toleratesNulls() {
+        EventData event = new EventData();
+
+        assertThat(eventViewService.details(null).event()).isNull();
+        EventViewService.EventDetails details = eventViewService.details(event);
+        assertThat(details.event()).isEqualTo(event);
+        assertThat(details.map()).isNull();
+        assertThat(details.author()).isNull();
+    }
+
+    @Test
+    @DisplayName("page clamps requested page and loads repository slice")
+    void page_clampsAndLoadsSlice() {
+        Map<String, StatusEnum> filters = Map.of("active", StatusEnum.Active);
+        EventData event = new EventData();
+        when(eventDataRepository.count(filters)).thenReturn(25L);
+        when(eventDataRepository.findPage(20, 10, filters)).thenReturn(List.of(event));
+
+        EventViewService.EventPage page = eventViewService.page(5, 10, filters);
+
+        assertThat(page.events()).containsExactly(event);
+        assertThat(page.total()).isEqualTo(25);
+        assertThat(page.page()).isEqualTo(3);
+        assertThat(page.totalPages()).isEqualTo(3);
+        assertThat(page.hasPrevious()).isTrue();
+        assertThat(page.hasNext()).isFalse();
+    }
+
+    @Test
+    @DisplayName("empty page returns page one and skips slice query")
+    void page_emptySkipsFindPage() {
+        when(eventDataRepository.count(isNull(Map.class))).thenReturn(0L);
+
+        EventViewService.EventPage page = eventViewService.page(1, 10, null);
+
+        assertThat(page.events()).isEmpty();
+        assertThat(page.total()).isZero();
+        assertThat(page.page()).isEqualTo(1);
+        assertThat(page.totalPages()).isZero();
+        assertThat(page.isEmpty()).isTrue();
+        assertThat(page.hasPrevious()).isFalse();
+        assertThat(page.hasNext()).isFalse();
+        verify(eventDataRepository, never()).findPage(anyInt(), anyInt(), org.mockito.ArgumentMatchers.any());
+    }
+}

--- a/src/test/java/org/xcore/plugin/service/PlayerProfileSettingsServiceTest.java
+++ b/src/test/java/org/xcore/plugin/service/PlayerProfileSettingsServiceTest.java
@@ -1,0 +1,341 @@
+package org.xcore.plugin.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.xcore.plugin.config.Config;
+import org.xcore.plugin.database.repository.PlayerDataRepository;
+import org.xcore.plugin.model.PlayerData;
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.session.SessionService;
+import org.xcore.protocol.generated.messages.chat.ChatMessages.PlayerCustomNicknameChangedCommandV1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PlayerProfileSettingsServiceTest {
+
+    @Test
+    @DisplayName("validateCustomNickname accepts blank input as reset")
+    void validateCustomNickname_acceptsBlankAsReset() {
+        var service = service();
+
+        assertThat(service.validateCustomNickname("").valid()).isTrue();
+        assertThat(service.validateCustomNickname("   ").valid()).isTrue();
+        assertThat(service.validateCustomNickname(null)).satisfies(r -> {
+            assertThat(r.valid()).isTrue();
+            assertThat(r.errorKey()).isNull();
+        });
+    }
+
+    @Test
+    @DisplayName("validateCustomNickname accepts valid plain nickname")
+    void validateCustomNickname_acceptsValidPlainNickname() {
+        var service = service();
+
+        assertThat(service.validateCustomNickname("Hello").valid()).isTrue();
+        assertThat(service.validateCustomNickname("[green]Colored[]").valid()).isTrue();
+    }
+
+    @Test
+    @DisplayName("validateCustomNickname rejects too-long plain UTF-8 nickname")
+    void validateCustomNickname_rejectsTooLongUtf8() {
+        var service = service();
+        String tooLong = "a".repeat(41);
+
+        var result = service.validateCustomNickname(tooLong);
+
+        assertThat(result.valid()).isFalse();
+        assertThat(result.errorKey()).isEqualTo("error-nickname-too-long");
+        assertThat(result.maxBytes()).isEqualTo(40);
+    }
+
+    @Test
+    @DisplayName("validateCustomNickname rejects badge-like glyphs in private use area")
+    void validateCustomNickname_rejectsBadgeLikeGlyphs() {
+        var service = service();
+        String withGlyph = "Player" + Character.toString(0xE800);
+
+        var result = service.validateCustomNickname(withGlyph);
+
+        assertThat(result.valid()).isFalse();
+        assertThat(result.errorKey()).isEqualTo("error-nickname-badge-glyph");
+    }
+
+    @Test
+    @DisplayName("validateCustomNickname rejects badge-like glyph at range end")
+    void validateCustomNickname_rejectsGlyphAtRangeEnd() {
+        var service = service();
+        String withGlyph = "Player" + Character.toString(0xF8FF);
+
+        var result = service.validateCustomNickname(withGlyph);
+
+        assertThat(result.valid()).isFalse();
+        assertThat(result.errorKey()).isEqualTo("error-nickname-badge-glyph");
+    }
+
+    @Test
+    @DisplayName("validateCustomNickname accepts glyph just outside private use area")
+    void validateCustomNickname_acceptsGlyphOutsideRange() {
+        var service = service();
+        String withGlyph = "Player" + Character.toString(0xE7FF);
+
+        assertThat(service.validateCustomNickname(withGlyph).valid()).isTrue();
+    }
+
+    @Test
+    @DisplayName("updateCustomNickname for online session mutates session data and refreshes display and posts sync")
+    void updateCustomNickname_onlineSession_mutatesAndRefreshesAndSyncs() {
+        SessionService sessionService = mock(SessionService.class);
+        PlayerDataRepository repository = mock(PlayerDataRepository.class);
+        PlayerDisplayService displayService = mock(PlayerDisplayService.class);
+        NetworkService network = mock(NetworkService.class);
+        Config config = new Config();
+        config.server = "mini-pvp";
+
+        PlayerProfileSettingsService service = new PlayerProfileSettingsService(
+                sessionService, repository, displayService, network, config);
+
+        PlayerData targetData = new PlayerData("uuid-1", true);
+        targetData.customNickname = "old";
+
+        Session onlineSession = mock(Session.class);
+        onlineSession.data = targetData;
+        when(sessionService.get("uuid-1")).thenReturn(onlineSession);
+        when(repository.updateCustomNickname("uuid-1", "new")).thenReturn(true);
+
+        service.updateCustomNickname(targetData, "new", true, true);
+
+        assertThat(onlineSession.data.customNickname).isEqualTo("new");
+        verify(repository).updateCustomNickname("uuid-1", "new");
+        verify(displayService).refresh(onlineSession);
+        verify(network).post(any(PlayerCustomNicknameChangedCommandV1.class));
+    }
+
+    @Test
+    @DisplayName("updateCustomNickname for offline target mutates data and posts sync without display refresh")
+    void updateCustomNickname_offlineTarget_mutatesAndSyncsWithoutRefresh() {
+        SessionService sessionService = mock(SessionService.class);
+        PlayerDataRepository repository = mock(PlayerDataRepository.class);
+        PlayerDisplayService displayService = mock(PlayerDisplayService.class);
+        NetworkService network = mock(NetworkService.class);
+        Config config = new Config();
+        config.server = "mini-pvp";
+
+        PlayerProfileSettingsService service = new PlayerProfileSettingsService(
+                sessionService, repository, displayService, network, config);
+
+        PlayerData targetData = new PlayerData("uuid-1", true);
+        targetData.customNickname = "old";
+        when(sessionService.get("uuid-1")).thenReturn(null);
+        when(repository.updateCustomNickname("uuid-1", "new")).thenReturn(true);
+
+        service.updateCustomNickname(targetData, "new", true, true);
+
+        assertThat(targetData.customNickname).isEqualTo("new");
+        verify(repository).updateCustomNickname("uuid-1", "new");
+        verify(displayService, never()).refresh(any());
+        verify(network).post(any(PlayerCustomNicknameChangedCommandV1.class));
+    }
+
+    @Test
+    @DisplayName("updateCustomNickname for online session with sync=false does not post network event")
+    void updateCustomNickname_onlineSession_noSync_noNetworkPost() {
+        SessionService sessionService = mock(SessionService.class);
+        PlayerDataRepository repository = mock(PlayerDataRepository.class);
+        PlayerDisplayService displayService = mock(PlayerDisplayService.class);
+        NetworkService network = mock(NetworkService.class);
+        Config config = new Config();
+        config.server = "mini-pvp";
+
+        PlayerProfileSettingsService service = new PlayerProfileSettingsService(
+                sessionService, repository, displayService, network, config);
+
+        PlayerData targetData = new PlayerData("uuid-1", true);
+        Session onlineSession = mock(Session.class);
+        onlineSession.data = targetData;
+        when(sessionService.get("uuid-1")).thenReturn(onlineSession);
+
+        service.updateCustomNickname(targetData, "new", false, false);
+
+        verify(displayService, never()).refresh(any());
+        verify(network, never()).post(any());
+    }
+
+    @Test
+    @DisplayName("updateLanguage for online session delegates to session helper")
+    void updateLanguage_onlineSession_delegatesToSessionHelper() {
+        SessionService sessionService = mock(SessionService.class);
+        PlayerDataRepository repository = mock(PlayerDataRepository.class);
+        PlayerDisplayService displayService = mock(PlayerDisplayService.class);
+        NetworkService network = mock(NetworkService.class);
+        Config config = new Config();
+
+        PlayerProfileSettingsService service = new PlayerProfileSettingsService(
+                sessionService, repository, displayService, network, config);
+
+        PlayerData targetData = new PlayerData("uuid-1", true);
+        Session onlineSession = mock(Session.class);
+        onlineSession.data = targetData;
+        when(sessionService.get("uuid-1")).thenReturn(onlineSession);
+        when(onlineSession.updateLanguage("uk_UA")).thenReturn(true);
+
+        service.updateLanguage(targetData, "uk_UA");
+
+        verify(onlineSession).updateLanguage("uk_UA");
+        verify(repository, never()).updateLanguage(any(), any());
+    }
+
+    @Test
+    @DisplayName("updateLanguage for offline target mutates data and calls repository")
+    void updateLanguage_offlineTarget_mutatesAndCallsRepository() {
+        SessionService sessionService = mock(SessionService.class);
+        PlayerDataRepository repository = mock(PlayerDataRepository.class);
+        PlayerDisplayService displayService = mock(PlayerDisplayService.class);
+        NetworkService network = mock(NetworkService.class);
+        Config config = new Config();
+
+        PlayerProfileSettingsService service = new PlayerProfileSettingsService(
+                sessionService, repository, displayService, network, config);
+
+        PlayerData targetData = new PlayerData("uuid-1", true);
+        targetData.language = "auto";
+        when(sessionService.get("uuid-1")).thenReturn(null);
+        when(repository.updateLanguage("uuid-1", "uk_UA")).thenReturn(true);
+
+        service.updateLanguage(targetData, "uk_UA");
+
+        assertThat(targetData.language).isEqualTo("uk_UA");
+        verify(repository).updateLanguage("uuid-1", "uk_UA");
+    }
+
+    @Test
+    @DisplayName("updateDescription for online session mutates session data and calls repository")
+    void updateDescription_onlineSession_mutatesAndCallsRepository() {
+        SessionService sessionService = mock(SessionService.class);
+        PlayerDataRepository repository = mock(PlayerDataRepository.class);
+        PlayerDisplayService displayService = mock(PlayerDisplayService.class);
+        NetworkService network = mock(NetworkService.class);
+        Config config = new Config();
+
+        PlayerProfileSettingsService service = new PlayerProfileSettingsService(
+                sessionService, repository, displayService, network, config);
+
+        PlayerData targetData = new PlayerData("uuid-1", true);
+        Session onlineSession = mock(Session.class);
+        onlineSession.data = targetData;
+        when(sessionService.get("uuid-1")).thenReturn(onlineSession);
+
+        service.updateDescription(targetData, "new desc");
+
+        assertThat(onlineSession.data.description).isEqualTo("new desc");
+        verify(repository).updateDescription("uuid-1", "new desc");
+    }
+
+    @Test
+    @DisplayName("updateDescription for offline target mutates provided data and calls repository")
+    void updateDescription_offlineTarget_mutatesAndCallsRepository() {
+        SessionService sessionService = mock(SessionService.class);
+        PlayerDataRepository repository = mock(PlayerDataRepository.class);
+        PlayerDisplayService displayService = mock(PlayerDisplayService.class);
+        NetworkService network = mock(NetworkService.class);
+        Config config = new Config();
+
+        PlayerProfileSettingsService service = new PlayerProfileSettingsService(
+                sessionService, repository, displayService, network, config);
+
+        PlayerData targetData = new PlayerData("uuid-1", true);
+        when(sessionService.get("uuid-1")).thenReturn(null);
+
+        service.updateDescription(targetData, "new desc");
+
+        assertThat(targetData.description).isEqualTo("new desc");
+        verify(repository).updateDescription("uuid-1", "new desc");
+    }
+
+    @Test
+    @DisplayName("updateLeaderboard for online session mutates session data and calls repository")
+    void updateLeaderboard_onlineSession_mutatesAndCallsRepository() {
+        SessionService sessionService = mock(SessionService.class);
+        PlayerDataRepository repository = mock(PlayerDataRepository.class);
+        PlayerDisplayService displayService = mock(PlayerDisplayService.class);
+        NetworkService network = mock(NetworkService.class);
+        Config config = new Config();
+
+        PlayerProfileSettingsService service = new PlayerProfileSettingsService(
+                sessionService, repository, displayService, network, config);
+
+        PlayerData targetData = new PlayerData("uuid-1", true);
+        targetData.leaderboard = false;
+        Session onlineSession = mock(Session.class);
+        onlineSession.data = targetData;
+        when(sessionService.get("uuid-1")).thenReturn(onlineSession);
+
+        service.updateLeaderboard(targetData, true);
+
+        assertThat(onlineSession.data.leaderboard).isTrue();
+        verify(repository).updateLeaderboard("uuid-1", true);
+    }
+
+    @Test
+    @DisplayName("updateActiveBadge for online session mutates session data and refreshes display and posts sync")
+    void updateActiveBadge_onlineSession_mutatesAndRefreshesAndSyncs() {
+        SessionService sessionService = mock(SessionService.class);
+        PlayerDataRepository repository = mock(PlayerDataRepository.class);
+        PlayerDisplayService displayService = mock(PlayerDisplayService.class);
+        NetworkService network = mock(NetworkService.class);
+        Config config = new Config();
+        config.server = "mini-pvp";
+
+        PlayerProfileSettingsService service = new PlayerProfileSettingsService(
+                sessionService, repository, displayService, network, config);
+
+        PlayerData targetData = new PlayerData("uuid-1", true);
+        Session onlineSession = mock(Session.class);
+        onlineSession.data = targetData;
+        when(sessionService.get("uuid-1")).thenReturn(onlineSession);
+
+        service.updateActiveBadge(targetData, "developer", true, true);
+
+        assertThat(onlineSession.data.activeBadge).isEqualTo("developer");
+        verify(repository).setActiveBadge("uuid-1", "developer");
+        verify(displayService).refresh(onlineSession);
+        verify(network).post(any(org.xcore.protocol.generated.messages.chat.ChatMessages.PlayerActiveBadgeChangedCommandV1.class));
+    }
+
+    @Test
+    @DisplayName("updateBadgeSymbolColorMode for offline target mutates data and calls repository")
+    void updateBadgeSymbolColorMode_offlineTarget_mutatesAndCallsRepository() {
+        SessionService sessionService = mock(SessionService.class);
+        PlayerDataRepository repository = mock(PlayerDataRepository.class);
+        PlayerDisplayService displayService = mock(PlayerDisplayService.class);
+        NetworkService network = mock(NetworkService.class);
+        Config config = new Config();
+        config.server = "mini-pvp";
+
+        PlayerProfileSettingsService service = new PlayerProfileSettingsService(
+                sessionService, repository, displayService, network, config);
+
+        PlayerData targetData = new PlayerData("uuid-1", true);
+        when(sessionService.get("uuid-1")).thenReturn(null);
+
+        service.updateBadgeSymbolColorMode(targetData, "player-color", false, false);
+
+        assertThat(targetData.badgeSymbolColorMode).isEqualTo("player-color");
+        verify(repository).updateBadgeSymbolColorMode("uuid-1", "player-color");
+        verify(displayService, never()).refresh(any());
+        verify(network, never()).post(any());
+    }
+
+    private PlayerProfileSettingsService service() {
+        return new PlayerProfileSettingsService(
+                mock(SessionService.class),
+                mock(PlayerDataRepository.class),
+                mock(PlayerDisplayService.class),
+                mock(NetworkService.class),
+                new Config());
+    }
+}

--- a/src/test/java/org/xcore/plugin/session/SessionUiStateTest.java
+++ b/src/test/java/org/xcore/plugin/session/SessionUiStateTest.java
@@ -1,0 +1,95 @@
+package org.xcore.plugin.session;
+
+import com.ospx.flubundle.Bundle;
+import mindustry.gen.Player;
+import mindustry.net.NetConnection;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.xcore.plugin.common.StatusEnum;
+import org.xcore.plugin.config.GlobalConfig;
+import org.xcore.plugin.database.repository.PlayerDataRepository;
+import org.xcore.plugin.model.PlayerData;
+import org.xcore.plugin.ui.MenuService;
+import org.xcore.plugin.ui.flow.ActiveMenuPrompt;
+import org.xcore.plugin.ui.flow.ActiveMenuScreen;
+import org.xcore.plugin.ui.flow.MenuMode;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class SessionUiStateTest {
+
+    @Test
+    @DisplayName("nextUiVersion increments")
+    void nextUiVersion_increments() {
+        Session session = session();
+
+        assertThat(session.nextUiVersion()).isEqualTo(1L);
+        assertThat(session.nextUiVersion()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("clearUiState clears active screen, active prompt, legacy actions, and textHandler")
+    void clearUiState_clearsUiState() {
+        Session session = session();
+        session.setActiveScreen(ActiveMenuScreen.create(1L, MenuMode.NORMAL, List.of()));
+        session.setActivePrompt(ActiveMenuPrompt.create(1L, 42, s -> {}, () -> {}));
+        session.actions.add(() -> {});
+        session.textHandler = s -> {};
+
+        session.clearUiState();
+
+        assertThat(session.activeScreen()).isNull();
+        assertThat(session.activePrompt()).isNull();
+        assertThat(session.actions).isEmpty();
+        assertThat(session.textHandler).isNull();
+    }
+
+    @Test
+    @DisplayName("clear delegates to clearUiState")
+    void clear_delegatesToClearUiState() {
+        Session session = session();
+        session.setActiveScreen(ActiveMenuScreen.create(1L, MenuMode.NORMAL, List.of()));
+        session.setActivePrompt(ActiveMenuPrompt.create(1L, 42, s -> {}, () -> {}));
+        session.actions.add(() -> {});
+        session.textHandler = s -> {};
+
+        session.clear();
+
+        assertThat(session.activeScreen()).isNull();
+        assertThat(session.activePrompt()).isNull();
+        assertThat(session.actions).isEmpty();
+        assertThat(session.textHandler).isNull();
+    }
+
+    @Test
+    @DisplayName("clearUiState does not clear history, drafts, or sortStatus")
+    void clearUiState_preservesHistoryDraftsSortStatus() {
+        Session session = session();
+        session.pushHistory(() -> {});
+        session.setDraft("draft");
+        session.sortStatus.put("key", StatusEnum.Active);
+
+        session.clearUiState();
+
+        assertThat(session.hasHistory()).isTrue();
+        assertThat(session.hasDraft(String.class)).isTrue();
+        assertThat(session.sortStatus).containsKey("key");
+    }
+
+    private Session session() {
+        Player player = Player.create();
+        player.con = mock(NetConnection.class);
+        PlayerData data = new PlayerData("uuid-1", true);
+        return new Session(
+                new GlobalConfig(),
+                mock(Bundle.class),
+                mock(MenuService.class),
+                mock(PlayerDataRepository.class),
+                player,
+                data
+        );
+    }
+}

--- a/src/test/java/org/xcore/plugin/ui/AuditHistoryMenuFlowTest.java
+++ b/src/test/java/org/xcore/plugin/ui/AuditHistoryMenuFlowTest.java
@@ -1,0 +1,378 @@
+package org.xcore.plugin.ui;
+
+import com.ospx.flubundle.Bundle;
+import mindustry.gen.Player;
+import mindustry.net.NetConnection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.xcore.plugin.config.Config;
+import org.xcore.plugin.config.GlobalConfig;
+import org.xcore.plugin.database.repository.PlayerDataRepository;
+import org.xcore.plugin.localization.Localization;
+import org.xcore.plugin.model.AuditAction;
+import org.xcore.plugin.model.AuditActor;
+import org.xcore.plugin.model.AuditCursor;
+import org.xcore.plugin.model.AuditRecord;
+import org.xcore.plugin.model.AuditRecordSummary;
+import org.xcore.plugin.model.PlayerData;
+import org.xcore.plugin.model.Slice;
+import org.xcore.plugin.service.moderation.AuditService;
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.flow.ActiveMenuScreen;
+import org.xcore.plugin.ui.flow.MenuMode;
+import org.xcore.plugin.ui.menu.AuditHistoryMenu;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AuditHistoryMenuFlowTest {
+
+    private MindustryMenuGateway gateway;
+    private MenuService menuService;
+
+    @BeforeEach
+    void setUp() {
+        gateway = mock(MindustryMenuGateway.class);
+        menuService = new MenuService(null, gateway);
+    }
+
+    @Test
+    @DisplayName("history flow renders next when hasNext and hides previous on first page")
+    void historyFlow_rendersNextWhenHasNextAndHidesPreviousOnFirstPage() {
+        SessionService sessionService = mock(SessionService.class);
+        AuditService auditService = mock(AuditService.class);
+        AuditHistoryMenu menu = new AuditHistoryMenu(new Config(), new GlobalConfig(), sessionService, auditService);
+
+        Session session = session("viewer-1");
+        PlayerData target = playerData("target-1", 1);
+        when(sessionService.get("viewer-1")).thenReturn(session);
+
+        AuditCursor nextCursor = new AuditCursor(100L, "audit-2");
+        AuditRecordSummary summary = new AuditRecordSummary(
+                "audit-1", AuditAction.BAN, "Target", "Moderator", "Reason", null, null, 10L
+        );
+        when(auditService.findSummaryByTargetUuid("target-1", null, 10))
+                .thenReturn(new Slice<>(List.of(summary), true, nextCursor));
+
+        menu.history("viewer-1", target);
+
+        AuditHistoryMenu.AuditHistoryState state = session.getDraft(AuditHistoryMenu.AuditHistoryState.class);
+        assertThat(state.currentCursor).isNull();
+        assertThat(state.nextCursor).isEqualTo(nextCursor);
+
+        ActiveMenuScreen screen = session.activeScreen();
+        assertThat(screen).isNotNull();
+        assertThat(screen.hasFlow()).isTrue();
+        assertThat(optionIndexOf(screen, "previous")).isEqualTo(-1);
+        assertThat(optionIndexOf(screen, "next")).isGreaterThanOrEqualTo(0);
+        assertThat(optionIndexOf(screen, "details:audit-1")).isGreaterThanOrEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("next action pushes first-page marker and loads next cursor page")
+    void nextAction_pushesFirstPageMarkerAndLoadsNextCursorPage() {
+        SessionService sessionService = mock(SessionService.class);
+        AuditService auditService = mock(AuditService.class);
+        AuditHistoryMenu menu = new AuditHistoryMenu(new Config(), new GlobalConfig(), sessionService, auditService);
+
+        Session session = session("viewer-1");
+        PlayerData target = playerData("target-1", 1);
+        when(sessionService.get("viewer-1")).thenReturn(session);
+
+        AuditCursor nextCursor = new AuditCursor(100L, "audit-2");
+        AuditRecordSummary firstSummary = new AuditRecordSummary(
+                "audit-3", AuditAction.BAN, "T", "A", "R", null, null, 20L
+        );
+        AuditRecordSummary nextSummary = new AuditRecordSummary(
+                "audit-2", AuditAction.MUTE, "T", "A", "R", null, null, 10L
+        );
+
+        when(auditService.findSummaryByTargetUuid("target-1", null, 10))
+                .thenReturn(new Slice<>(List.of(firstSummary), true, nextCursor));
+        when(auditService.findSummaryByTargetUuid("target-1", nextCursor, 10))
+                .thenReturn(new Slice<>(List.of(nextSummary), false, null));
+
+        menu.history("viewer-1", target);
+
+        int nextIndex = optionIndexOf(session.activeScreen(), "next");
+        menuService.onMenuOption(session, nextIndex);
+
+        AuditHistoryMenu.AuditHistoryState state = session.getDraft(AuditHistoryMenu.AuditHistoryState.class);
+        assertThat(state.backStack).hasSize(1);
+        assertThat(state.currentCursor).isEqualTo(nextCursor);
+        verify(auditService).findSummaryByTargetUuid("target-1", nextCursor, 10);
+    }
+
+    @Test
+    @DisplayName("previous action restores first page cursor from marker")
+    void previousAction_restoresFirstPageCursorFromMarker() {
+        SessionService sessionService = mock(SessionService.class);
+        AuditService auditService = mock(AuditService.class);
+        AuditHistoryMenu menu = new AuditHistoryMenu(new Config(), new GlobalConfig(), sessionService, auditService);
+
+        Session session = session("viewer-1");
+        PlayerData target = playerData("target-1", 1);
+        when(sessionService.get("viewer-1")).thenReturn(session);
+
+        AuditCursor nextCursor = new AuditCursor(100L, "audit-2");
+        AuditRecordSummary firstSummary = new AuditRecordSummary(
+                "audit-3", AuditAction.BAN, "T", "A", "R", null, null, 20L
+        );
+        AuditRecordSummary nextSummary = new AuditRecordSummary(
+                "audit-2", AuditAction.MUTE, "T", "A", "R", null, null, 10L
+        );
+
+        when(auditService.findSummaryByTargetUuid("target-1", null, 10))
+                .thenReturn(new Slice<>(List.of(firstSummary), true, nextCursor));
+        when(auditService.findSummaryByTargetUuid("target-1", nextCursor, 10))
+                .thenReturn(new Slice<>(List.of(nextSummary), false, null));
+
+        menu.history("viewer-1", target);
+
+        menuService.onMenuOption(session, optionIndexOf(session.activeScreen(), "next"));
+        menuService.onMenuOption(session, optionIndexOf(session.activeScreen(), "previous"));
+
+        AuditHistoryMenu.AuditHistoryState state = session.getDraft(AuditHistoryMenu.AuditHistoryState.class);
+        assertThat(state.currentCursor).isNull();
+        assertThat(state.backStack).isEmpty();
+        verify(auditService, times(2)).findSummaryByTargetUuid("target-1", null, 10);
+    }
+
+    @Test
+    @DisplayName("details action opens details via follow-up menu and active screen mode FOLLOW_UP")
+    void detailsAction_opensDetailsViaFollowUpMenu() {
+        SessionService sessionService = mock(SessionService.class);
+        AuditService auditService = mock(AuditService.class);
+        AuditHistoryMenu menu = new AuditHistoryMenu(new Config(), new GlobalConfig(), sessionService, auditService);
+
+        Session session = session("viewer-1");
+        PlayerData target = playerData("target-1", 1);
+        when(sessionService.get("viewer-1")).thenReturn(session);
+
+        AuditRecordSummary summary = new AuditRecordSummary(
+                "audit-3", AuditAction.BAN, "T", "A", "R", null, null, 20L
+        );
+        AuditRecord record = AuditRecord.builder()
+                .auditId("audit-3")
+                .action(AuditAction.BAN)
+                .actor(AuditActor.builder().nameSnapshot("Actor").build())
+                .reason("Reason")
+                .build();
+
+        when(auditService.findSummaryByTargetUuid("target-1", null, 10))
+                .thenReturn(new Slice<>(List.of(summary), false, null));
+        when(auditService.findByAuditId("audit-3")).thenReturn(Optional.of(record));
+
+        menu.history("viewer-1", target);
+
+        int detailsIndex = optionIndexOf(session.activeScreen(), "details:audit-3");
+        menuService.onMenuOption(session, detailsIndex);
+
+        assertThat(session.hasHistory()).isTrue();
+        ActiveMenuScreen detailsScreen = session.activeScreen();
+        assertThat(detailsScreen).isNotNull();
+        assertThat(detailsScreen.mode()).isEqualTo(MenuMode.FOLLOW_UP);
+        verify(gateway).followUpMenu(eq(session.player), eq(0), eq("audit-menu-details-title"), any(), any());
+    }
+
+    @Test
+    @DisplayName("back from details hides follow-up and restores list via normal gateway menu")
+    void backFromDetails_hidesFollowUpAndRestoresList() {
+        SessionService sessionService = mock(SessionService.class);
+        AuditService auditService = mock(AuditService.class);
+        AuditHistoryMenu menu = new AuditHistoryMenu(new Config(), new GlobalConfig(), sessionService, auditService);
+
+        Session session = session("viewer-1");
+        PlayerData target = playerData("target-1", 1);
+        when(sessionService.get("viewer-1")).thenReturn(session);
+
+        AuditRecordSummary summary = new AuditRecordSummary(
+                "audit-3", AuditAction.BAN, "T", "A", "R", null, null, 20L
+        );
+        AuditRecord record = AuditRecord.builder()
+                .auditId("audit-3")
+                .action(AuditAction.BAN)
+                .actor(AuditActor.builder().nameSnapshot("Actor").build())
+                .reason("Reason")
+                .build();
+
+        when(auditService.findSummaryByTargetUuid("target-1", null, 10))
+                .thenReturn(new Slice<>(List.of(summary), false, null));
+        when(auditService.findByAuditId("audit-3")).thenReturn(Optional.of(record));
+
+        menu.history("viewer-1", target);
+
+        int detailsIndex = optionIndexOf(session.activeScreen(), "details:audit-3");
+        menuService.onMenuOption(session, detailsIndex);
+
+        ActiveMenuScreen detailsScreen = session.activeScreen();
+        assertThat(detailsScreen).isNotNull();
+        assertThat(detailsScreen.mode()).isEqualTo(MenuMode.FOLLOW_UP);
+
+        // Back is at index 0 when history exists
+        menuService.onMenuOption(session, 0);
+
+        verify(gateway).followUpMenu(eq(session.player), eq(0), eq("audit-menu-details-title"), any(), any());
+        verify(gateway).hideFollowUpMenu(eq(session.player), eq(0));
+        verify(gateway, times(2)).menu(eq(session.player), eq(0), any(), any(), any());
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.NORMAL);
+    }
+
+    @Test
+    @DisplayName("close from details hides follow-up and clears active screen")
+    void closeFromDetails_hidesFollowUpAndClearsActiveScreen() {
+        SessionService sessionService = mock(SessionService.class);
+        AuditService auditService = mock(AuditService.class);
+        AuditHistoryMenu menu = new AuditHistoryMenu(new Config(), new GlobalConfig(), sessionService, auditService);
+
+        Session session = session("viewer-1");
+        PlayerData target = playerData("target-1", 1);
+        when(sessionService.get("viewer-1")).thenReturn(session);
+
+        AuditRecordSummary summary = new AuditRecordSummary(
+                "audit-3", AuditAction.BAN, "T", "A", "R", null, null, 20L
+        );
+        AuditRecord record = AuditRecord.builder()
+                .auditId("audit-3")
+                .action(AuditAction.BAN)
+                .actor(AuditActor.builder().nameSnapshot("Actor").build())
+                .reason("Reason")
+                .build();
+
+        when(auditService.findSummaryByTargetUuid("target-1", null, 10))
+                .thenReturn(new Slice<>(List.of(summary), false, null));
+        when(auditService.findByAuditId("audit-3")).thenReturn(Optional.of(record));
+
+        menu.history("viewer-1", target);
+
+        int detailsIndex = optionIndexOf(session.activeScreen(), "details:audit-3");
+        menuService.onMenuOption(session, detailsIndex);
+
+        // Close is at index 1 when history exists (back at 0)
+        menuService.onMenuOption(session, 1);
+
+        verify(gateway).followUpMenu(eq(session.player), eq(0), eq("audit-menu-details-title"), any(), any());
+        verify(gateway).hideFollowUpMenu(eq(session.player), eq(0));
+        assertThat(session.activeScreen()).isNull();
+    }
+
+    @Test
+    @DisplayName("dismiss from details hides follow-up and clears active screen while preserving history")
+    void dismissFromDetails_hidesFollowUpAndClearsActiveScreen() {
+        SessionService sessionService = mock(SessionService.class);
+        AuditService auditService = mock(AuditService.class);
+        AuditHistoryMenu menu = new AuditHistoryMenu(new Config(), new GlobalConfig(), sessionService, auditService);
+
+        Session session = session("viewer-1");
+        PlayerData target = playerData("target-1", 1);
+        when(sessionService.get("viewer-1")).thenReturn(session);
+
+        AuditRecordSummary summary = new AuditRecordSummary(
+                "audit-3", AuditAction.BAN, "T", "A", "R", null, null, 20L
+        );
+        AuditRecord record = AuditRecord.builder()
+                .auditId("audit-3")
+                .action(AuditAction.BAN)
+                .actor(AuditActor.builder().nameSnapshot("Actor").build())
+                .reason("Reason")
+                .build();
+
+        when(auditService.findSummaryByTargetUuid("target-1", null, 10))
+                .thenReturn(new Slice<>(List.of(summary), false, null));
+        when(auditService.findByAuditId("audit-3")).thenReturn(Optional.of(record));
+
+        menu.history("viewer-1", target);
+
+        int detailsIndex = optionIndexOf(session.activeScreen(), "details:audit-3");
+        menuService.onMenuOption(session, detailsIndex);
+
+        assertThat(session.hasHistory()).isTrue();
+
+        // Dismiss with option == -1
+        menuService.onMenuOption(session, -1);
+
+        verify(gateway).followUpMenu(eq(session.player), eq(0), eq("audit-menu-details-title"), any(), any());
+        verify(gateway).hideFollowUpMenu(eq(session.player), eq(0));
+        assertThat(session.activeScreen()).isNull();
+        assertThat(session.hasHistory()).isTrue();
+    }
+
+    @Test
+    @DisplayName("close action clears active screen")
+    void closeAction_clearsActiveScreen() {
+        SessionService sessionService = mock(SessionService.class);
+        AuditService auditService = mock(AuditService.class);
+        AuditHistoryMenu menu = new AuditHistoryMenu(new Config(), new GlobalConfig(), sessionService, auditService);
+
+        Session session = session("viewer-1");
+        PlayerData target = playerData("target-1", 1);
+        when(sessionService.get("viewer-1")).thenReturn(session);
+        when(auditService.findSummaryByTargetUuid("target-1", null, 10))
+                .thenReturn(new Slice<>(List.of(), false, null));
+
+        menu.history("viewer-1", target);
+
+        assertThat(session.activeScreen()).isNotNull();
+        menuService.onMenuOption(session, optionIndexOf(session.activeScreen(), "close"));
+
+        assertThat(session.activeScreen()).isNull();
+    }
+
+    private static int optionIndexOf(ActiveMenuScreen screen, String actionId) {
+        if (screen == null) return -1;
+        for (int i = 0; i < screen.actionCount(); i++) {
+            if (actionId.equals(screen.actionIdAt(i))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private Session session(String uuid) {
+        Player player = Player.create();
+        player.con = mock(NetConnection.class);
+        PlayerData data = playerData(uuid, 1);
+        data.uuid = uuid;
+
+        Session session = new Session(
+                new GlobalConfig(),
+                mock(Bundle.class),
+                menuService,
+                mock(PlayerDataRepository.class),
+                player,
+                data
+        );
+
+        Localization localization = mock(Localization.class);
+        when(localization.t(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.t(anyString(), anyMap())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.format(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.format(anyString(), anyMap())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.getLocale()).thenReturn(Locale.US);
+        session.localization = localization;
+
+        return session;
+    }
+
+    private static PlayerData playerData(String uuid, int pid) {
+        PlayerData data = new PlayerData(uuid, true);
+        data.uuid = uuid;
+        data.pid = pid;
+        data.nickname = uuid;
+        return data;
+    }
+}

--- a/src/test/java/org/xcore/plugin/ui/BanMenuTest.java
+++ b/src/test/java/org/xcore/plugin/ui/BanMenuTest.java
@@ -1,0 +1,246 @@
+package org.xcore.plugin.ui;
+
+import com.ospx.flubundle.Bundle;
+import jakarta.inject.Provider;
+import mindustry.gen.Player;
+import mindustry.net.NetConnection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.xcore.plugin.config.Config;
+import org.xcore.plugin.config.GlobalConfig;
+import org.xcore.plugin.database.repository.PlayerDataRepository;
+import org.xcore.plugin.localization.Localization;
+import org.xcore.plugin.model.BanData;
+import org.xcore.plugin.model.PlayerData;
+import org.xcore.plugin.service.TimeService;
+import org.xcore.plugin.service.moderation.ModerationResult;
+import org.xcore.plugin.service.moderation.ModerationService;
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.flow.MenuMode;
+import org.xcore.plugin.ui.menu.BanMenu;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BanMenuTest {
+
+    private SessionService sessionService;
+    private ModerationService moderationService;
+    private TimeService timeService;
+    private MindustryMenuGateway gateway;
+    private MenuService menuService;
+    private BanMenu banMenu;
+    private Session session;
+    private Player target;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        sessionService = mock(SessionService.class);
+        moderationService = mock(ModerationService.class);
+        timeService = mock(TimeService.class);
+        gateway = mock(MindustryMenuGateway.class);
+
+        Provider<SessionService> sessionProvider = mock(Provider.class);
+        when(sessionProvider.get()).thenReturn(sessionService);
+        menuService = new MenuService(sessionProvider, gateway);
+        banMenu = new BanMenu(new Config(), new GlobalConfig(), sessionService, moderationService, timeService);
+
+        session = session("admin-uuid", 1);
+        target = target("target-uuid");
+
+        PlayerData targetData = new PlayerData("target-uuid", false);
+        targetData.uuid = "target-uuid";
+        targetData.pid = 42;
+
+        when(sessionService.get(session.player)).thenReturn(session);
+        when(sessionService.getOrLoadFromDb("target-uuid")).thenReturn(targetData);
+        when(timeService.parsePeriod("2d", java.util.concurrent.TimeUnit.DAYS)).thenReturn(Instant.ofEpochMilli(Duration.ofDays(2).toMillis()));
+    }
+
+    @Test
+    @DisplayName("open starts duration prompt through MenuService and does not set textHandler")
+    void open_startsDurationPromptThroughMenuService() {
+        banMenu.open(session.player, target);
+
+        assertThat(session.activePrompt()).isNotNull();
+        assertThat(session.textHandler).isNull();
+        verify(gateway).textInput(eq(session.player), eq(0), eq("ban-menu-duration-title"), eq("ban-menu-duration-message"), eq(64), eq("1d"), eq(false));
+    }
+
+    @Test
+    @DisplayName("duration submit opens reason prompt and clears stale handler")
+    void durationSubmit_opensReasonPrompt() {
+        banMenu.open(session.player, target);
+
+        menuService.onTextInput(session, "2d");
+
+        assertThat(session.activePrompt()).isNotNull();
+        assertThat(session.textHandler).isNull();
+        verify(gateway).textInput(eq(session.player), eq(0), eq("ban-menu-reason-title"), eq("ban-menu-reason-message"), eq(256), eq(""), eq(false));
+    }
+
+    @Test
+    @DisplayName("invalid duration reopens duration prompt without stale textHandler")
+    void durationSubmit_invalidDurationReopensDurationPrompt() {
+        banMenu.open(session.player, target);
+
+        menuService.onTextInput(session, "bad");
+
+        verify(session.localization).send(eq("error-wrong-period-format"), anyMap());
+        assertThat(session.activePrompt()).isNotNull();
+        assertThat(session.textHandler).isNull();
+        verify(gateway, times(2)).textInput(eq(session.player), eq(0), eq("ban-menu-duration-title"), eq("ban-menu-duration-message"), eq(64), eq("1d"), eq(false));
+    }
+
+    @Test
+    @DisplayName("duration cancel clears draft and does not call moderation service")
+    void durationCancel_clearsDraft() {
+        banMenu.open(session.player, target);
+
+        menuService.onTextInput(session, null);
+
+        assertThat(session.activePrompt()).isNull();
+        assertThat(session.textHandler).isNull();
+        assertThat(session.hasDraft(draftClass())).isFalse();
+        verify(moderationService, never()).banById(eq(42), anyString(), anyString(), anyString(), eq(Duration.ofDays(2)), eq(true));
+        verify(session.localization).send(eq("ban-cancelled"), anyMap());
+    }
+
+    @Test
+    @DisplayName("reason submit opens confirmation follow-up screen with no active prompt")
+    void reasonSubmit_opensConfirmationScreen() {
+        banMenu.open(session.player, target);
+        menuService.onTextInput(session, "2d");
+
+        menuService.onTextInput(session, "griefing");
+
+        assertThat(session.activePrompt()).isNull();
+        assertThat(session.textHandler).isNull();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
+        verify(gateway).followUpMenu(eq(session.player), eq(0), eq("ban-menu-confirm-title"), anyString(), any());
+    }
+
+    @Test
+    @DisplayName("reason cancel returns to duration prompt without stale textHandler")
+    void reasonCancel_returnsToDurationPrompt() {
+        banMenu.open(session.player, target);
+        menuService.onTextInput(session, "2d");
+
+        menuService.onTextInput(session, null);
+
+        assertThat(session.activePrompt()).isNotNull();
+        assertThat(session.textHandler).isNull();
+        verify(gateway).textInput(eq(session.player), eq(0), eq("ban-menu-duration-title"), eq("ban-menu-duration-message"), eq(64), eq("2d"), eq(false));
+    }
+
+    @Test
+    @DisplayName("confirm action applies ban through moderation service and clears draft")
+    void confirmAction_appliesBan() {
+        BanData ban = new BanData();
+        ban.name = "Target";
+        when(moderationService.banById(eq(42), eq(session.player.name), eq(session.data.discordId), eq("griefing"), eq(Duration.ofDays(2)), eq(true)))
+                .thenReturn(ModerationResult.success(ban));
+
+        banMenu.open(session.player, target);
+        menuService.onTextInput(session, "2d");
+        menuService.onTextInput(session, "griefing");
+
+        menuService.onMenuOption(session, 0);
+
+        verify(moderationService).banById(42, session.player.name, session.data.discordId, "griefing", Duration.ofDays(2), true);
+        assertThat(session.hasDraft(draftClass())).isFalse();
+        verify(sessionService).broadcast(eq("tempban-player-banned"), anyMap());
+        verify(session.localization).send(eq("commands-ban-success"), anyMap());
+        assertThat(session.activeScreen()).isNull();
+        verify(gateway).hideFollowUpMenu(eq(session.player), eq(0));
+    }
+
+    @Test
+    @DisplayName("confirm cancel clears draft, hides follow-up, and clears UI state")
+    void confirmCancel_clearsDraftAndHidesFollowUp() {
+        banMenu.open(session.player, target);
+        menuService.onTextInput(session, "2d");
+        menuService.onTextInput(session, "griefing");
+
+        menuService.onMenuOption(session, 1);
+
+        assertThat(session.hasDraft(draftClass())).isFalse();
+        assertThat(session.activeScreen()).isNull();
+        assertThat(session.activePrompt()).isNull();
+        assertThat(session.textHandler).isNull();
+        assertThat(session.actions).isEmpty();
+        verify(gateway).hideFollowUpMenu(eq(session.player), eq(0));
+        verify(session.localization).send(eq("ban-cancelled"), anyMap());
+    }
+
+    @Test
+    @DisplayName("confirm dismiss -1 hides follow-up and clears UI state")
+    void confirmDismiss_hidesFollowUpAndClearsState() {
+        banMenu.open(session.player, target);
+        menuService.onTextInput(session, "2d");
+        menuService.onTextInput(session, "griefing");
+
+        menuService.onMenuOption(session, -1);
+
+        assertThat(session.activeScreen()).isNull();
+        assertThat(session.activePrompt()).isNull();
+        assertThat(session.textHandler).isNull();
+        assertThat(session.actions).isEmpty();
+        verify(gateway).hideFollowUpMenu(eq(session.player), eq(0));
+        assertThat(session.hasDraft(draftClass())).isTrue();
+    }
+
+    private Session session(String uuid, int pid) {
+        Player player = Player.create();
+        player.con = mock(NetConnection.class);
+        player.name = "Admin";
+
+        PlayerData data = new PlayerData(uuid, true);
+        data.uuid = uuid;
+        data.pid = pid;
+        data.discordId = "discord-admin";
+
+        Session session = new Session(new GlobalConfig(), mock(Bundle.class), menuService, mock(PlayerDataRepository.class), player, data);
+        Localization localization = mock(Localization.class);
+        when(localization.t(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.t(anyString(), anyMap())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.format(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.format(anyString(), anyMap())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.getLocale()).thenReturn(Locale.US);
+        session.localization = localization;
+        return session;
+    }
+
+    private Player target(String uuid) {
+        Player player = mock(Player.class);
+        when(player.uuid()).thenReturn(uuid);
+        when(player.coloredName()).thenReturn("[scarlet]Target");
+        when(player.plainName()).thenReturn("Target");
+        return player;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<Object> draftClass() {
+        try {
+            return (Class<Object>) Class.forName("org.xcore.plugin.ui.menu.BanMenu$BanDraft");
+        } catch (ClassNotFoundException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/src/test/java/org/xcore/plugin/ui/DefaultMindustryMenuGatewayTest.java
+++ b/src/test/java/org/xcore/plugin/ui/DefaultMindustryMenuGatewayTest.java
@@ -1,0 +1,40 @@
+package org.xcore.plugin.ui;
+
+import mindustry.gen.Player;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class DefaultMindustryMenuGatewayTest {
+
+    private final DefaultMindustryMenuGateway gateway = new DefaultMindustryMenuGateway();
+
+    @Test
+    @DisplayName("openUri tolerates null player")
+    void openUri_toleratesNullPlayer() {
+        assertThatNoException().isThrownBy(() -> gateway.openUri(null, "https://example.com"));
+    }
+
+    @Test
+    @DisplayName("openUri tolerates null connection")
+    void openUri_toleratesNullConnection() {
+        Player player = Player.create();
+        player.con = null;
+        assertThatNoException().isThrownBy(() -> gateway.openUri(player, "https://example.com"));
+    }
+
+    @Test
+    @DisplayName("copyToClipboard tolerates null player")
+    void copyToClipboard_toleratesNullPlayer() {
+        assertThatNoException().isThrownBy(() -> gateway.copyToClipboard(null, "code"));
+    }
+
+    @Test
+    @DisplayName("copyToClipboard tolerates null connection")
+    void copyToClipboard_toleratesNullConnection() {
+        Player player = Player.create();
+        player.con = null;
+        assertThatNoException().isThrownBy(() -> gateway.copyToClipboard(player, "code"));
+    }
+}

--- a/src/test/java/org/xcore/plugin/ui/DiscordMenuTest.java
+++ b/src/test/java/org/xcore/plugin/ui/DiscordMenuTest.java
@@ -1,0 +1,138 @@
+package org.xcore.plugin.ui;
+
+import com.ospx.flubundle.Bundle;
+import mindustry.gen.Player;
+import mindustry.net.NetConnection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.xcore.plugin.config.Config;
+import org.xcore.plugin.config.GlobalConfig;
+import org.xcore.plugin.database.repository.PlayerDataRepository;
+import org.xcore.plugin.localization.Localization;
+import org.xcore.plugin.model.PlayerData;
+import org.xcore.plugin.service.DiscordLinkService;
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.flow.MenuMode;
+import org.xcore.plugin.ui.menu.DiscordMenu;
+
+import jakarta.inject.Provider;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DiscordMenuTest {
+
+    private SessionService sessionService;
+    private MindustryMenuGateway gateway;
+    private MenuService menuService;
+    private DiscordMenu discordMenu;
+    private Session session;
+    private GlobalConfig globalConfig;
+    private DiscordLinkService discordLinkService;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        sessionService = mock(SessionService.class);
+        gateway = mock(MindustryMenuGateway.class);
+        Provider<SessionService> sessionProvider = mock(Provider.class);
+        when(sessionProvider.get()).thenReturn(sessionService);
+        menuService = new MenuService(sessionProvider, gateway);
+
+        Config config = new Config();
+        config.server = "xcore";
+        globalConfig = new GlobalConfig();
+        globalConfig.discordUrl = "https://discord.example";
+
+        discordLinkService = mock(DiscordLinkService.class);
+        discordMenu = new DiscordMenu(config, globalConfig, sessionService, discordLinkService);
+
+        session = session();
+        when(sessionService.get("viewer-1")).thenReturn(session);
+        when(discordLinkService.status(session)).thenReturn(DiscordLinkService.LinkStatusResult.notLinked());
+        when(discordLinkService.getOrCreateActiveCode(session)).thenReturn(
+                DiscordLinkService.LinkCodeResult.success("ABCD12", System.currentTimeMillis() + 10 * 60_000L)
+        );
+    }
+
+    @Test
+    @DisplayName("main open button routes through gateway openUri")
+    void main_openButtonRoutesThroughGatewayOpenUri() {
+        discordMenu.main("viewer-1");
+
+        menuService.onMenuOption(session, 0);
+
+        verify(gateway).openUri(eq(session.player), eq(globalConfig.discordUrl));
+    }
+
+    @Test
+    @DisplayName("linking copy button routes through gateway copyToClipboard")
+    void linking_copyButtonRoutesThroughGatewayCopyToClipboard() {
+        discordMenu.linking("viewer-1", false);
+
+        menuService.onMenuOption(session, 1);
+
+        verify(gateway).copyToClipboard(eq(session.player), eq("ABCD12"));
+    }
+
+    @Test
+    @DisplayName("linking renders via gateway followUpMenu and sets active screen mode FOLLOW_UP")
+    void linking_rendersViaFollowUpMenu() {
+        discordMenu.linking("viewer-1", false);
+
+        verify(gateway).followUpMenu(eq(session.player), eq(menuService.getMenuId()), any(), any(), any());
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
+    }
+
+    @Test
+    @DisplayName("linking dismiss -1 hides follow-up and clears active screen")
+    void linking_dismissHidesFollowUp() {
+        discordMenu.linking("viewer-1", false);
+
+        menuService.onMenuOption(session, -1);
+
+        verify(gateway).hideFollowUpMenu(eq(session.player), eq(menuService.getMenuId()));
+        assertThat(session.activeScreen()).isNull();
+    }
+
+    @Test
+    @DisplayName("linking status action returns to main menu via normal show")
+    void linking_statusActionReturnsToMain() {
+        discordMenu.linking("viewer-1", false);
+
+        menuService.onMenuOption(session, 4); // status button
+
+        verify(gateway).hideFollowUpMenu(eq(session.player), eq(menuService.getMenuId()));
+        verify(gateway).menu(eq(session.player), eq(menuService.getMenuId()), any(), any(), any());
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.NORMAL);
+    }
+
+    private Session session() {
+        Player player = Player.create();
+        player.con = mock(NetConnection.class);
+        PlayerData data = new PlayerData("viewer-1", true);
+        data.uuid = "viewer-1";
+        Session session = new Session(
+                globalConfig,
+                mock(Bundle.class),
+                menuService,
+                mock(PlayerDataRepository.class),
+                player,
+                data
+        );
+        Localization localization = mock(Localization.class);
+        when(localization.t(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.t(anyString(), any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.getLocale()).thenReturn(Locale.US);
+        session.localization = localization;
+        return session;
+    }
+}

--- a/src/test/java/org/xcore/plugin/ui/DiscordMenuTest.java
+++ b/src/test/java/org/xcore/plugin/ui/DiscordMenuTest.java
@@ -19,11 +19,13 @@ import org.xcore.plugin.ui.menu.DiscordMenu;
 
 import jakarta.inject.Provider;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -108,10 +110,30 @@ class DiscordMenuTest {
     void linking_statusActionReturnsToMain() {
         discordMenu.linking("viewer-1", false);
 
-        menuService.onMenuOption(session, 4); // status button
+        menuService.onMenuOption(session, 4); // status button without history
 
         verify(gateway).hideFollowUpMenu(eq(session.player), eq(menuService.getMenuId()));
         verify(gateway).menu(eq(session.player), eq(menuService.getMenuId()), any(), any(), any());
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.NORMAL);
+    }
+
+    @Test
+    @DisplayName("linking back action hides follow-up before restoring previous menu")
+    void linking_backActionHidesFollowUpBeforeRestoringPreviousMenu() {
+        AtomicBoolean previousMenuRan = new AtomicBoolean(false);
+        session.pushHistory(() -> {
+            previousMenuRan.set(true);
+            discordMenu.main("viewer-1");
+        });
+        discordMenu.linking("viewer-1", false);
+
+        menuService.onMenuOption(session, 5); // back button when history exists
+
+        assertThat(previousMenuRan).isTrue();
+        var inOrder = inOrder(gateway);
+        inOrder.verify(gateway).followUpMenu(eq(session.player), eq(menuService.getMenuId()), any(), any(), any());
+        inOrder.verify(gateway).hideFollowUpMenu(eq(session.player), eq(menuService.getMenuId()));
+        inOrder.verify(gateway).menu(eq(session.player), eq(menuService.getMenuId()), any(), any(), any());
         assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.NORMAL);
     }
 

--- a/src/test/java/org/xcore/plugin/ui/EventMenuTest.java
+++ b/src/test/java/org/xcore/plugin/ui/EventMenuTest.java
@@ -1,0 +1,255 @@
+package org.xcore.plugin.ui;
+
+import com.ospx.flubundle.Bundle;
+import jakarta.inject.Provider;
+import mindustry.gen.Player;
+import mindustry.net.NetConnection;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.xcore.plugin.config.Config;
+import org.xcore.plugin.config.GlobalConfig;
+import org.xcore.plugin.common.StatusEnum;
+import org.xcore.plugin.database.repository.EventDataRepository;
+import org.xcore.plugin.database.repository.MapDataRepository;
+import org.xcore.plugin.database.repository.PlayerDataRepository;
+import org.xcore.plugin.localization.Localization;
+import org.xcore.plugin.model.EventData;
+import org.xcore.plugin.model.MapData;
+import org.xcore.plugin.model.PlayerData;
+import org.xcore.plugin.service.EventEditorService;
+import org.xcore.plugin.service.EventService;
+import org.xcore.plugin.service.EventViewService;
+import org.xcore.plugin.service.MapService;
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.menu.EventMenu;
+import org.xcore.plugin.ui.menu.MapMenu;
+import org.xcore.plugin.vote.VoteService;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class EventMenuTest {
+
+    private SessionService sessionService;
+    private EventDataRepository eventDataRepository;
+    private MapDataRepository mapDataRepository;
+    private PlayerDataRepository playerDataRepository;
+    private MapService mapService;
+    private EventService eventService;
+    private VoteService voteService;
+    private Provider<MapMenu> mapMenuProvider;
+    private MindustryMenuGateway gateway;
+    private MenuService menuService;
+    private EventMenu eventMenu;
+    private Session session;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        sessionService = mock(SessionService.class);
+        eventDataRepository = mock(EventDataRepository.class);
+        mapDataRepository = mock(MapDataRepository.class);
+        playerDataRepository = mock(PlayerDataRepository.class);
+        mapService = mock(MapService.class);
+        eventService = mock(EventService.class);
+        voteService = mock(VoteService.class);
+        mapMenuProvider = mock(Provider.class);
+        gateway = mock(MindustryMenuGateway.class);
+
+        Provider<SessionService> sessionProvider = mock(Provider.class);
+        when(sessionProvider.get()).thenReturn(sessionService);
+        menuService = new MenuService(sessionProvider, gateway);
+
+        GlobalConfig globalConfig = new GlobalConfig();
+        globalConfig.eventsPerPage = 10;
+        globalConfig.mapsPerPage = 10;
+        EventEditorService eventEditorService = new EventEditorService(eventDataRepository, mapDataRepository, playerDataRepository);
+        EventViewService eventViewService = new EventViewService(eventDataRepository, mapDataRepository, playerDataRepository);
+        eventMenu = new EventMenu(
+                new Config(),
+                globalConfig,
+                sessionService,
+                mapService,
+                eventService,
+                eventEditorService,
+                eventViewService,
+                voteService,
+                mapMenuProvider
+        );
+
+        session = session();
+        when(sessionService.get(session.data.uuid)).thenReturn(session);
+
+        when(eventDataRepository.findActive()).thenReturn(Optional.empty());
+        when(eventDataRepository.count(anyMapOfStatus())).thenReturn(0L);
+        when(eventDataRepository.findPage(anyInt(), anyInt(), any())).thenReturn(List.of());
+    }
+
+    @Test
+    @DisplayName("createStart opens active prompt via gateway textInput, sets draft author and map, and does not set textHandler")
+    void createStart_opensPromptAndSetsDraft() {
+        MapData map = new MapData();
+        map.id = new ObjectId();
+
+        eventMenu.createStart(session.data.uuid, map);
+
+        EventData draft = session.getDraft(EventData.class);
+        assertThat(draft.author).isEqualTo(session.data.id);
+        assertThat(draft.map).isEqualTo(map.id);
+        assertThat(session.textHandler).isNull();
+        assertThat(session.activePrompt()).isNotNull();
+        verify(gateway).textInput(eq(session.player), eq(0), eq("event-menu-create-start-title"), eq("event-menu-create-start-message"), eq(20), anyString(), eq(false));
+    }
+
+    @Test
+    @DisplayName("createStart submit sets draft name and returns to edit screen with no active prompt")
+    void createStart_submit_setsNameAndReturnsToEdit() {
+        MapData map = new MapData();
+        map.id = new ObjectId();
+
+        eventMenu.createStart(session.data.uuid, map);
+        assertThat(session.activePrompt()).isNotNull();
+
+        menuService.onTextInput(session, "My Event");
+
+        EventData draft = session.getDraft(EventData.class);
+        assertThat(draft.name).isEqualTo("My Event");
+        assertThat(session.activePrompt()).isNull();
+        assertThat(session.activeScreen()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("createStart cancel clears draft and leaves no active prompt or textHandler")
+    void createStart_cancel_clearsDraftAndPrompt() {
+        MapData map = new MapData();
+        map.id = new ObjectId();
+
+        eventMenu.createStart(session.data.uuid, map);
+        assertThat(session.activePrompt()).isNotNull();
+
+        menuService.onTextInput(session, null);
+
+        assertThat(session.activePrompt()).isNull();
+        assertThat(session.textHandler).isNull();
+        assertThat(session.hasDraft(EventData.class)).isFalse();
+        assertThat(session.activeScreen()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("edit name prompt submit mutates draft name, clears active prompt, leaves textHandler null")
+    void editName_submit_mutatesDraftName() {
+        EventData draft = new EventData();
+        draft.name = "Old";
+        draft.author = session.data.id;
+        session.setDraft(draft);
+
+        eventMenu.edit(session.data.uuid);
+        menuService.onMenuOption(session, 0);
+
+        assertThat(session.activePrompt()).isNotNull();
+        assertThat(session.textHandler).isNull();
+        verify(gateway).textInput(eq(session.player), eq(0), eq("event-menu-edit-name-title"), eq(""), eq(24), eq("Old"), eq(false));
+
+        menuService.onTextInput(session, "New Name");
+
+        assertThat(draft.name).isEqualTo("New Name");
+        assertThat(session.activePrompt()).isNull();
+        assertThat(session.textHandler).isNull();
+        assertThat(session.activeScreen()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("edit description prompt submit mutates draft description")
+    void editDescription_submit_mutatesDraftDescription() {
+        EventData draft = new EventData();
+        draft.name = "Event";
+        draft.author = session.data.id;
+        session.setDraft(draft);
+
+        eventMenu.edit(session.data.uuid);
+        menuService.onMenuOption(session, 2);
+
+        assertThat(session.activePrompt()).isNotNull();
+        verify(gateway).textInput(eq(session.player), eq(0), eq("event-menu-edit-description-title"), eq(""), eq(1000), eq("Unknown"), eq(false));
+
+        menuService.onTextInput(session, "New Desc");
+
+        assertThat(draft.description).isEqualTo("New Desc");
+        assertThat(session.activePrompt()).isNull();
+        assertThat(session.textHandler).isNull();
+    }
+
+    @Test
+    @DisplayName("planned start and end prompts apply parseTime correctly")
+    void plannedStartEnd_submit_appliesParseTime() {
+        EventData draft = new EventData();
+        draft.name = "Event";
+        draft.author = session.data.id;
+        session.setDraft(draft);
+
+        eventMenu.edit(session.data.uuid);
+
+        // planned start is option 5
+        menuService.onMenuOption(session, 5);
+        assertThat(session.activePrompt()).isNotNull();
+        verify(gateway).textInput(eq(session.player), eq(0), eq("event-menu-edit-planned-start-title"), eq(""), eq(64), eq(""), eq(false));
+
+        menuService.onTextInput(session, "12345");
+        assertThat(draft.plannedStartTime).isEqualTo(12345L);
+        assertThat(session.activePrompt()).isNull();
+
+        // planned end is option 6
+        menuService.onMenuOption(session, 6);
+        assertThat(session.activePrompt()).isNotNull();
+        verify(gateway).textInput(eq(session.player), eq(0), eq("event-menu-edit-planned-end-title"), eq(""), eq(10), eq(""), eq(false));
+
+        menuService.onTextInput(session, "bad");
+        assertThat(draft.plannedEndTime).isEqualTo(0L);
+        assertThat(session.activePrompt()).isNull();
+    }
+
+    private Session session() {
+        Player player = Player.create();
+        player.con = mock(NetConnection.class);
+        PlayerData data = new PlayerData("test-uuid", true);
+        data.uuid = "test-uuid";
+        data.id = new ObjectId();
+        Session session = new Session(
+                new GlobalConfig(),
+                mock(Bundle.class),
+                menuService,
+                mock(PlayerDataRepository.class),
+                player,
+                data
+        );
+        Localization localization = mock(Localization.class);
+        when(localization.t(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.t(anyString(), anyMap())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.format(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.format(anyString(), anyMap())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.getLocale()).thenReturn(Locale.US);
+        session.localization = localization;
+        return session;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, StatusEnum> anyMapOfStatus() {
+        return any(Map.class);
+    }
+}

--- a/src/test/java/org/xcore/plugin/ui/InformationMenuTest.java
+++ b/src/test/java/org/xcore/plugin/ui/InformationMenuTest.java
@@ -1,0 +1,153 @@
+package org.xcore.plugin.ui;
+
+import com.ospx.flubundle.Bundle;
+import jakarta.inject.Provider;
+import mindustry.gen.Player;
+import mindustry.net.NetConnection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.xcore.plugin.common.BuildInfo;
+import org.xcore.plugin.config.Config;
+import org.xcore.plugin.config.GlobalConfig;
+import org.xcore.plugin.database.repository.PlayerDataRepository;
+import org.xcore.plugin.localization.Localization;
+import org.xcore.plugin.model.PlayerData;
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.flow.MenuMode;
+import org.xcore.plugin.ui.menu.EventMenu;
+import org.xcore.plugin.ui.menu.HelpMenu;
+import org.xcore.plugin.ui.menu.InformationMenu;
+import org.xcore.plugin.ui.menu.MapMenu;
+import org.xcore.plugin.ui.menu.PlayerMenu;
+
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class InformationMenuTest {
+
+    private SessionService sessionService;
+    private MindustryMenuGateway gateway;
+    private MenuService menuService;
+    private InformationMenu informationMenu;
+    private Session session;
+    private GlobalConfig globalConfig;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        sessionService = mock(SessionService.class);
+        gateway = mock(MindustryMenuGateway.class);
+        Provider<SessionService> sessionProvider = mock(Provider.class);
+        when(sessionProvider.get()).thenReturn(sessionService);
+        menuService = new MenuService(sessionProvider, gateway);
+
+        Config config = new Config();
+        config.server = "xcore";
+        globalConfig = new GlobalConfig();
+        globalConfig.discordUrl = "https://discord.example";
+        globalConfig.githubUrl = "https://github.example";
+        globalConfig.donatelloUrl = "https://donate.example";
+        globalConfig.weblateUrl = "https://translate.example";
+        globalConfig.discordRedVSBlueUrl = "https://rvb.example";
+
+        BuildInfo buildInfo = new BuildInfo();
+        buildInfo.setVersion("test-version");
+        Provider<MapMenu> map = mock(Provider.class);
+        Provider<EventMenu> event = mock(Provider.class);
+        Provider<HelpMenu> help = mock(Provider.class);
+        Provider<PlayerMenu> player = mock(Provider.class);
+        informationMenu = new InformationMenu(config, globalConfig, sessionService, buildInfo, map, event, help, player);
+
+        session = session();
+        when(sessionService.get("viewer-1")).thenReturn(session);
+    }
+
+    @Test
+    @DisplayName("information renders through flow runtime")
+    void information_rendersThroughFlowRuntime() {
+        informationMenu.information("viewer-1");
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
+        assertThat(session.activeScreen().actionCount()).isEqualTo(6);
+        verify(gateway).followUpMenu(eq(session.player), eq(0), eq("commands-info-title"), eq("commands-info-text"), any());
+    }
+
+    @Test
+    @DisplayName("information includes back action only when history exists")
+    void information_includesBackActionOnlyWhenHistoryExists() {
+        session.pushHistory(() -> {});
+
+        informationMenu.information("viewer-1");
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().actionCount()).isEqualTo(7);
+    }
+
+    @Test
+    @DisplayName("information back action runs previous menu")
+    void information_backActionRunsPreviousMenu() {
+        final boolean[] ran = {false};
+        session.pushHistory(() -> ran[0] = true);
+        informationMenu.information("viewer-1");
+
+        menuService.onMenuOption(session, 5);
+
+        verify(gateway).hideFollowUpMenu(eq(session.player), eq(0));
+        assertThat(ran[0]).isTrue();
+    }
+
+    @Test
+    @DisplayName("information close action clears active screen")
+    void information_closeActionClearsActiveScreen() {
+        informationMenu.information("viewer-1");
+
+        menuService.onMenuOption(session, 5);
+
+        assertThat(session.activeScreen()).isNull();
+        verify(gateway).hideFollowUpMenu(eq(session.player), eq(0));
+    }
+
+    @Test
+    @DisplayName("information discord action routes through gateway openUri")
+    void information_discordActionRoutesThroughGatewayOpenUri() {
+        informationMenu.information("viewer-1");
+
+        menuService.onMenuOption(session, 0);
+
+        verify(gateway).openUri(eq(session.player), eq(globalConfig.discordUrl));
+    }
+
+    private Session session() {
+        Player player = Player.create();
+        player.con = mock(NetConnection.class);
+        PlayerData data = new PlayerData("viewer-1", true);
+        data.uuid = "viewer-1";
+        Session session = new Session(
+                new GlobalConfig(),
+                mock(Bundle.class),
+                menuService,
+                mock(PlayerDataRepository.class),
+                player,
+                data
+        );
+        Localization localization = mock(Localization.class);
+        when(localization.t(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.t(anyString(), anyMap())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.getLocale()).thenReturn(Locale.US);
+        session.localization = localization;
+        return session;
+    }
+}

--- a/src/test/java/org/xcore/plugin/ui/MenuServiceFlowTest.java
+++ b/src/test/java/org/xcore/plugin/ui/MenuServiceFlowTest.java
@@ -1,0 +1,325 @@
+package org.xcore.plugin.ui;
+
+import com.ospx.flubundle.Bundle;
+import mindustry.gen.Player;
+import mindustry.net.NetConnection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.xcore.plugin.config.GlobalConfig;
+import org.xcore.plugin.database.repository.PlayerDataRepository;
+import org.xcore.plugin.model.PlayerData;
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.ui.flow.*;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class MenuServiceFlowTest {
+
+    private MindustryMenuGateway gateway;
+    private MenuService menuService;
+    private Session session;
+
+    @BeforeEach
+    void setUp() {
+        gateway = mock(MindustryMenuGateway.class);
+        menuService = new MenuService(null, gateway);
+        session = session();
+    }
+
+    @Test
+    @DisplayName("renderFlow shows NORMAL screen from flow render")
+    void renderFlow_showsNormalScreenFromFlowRender() {
+        MenuFlow<String> flow = mock(MenuFlow.class);
+        when(flow.stateType()).thenReturn(String.class);
+        MenuScreen screen = MenuScreen.normal("Title", "Content", List.of(List.of(MenuButton.of("Btn", "btn1"))));
+        when(flow.render(any(MenuRenderContext.class))).thenReturn(screen);
+
+        session.setDraft("state");
+        menuService.renderFlow(session, flow);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.NORMAL);
+        verify(gateway).menu(eq(session.player), eq(0), eq("Title"), eq("Content"), any());
+    }
+
+    @Test
+    @DisplayName("renderFlow shows FOLLOW_UP screen from flow render")
+    void renderFlow_showsFollowUpScreenFromFlowRender() {
+        MenuFlow<String> flow = mock(MenuFlow.class);
+        when(flow.stateType()).thenReturn(String.class);
+        MenuScreen screen = MenuScreen.followUp("Title", "Content", List.of(List.of(MenuButton.of("Btn", "btn1"))));
+        when(flow.render(any(MenuRenderContext.class))).thenReturn(screen);
+
+        session.setDraft("state");
+        menuService.renderFlow(session, flow);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
+        verify(gateway).followUpMenu(eq(session.player), eq(0), eq("Title"), eq("Content"), any());
+    }
+
+    @Test
+    @DisplayName("onMenuOption dispatches named action to flow onAction")
+    void onMenuOption_dispatchesNamedActionToFlowOnAction() {
+        AtomicReference<String> receivedActionId = new AtomicReference<>();
+
+        MenuFlow<String> flow = new MenuFlow<>() {
+            @Override
+            public Class<String> stateType() {
+                return String.class;
+            }
+
+            @Override
+            public MenuScreen render(MenuRenderContext<String> context) {
+                return MenuScreen.normal("T", "C", List.of(List.of(MenuButton.of("OK", "ok"))));
+            }
+
+            @Override
+            public void onAction(MenuRenderContext<String> context, String actionId) {
+                receivedActionId.set(actionId);
+            }
+        };
+
+        session.setDraft("state");
+        menuService.renderFlow(session, flow);
+
+        menuService.onMenuOption(session, 0);
+
+        assertThat(receivedActionId.get()).isEqualTo("ok");
+    }
+
+    @Test
+    @DisplayName("onMenuOption option -1 calls flow onClose")
+    void onMenuOption_optionMinusOneCallsFlowOnClose() {
+        AtomicBoolean closed = new AtomicBoolean(false);
+
+        MenuFlow<String> flow = new MenuFlow<>() {
+            @Override
+            public Class<String> stateType() {
+                return String.class;
+            }
+
+            @Override
+            public MenuScreen render(MenuRenderContext<String> context) {
+                return MenuScreen.followUp("T", "C", List.of());
+            }
+
+            @Override
+            public void onClose(MenuRenderContext<String> context) {
+                closed.set(true);
+            }
+        };
+
+        session.setDraft("state");
+        menuService.renderFlow(session, flow);
+
+        menuService.onMenuOption(session, -1);
+
+        assertThat(closed).isTrue();
+        assertThat(session.activeScreen()).isNull();
+    }
+
+    @Test
+    @DisplayName("onMenuOption option -1 keeps replacement screen rendered by flow onClose")
+    void onMenuOption_optionMinusOneKeepsReplacementScreenRenderedByFlowOnClose() {
+        MenuFlow<String> replacementFlow = mockFlow("Replacement", "C2");
+
+        MenuFlow<String> flow = new MenuFlow<>() {
+            @Override
+            public Class<String> stateType() {
+                return String.class;
+            }
+
+            @Override
+            public MenuScreen render(MenuRenderContext<String> context) {
+                return MenuScreen.normal("T", "C", List.of());
+            }
+
+            @Override
+            public void onClose(MenuRenderContext<String> context) {
+                context.session().menuService.show(
+                        context.session(),
+                        MenuScreen.normal("Replacement", "C2", List.of()),
+                        replacementFlow,
+                        context.state()
+                );
+            }
+        };
+
+        session.setDraft("state");
+        menuService.renderFlow(session, flow);
+        ActiveMenuScreen original = session.activeScreen();
+
+        menuService.onMenuOption(session, -1);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen()).isNotSameAs(original);
+        verify(gateway).menu(eq(session.player), eq(0), eq("Replacement"), eq("C2"), any());
+    }
+
+    @Test
+    @DisplayName("close calls flow onClose for active flow screen")
+    void close_callsFlowOnClose() {
+        AtomicBoolean closed = new AtomicBoolean(false);
+
+        MenuFlow<String> flow = new MenuFlow<>() {
+            @Override
+            public Class<String> stateType() {
+                return String.class;
+            }
+
+            @Override
+            public MenuScreen render(MenuRenderContext<String> context) {
+                return MenuScreen.normal("T", "C", List.of());
+            }
+
+            @Override
+            public void onClose(MenuRenderContext<String> context) {
+                closed.set(true);
+            }
+        };
+
+        session.setDraft("state");
+        menuService.renderFlow(session, flow);
+
+        menuService.close(session);
+
+        assertThat(closed).isTrue();
+        assertThat(session.activeScreen()).isNull();
+    }
+
+    @Test
+    @DisplayName("close keeps replacement screen rendered by flow onClose")
+    void close_keepsReplacementScreenRenderedByFlowOnClose() {
+        MenuFlow<String> replacementFlow = mockFlow("Replacement", "C2");
+
+        MenuFlow<String> flow = new MenuFlow<>() {
+            @Override
+            public Class<String> stateType() {
+                return String.class;
+            }
+
+            @Override
+            public MenuScreen render(MenuRenderContext<String> context) {
+                return MenuScreen.normal("T", "C", List.of());
+            }
+
+            @Override
+            public void onClose(MenuRenderContext<String> context) {
+                context.session().menuService.show(
+                        context.session(),
+                        MenuScreen.normal("Replacement", "C2", List.of()),
+                        replacementFlow,
+                        context.state()
+                );
+            }
+        };
+
+        session.setDraft("state");
+        menuService.renderFlow(session, flow);
+        ActiveMenuScreen original = session.activeScreen();
+
+        menuService.close(session);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen()).isNotSameAs(original);
+        verify(gateway).menu(eq(session.player), eq(0), eq("Replacement"), eq("C2"), any());
+    }
+
+    @Test
+    @DisplayName("onTextInput dispatches submit to flow onPromptSubmit")
+    void onTextInput_dispatchesSubmitToFlowOnPromptSubmit() {
+        AtomicReference<String> receivedText = new AtomicReference<>();
+
+        MenuFlow<String> flow = new MenuFlow<>() {
+            @Override
+            public Class<String> stateType() {
+                return String.class;
+            }
+
+            @Override
+            public MenuScreen render(MenuRenderContext<String> context) {
+                return MenuScreen.normal("T", "C", List.of());
+            }
+
+            @Override
+            public void onPromptSubmit(MenuRenderContext<String> context, String promptId, String text) {
+                receivedText.set(text);
+            }
+        };
+
+        session.setDraft("state");
+        menuService.openPrompt(session, flow, "state", new MenuPrompt("p1", "Title", "Content", 50, "def", false));
+
+        menuService.onTextInput(session, "hello");
+
+        assertThat(receivedText.get()).isEqualTo("hello");
+        assertThat(session.activePrompt()).isNull();
+    }
+
+    @Test
+    @DisplayName("onTextInput dispatches cancel to flow onPromptCancel")
+    void onTextInput_dispatchesCancelToFlowOnPromptCancel() {
+        AtomicBoolean cancelled = new AtomicBoolean(false);
+
+        MenuFlow<String> flow = new MenuFlow<>() {
+            @Override
+            public Class<String> stateType() {
+                return String.class;
+            }
+
+            @Override
+            public MenuScreen render(MenuRenderContext<String> context) {
+                return MenuScreen.normal("T", "C", List.of());
+            }
+
+            @Override
+            public void onPromptCancel(MenuRenderContext<String> context, String promptId) {
+                cancelled.set(true);
+            }
+        };
+
+        session.setDraft("state");
+        menuService.openPrompt(session, flow, "state", new MenuPrompt("p1", "Title", "Content", 50, "def", false));
+
+        menuService.onTextInput(session, null);
+
+        assertThat(cancelled).isTrue();
+        assertThat(session.activePrompt()).isNull();
+    }
+
+    private MenuFlow<String> mockFlow(String title, String content) {
+        return new MenuFlow<>() {
+            @Override
+            public Class<String> stateType() {
+                return String.class;
+            }
+
+            @Override
+            public MenuScreen render(MenuRenderContext<String> context) {
+                return MenuScreen.normal(title, content, List.of());
+            }
+        };
+    }
+
+    private Session session() {
+        Player player = Player.create();
+        player.con = mock(NetConnection.class);
+        PlayerData data = new PlayerData("uuid-flow", true);
+        return new Session(
+                new GlobalConfig(),
+                mock(Bundle.class),
+                menuService,
+                mock(PlayerDataRepository.class),
+                player,
+                data
+        );
+    }
+}

--- a/src/test/java/org/xcore/plugin/ui/MenuServiceTest.java
+++ b/src/test/java/org/xcore/plugin/ui/MenuServiceTest.java
@@ -1,0 +1,197 @@
+package org.xcore.plugin.ui;
+
+import com.ospx.flubundle.Bundle;
+import jakarta.inject.Provider;
+import mindustry.gen.Player;
+import mindustry.net.NetConnection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.xcore.plugin.config.GlobalConfig;
+import org.xcore.plugin.database.repository.PlayerDataRepository;
+import org.xcore.plugin.model.PlayerData;
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.flow.MenuMode;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class MenuServiceTest {
+
+    private MindustryMenuGateway gateway;
+    private MenuService menuService;
+    private Session session;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        gateway = mock(MindustryMenuGateway.class);
+        Provider<SessionService> sessionServiceProvider = mock(Provider.class);
+        menuService = new MenuService(sessionServiceProvider, gateway);
+        session = session();
+    }
+
+    @Test
+    @DisplayName("show sets active screen mode NORMAL and calls gateway.menu")
+    void show_setsActiveScreenModeNormalAndCallsGatewayMenu() {
+        menuService.show(session, "Title", "Content", List.of(), List.of(), MenuMode.NORMAL);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.NORMAL);
+        assertThat(session.activeScreen().version()).isEqualTo(1L);
+        verify(gateway).menu(eq(session.player), eq(0), eq("Title"), eq("Content"), any());
+    }
+
+    @Test
+    @DisplayName("show sets active screen mode FOLLOW_UP and calls gateway.followUpMenu")
+    void show_setsActiveScreenModeFollowUpAndCallsGatewayFollowUpMenu() {
+        menuService.show(session, "Title", "Content", List.of(), List.of(), MenuMode.FOLLOW_UP);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
+        assertThat(session.activeScreen().version()).isEqualTo(1L);
+        verify(gateway).followUpMenu(eq(session.player), eq(0), eq("Title"), eq("Content"), any());
+    }
+
+    @Test
+    @DisplayName("hideFollowUp calls gateway.hideFollowUpMenu when active screen is FOLLOW_UP and clears active screen")
+    void hideFollowUp_callsGatewayHideFollowUpWhenFollowUpActive() {
+        menuService.show(session, "Title", "Content", List.of(), List.of(), MenuMode.FOLLOW_UP);
+        assertThat(session.activeScreen()).isNotNull();
+
+        menuService.hideFollowUp(session);
+
+        verify(gateway).hideFollowUpMenu(eq(session.player), eq(0));
+        assertThat(session.activeScreen()).isNull();
+    }
+
+    @Test
+    @DisplayName("hideFollowUp does not call gateway when active screen is NORMAL")
+    void hideFollowUp_doesNotCallGatewayWhenNormalActive() {
+        menuService.show(session, "Title", "Content", List.of(), List.of(), MenuMode.NORMAL);
+
+        menuService.hideFollowUp(session);
+
+        verify(gateway, never()).hideFollowUpMenu(any(), anyInt());
+        assertThat(session.activeScreen()).isNull();
+    }
+
+    @Test
+    @DisplayName("close hides follow-up when active and clears active screen and actions")
+    void close_hidesFollowUpWhenActiveAndClearsScreenAndActions() {
+        menuService.show(session, "Title", "Content", List.of(), List.of(), MenuMode.FOLLOW_UP);
+        menuService.openTextPrompt(session, "Prompt", "Content", 100, "default", false, s -> {}, () -> {});
+        session.actions.add(() -> {});
+        session.textHandler = s -> {};
+        assertThat(session.actions).isNotEmpty();
+
+        menuService.close(session);
+
+        verify(gateway).hideFollowUpMenu(eq(session.player), eq(0));
+        assertThat(session.activeScreen()).isNull();
+        assertThat(session.activePrompt()).isNull();
+        assertThat(session.actions).isEmpty();
+        assertThat(session.textHandler).isNull();
+    }
+
+    @Test
+    @DisplayName("close clears active screen and actions for NORMAL mode")
+    void close_clearsScreenAndActionsForNormalMode() {
+        menuService.show(session, "Title", "Content", List.of(), List.of(), MenuMode.NORMAL);
+        menuService.openTextPrompt(session, "Prompt", "Content", 100, "default", false, s -> {}, () -> {});
+        session.actions.add(() -> {});
+        session.textHandler = s -> {};
+
+        menuService.close(session);
+
+        verify(gateway, never()).hideFollowUpMenu(any(), anyInt());
+        assertThat(session.activeScreen()).isNull();
+        assertThat(session.activePrompt()).isNull();
+        assertThat(session.actions).isEmpty();
+        assertThat(session.textHandler).isNull();
+    }
+
+    @Test
+    @DisplayName("openTextPrompt sets active prompt and calls gateway.textInput")
+    void openTextPrompt_setsActivePromptAndCallsGatewayTextInput() {
+        Consumer<String> onSubmit = s -> {};
+        Runnable onCancel = () -> {};
+
+        menuService.openTextPrompt(session, "Title", "Content", 100, "default", false, onSubmit, onCancel);
+
+        assertThat(session.activePrompt()).isNotNull();
+        assertThat(session.activePrompt().promptId()).isEqualTo(0);
+        assertThat(session.activePrompt().version()).isEqualTo(1L);
+        verify(gateway).textInput(eq(session.player), eq(0), eq("Title"), eq("Content"), eq(100), eq("default"), eq(false));
+    }
+
+    @Test
+    @DisplayName("builder show routes to service show with mode NORMAL")
+    void builderShow_routesToServiceShowWithModeNormal() {
+        MenuBuilder builder = new MenuBuilder(menuService, session);
+        builder.title = "Builder Title";
+        builder.content = "Builder Content";
+
+        builder.show();
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.NORMAL);
+        verify(gateway).menu(eq(session.player), eq(0), eq("Builder Title"), eq("Builder Content"), any());
+    }
+
+    @Test
+    @DisplayName("builder showFollowUp routes to service show with mode FOLLOW_UP")
+    void builderShowFollowUp_routesToServiceShowWithModeFollowUp() {
+        MenuBuilder builder = new MenuBuilder(menuService, session);
+        builder.title = "Builder Title";
+        builder.content = "Builder Content";
+
+        builder.showFollowUp();
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
+        verify(gateway).followUpMenu(eq(session.player), eq(0), eq("Builder Title"), eq("Builder Content"), any());
+    }
+
+    @Test
+    @DisplayName("builder followUp sets mode to FOLLOW_UP")
+    void builderFollowUp_setsModeToFollowUp() {
+        MenuBuilder builder = new MenuBuilder(menuService, session);
+
+        assertThat(builder.mode).isEqualTo(MenuMode.NORMAL);
+        builder.followUp();
+        assertThat(builder.mode).isEqualTo(MenuMode.FOLLOW_UP);
+    }
+
+    @Test
+    @DisplayName("builder show(int) routes to gateway.menu with custom menuId")
+    void builderShowInt_routesToGatewayMenuWithCustomMenuId() {
+        MenuBuilder builder = new MenuBuilder(menuService, session);
+        builder.title = "Builder Title";
+        builder.content = "Builder Content";
+
+        builder.show(42);
+
+        assertThat(session.activeScreen()).isNull();
+        verify(gateway).menu(eq(session.player), eq(42), eq("Builder Title"), eq("Builder Content"), any());
+    }
+
+    private Session session() {
+        Player player = Player.create();
+        player.con = mock(NetConnection.class);
+        PlayerData data = new PlayerData("uuid-1", true);
+        return new Session(
+                new GlobalConfig(),
+                mock(Bundle.class),
+                menuService,
+                mock(PlayerDataRepository.class),
+                player,
+                data
+        );
+    }
+}

--- a/src/test/java/org/xcore/plugin/ui/MessageMenuTest.java
+++ b/src/test/java/org/xcore/plugin/ui/MessageMenuTest.java
@@ -1,0 +1,197 @@
+package org.xcore.plugin.ui;
+
+import com.ospx.flubundle.Bundle;
+import jakarta.inject.Provider;
+import mindustry.gen.Player;
+import mindustry.net.NetConnection;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.xcore.plugin.config.Config;
+import org.xcore.plugin.config.GlobalConfig;
+import org.xcore.plugin.database.repository.PlayerDataRepository;
+import org.xcore.plugin.localization.Localization;
+import org.xcore.plugin.model.PlayerData;
+import org.xcore.plugin.model.PrivateMessage;
+import org.xcore.plugin.service.PrivateMessageService;
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.menu.MessageMenu;
+
+import java.util.List;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MessageMenuTest {
+
+    private SessionService sessionService;
+    private PrivateMessageService privateMessageService;
+    private MindustryMenuGateway gateway;
+    private MenuService menuService;
+    private MessageMenu messageMenu;
+    private Session session;
+    private PrivateMessage message;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        sessionService = mock(SessionService.class);
+        privateMessageService = mock(PrivateMessageService.class);
+        gateway = mock(MindustryMenuGateway.class);
+        Provider<SessionService> sessionProvider = mock(Provider.class);
+        when(sessionProvider.get()).thenReturn(sessionService);
+        menuService = new MenuService(sessionProvider, gateway);
+
+        GlobalConfig globalConfig = new GlobalConfig();
+        globalConfig.privateMessageMaxLength = 300;
+        globalConfig.privateMessagesPerPage = 10;
+        messageMenu = new MessageMenu(new Config(), globalConfig, sessionService, privateMessageService);
+
+        session = session();
+        when(sessionService.get("viewer-1")).thenReturn(session);
+
+        message = new PrivateMessage();
+        message.id = new ObjectId();
+        message.fromUuid = "author-1";
+        message.fromPid = 42;
+        message.fromName = "Author";
+        message.toUuid = session.data.uuid;
+        message.message = "hello";
+        when(privateMessageService.getMessage(message.id, session.data.uuid)).thenReturn(message);
+        when(privateMessageService.inbox(session.data.uuid, 1)).thenReturn(List.of());
+    }
+
+    @Test
+    @DisplayName("reply opens active prompt through menu service")
+    void reply_opensActivePromptThroughMenuService() {
+        messageMenu.details("viewer-1", message.id, 1);
+        menuService.onMenuOption(session, 0);
+
+        assertThat(session.activePrompt()).isNotNull();
+        assertThat(session.textHandler).isNull();
+        verify(gateway).textInput(eq(session.player), eq(0), eq("private-message-reply-title"), eq("private-message-reply-message"), eq(300), eq(""), eq(false));
+    }
+
+    @Test
+    @DisplayName("reply submit sends message and returns to details")
+    void replySubmit_sendsMessageAndReturnsToDetails() {
+        messageMenu.details("viewer-1", message.id, 1);
+        menuService.onMenuOption(session, 0);
+
+        menuService.onTextInput(session, "reply text");
+
+        verify(privateMessageService).send(session, 42, "reply text");
+        assertThat(session.activePrompt()).isNull();
+        assertThat(session.activeScreen()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("reply cancel returns to details without sending")
+    void replyCancel_returnsToDetailsWithoutSending() {
+        messageMenu.details("viewer-1", message.id, 1);
+        menuService.onMenuOption(session, 0);
+
+        menuService.onTextInput(session, null);
+
+        verify(privateMessageService, never()).send(any(), anyInt(), anyString());
+        assertThat(session.activePrompt()).isNull();
+        assertThat(session.activeScreen()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("compose opens target prompt then body prompt")
+    void compose_opensTargetPromptThenBodyPrompt() {
+        messageMenu.inbox("viewer-1", 1);
+        menuService.onMenuOption(session, 0);
+
+        verify(gateway).textInput(eq(session.player), eq(0), eq("private-message-compose-target-title"), eq("private-message-compose-target-message"), eq(32), eq(""), eq(false));
+        when(privateMessageService.parseMenuPid("#55")).thenReturn(55);
+
+        menuService.onTextInput(session, "#55");
+
+        assertThat(session.activePrompt()).isNotNull();
+        verify(gateway).textInput(eq(session.player), eq(0), eq("private-message-compose-body-title"), eq("private-message-compose-body-message"), eq(300), eq(""), eq(false));
+        assertThat(session.textHandler).isNull();
+    }
+
+    @Test
+    @DisplayName("compose body submit sends message and returns")
+    void composeBodySubmit_sendsMessageAndReturns() {
+        messageMenu.inbox("viewer-1", 1);
+        menuService.onMenuOption(session, 0);
+        when(privateMessageService.parseMenuPid("#55")).thenReturn(55);
+        menuService.onTextInput(session, "#55");
+
+        menuService.onTextInput(session, "hello target");
+
+        verify(privateMessageService).send(session, 55, "hello target");
+        assertThat(session.activePrompt()).isNull();
+        assertThat(session.activeScreen()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("compose target cancel returns without opening stale handler")
+    void composeTargetCancel_returnsWithoutOpeningStaleHandler() {
+        messageMenu.inbox("viewer-1", 1);
+        menuService.onMenuOption(session, 0);
+
+        menuService.onTextInput(session, null);
+
+        verify(privateMessageService, never()).parseMenuPid(anyString());
+        verify(privateMessageService, never()).send(any(), anyInt(), anyString());
+        assertThat(session.activePrompt()).isNull();
+        assertThat(session.textHandler).isNull();
+        assertThat(session.activeScreen()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("compose invalid target returns without leaving stale prompt")
+    void composeInvalidTarget_returnsWithoutLeavingStalePrompt() {
+        messageMenu.inbox("viewer-1", 1);
+        menuService.onMenuOption(session, 0);
+        when(privateMessageService.parseMenuPid("bad")).thenReturn(null);
+
+        menuService.onTextInput(session, "bad");
+
+        verify(privateMessageService, never()).send(any(), anyInt(), anyString());
+        assertThat(session.activePrompt()).isNull();
+        assertThat(session.textHandler).isNull();
+        assertThat(session.activeScreen()).isNotNull();
+        verify(session.localization).send(eq("error-private-message-invalid-pid"), anyMap());
+    }
+
+    private Session session() {
+        Player player = Player.create();
+        player.con = mock(NetConnection.class);
+        PlayerData data = new PlayerData("viewer-1", true);
+        data.uuid = "viewer-1";
+        data.pid = 7;
+        Session session = new Session(
+                new GlobalConfig(),
+                mock(Bundle.class),
+                menuService,
+                mock(PlayerDataRepository.class),
+                player,
+                data
+        );
+        Localization localization = mock(Localization.class);
+        when(localization.t(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.t(anyString(), anyMap())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.format(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.format(anyString(), anyMap())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.getLocale()).thenReturn(Locale.US);
+        session.localization = localization;
+        return session;
+    }
+}

--- a/src/test/java/org/xcore/plugin/ui/flow/ActiveMenuPromptTest.java
+++ b/src/test/java/org/xcore/plugin/ui/flow/ActiveMenuPromptTest.java
@@ -1,0 +1,50 @@
+package org.xcore.plugin.ui.flow;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ActiveMenuPromptTest {
+
+    @Test
+    @DisplayName("submit invokes submit callback")
+    void submit_invokesSubmitCallback() {
+        AtomicReference<String> received = new AtomicReference<>();
+        ActiveMenuPrompt prompt = ActiveMenuPrompt.create(1L, 42, received::set, () -> {});
+
+        prompt.submit("hello");
+
+        assertThat(received.get()).isEqualTo("hello");
+    }
+
+    @Test
+    @DisplayName("cancel invokes cancel callback")
+    void cancel_invokesCancelCallback() {
+        AtomicBoolean ran = new AtomicBoolean(false);
+        ActiveMenuPrompt prompt = ActiveMenuPrompt.create(1L, 42, s -> {}, () -> ran.set(true));
+
+        prompt.cancel();
+
+        assertThat(ran).isTrue();
+    }
+
+    @Test
+    @DisplayName("submit tolerates null callback")
+    void submit_toleratesNullCallback() {
+        ActiveMenuPrompt prompt = ActiveMenuPrompt.create(1L, 42, null, null);
+
+        prompt.submit("hello"); // should not throw
+    }
+
+    @Test
+    @DisplayName("cancel tolerates null callback")
+    void cancel_toleratesNullCallback() {
+        ActiveMenuPrompt prompt = ActiveMenuPrompt.create(1L, 42, null, null);
+
+        prompt.cancel(); // should not throw
+    }
+}

--- a/src/test/java/org/xcore/plugin/ui/flow/ActiveMenuScreenTest.java
+++ b/src/test/java/org/xcore/plugin/ui/flow/ActiveMenuScreenTest.java
@@ -1,0 +1,67 @@
+package org.xcore.plugin.ui.flow;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ActiveMenuScreenTest {
+
+    @Test
+    @DisplayName("runAction executes callback at valid index")
+    void runAction_executesCallbackAtValidIndex() {
+        AtomicBoolean ran = new AtomicBoolean(false);
+        List<MenuAction> actions = List.of(
+                new MenuAction.CallbackAction(() -> ran.set(true))
+        );
+        ActiveMenuScreen screen = ActiveMenuScreen.create(1L, MenuMode.NORMAL, actions);
+
+        screen.runAction(0);
+
+        assertThat(ran).isTrue();
+    }
+
+    @Test
+    @DisplayName("runAction ignores invalid negative index")
+    void runAction_ignoresInvalidNegativeIndex() {
+        AtomicBoolean ran = new AtomicBoolean(false);
+        List<MenuAction> actions = List.of(
+                new MenuAction.CallbackAction(() -> ran.set(true))
+        );
+        ActiveMenuScreen screen = ActiveMenuScreen.create(1L, MenuMode.NORMAL, actions);
+
+        screen.runAction(-1);
+
+        assertThat(ran).isFalse();
+    }
+
+    @Test
+    @DisplayName("runAction ignores out-of-range index")
+    void runAction_ignoresOutOfRangeIndex() {
+        AtomicBoolean ran = new AtomicBoolean(false);
+        List<MenuAction> actions = List.of(
+                new MenuAction.CallbackAction(() -> ran.set(true))
+        );
+        ActiveMenuScreen screen = ActiveMenuScreen.create(1L, MenuMode.NORMAL, actions);
+
+        screen.runAction(5);
+
+        assertThat(ran).isFalse();
+    }
+
+    @Test
+    @DisplayName("create defensively copies actions")
+    void create_defensivelyCopiesActions() {
+        List<MenuAction> original = new ArrayList<>();
+        original.add(new MenuAction.CallbackAction(() -> {}));
+        ActiveMenuScreen screen = ActiveMenuScreen.create(1L, MenuMode.NORMAL, original);
+
+        assertThat(screen.actionCount()).isEqualTo(1);
+        original.clear();
+        assertThat(screen.actionCount()).isEqualTo(1);
+    }
+}

--- a/src/test/java/org/xcore/plugin/ui/flow/MenuScreenTest.java
+++ b/src/test/java/org/xcore/plugin/ui/flow/MenuScreenTest.java
@@ -1,0 +1,108 @@
+package org.xcore.plugin.ui.flow;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MenuScreenTest {
+
+    @Test
+    @DisplayName("normal factory creates screen with NORMAL mode")
+    void normalFactory_createsNormalMode() {
+        MenuScreen screen = MenuScreen.normal("Title", "Content", List.of());
+        assertThat(screen.mode()).isEqualTo(MenuMode.NORMAL);
+        assertThat(screen.title()).isEqualTo("Title");
+        assertThat(screen.content()).isEqualTo("Content");
+    }
+
+    @Test
+    @DisplayName("followUp factory creates screen with FOLLOW_UP mode")
+    void followUpFactory_createsFollowUpMode() {
+        MenuScreen screen = MenuScreen.followUp("Title", "Content", List.of());
+        assertThat(screen.mode()).isEqualTo(MenuMode.FOLLOW_UP);
+    }
+
+    @Test
+    @DisplayName("defensively copies rows deeply")
+    void defensiveCopy_deeplyCopiesRows() {
+        List<List<MenuButton>> rows = new ArrayList<>();
+        List<MenuButton> row = new ArrayList<>();
+        row.add(MenuButton.of("A", "a1"));
+        rows.add(row);
+
+        MenuScreen screen = MenuScreen.normal("T", "C", rows);
+        row.clear();
+
+        assertThat(screen.rows()).hasSize(1);
+        assertThat(screen.rows().get(0)).hasSize(1);
+        assertThat(screen.rows().get(0).get(0).text()).isEqualTo("A");
+    }
+
+    @Test
+    @DisplayName("toTextRows maps button texts")
+    void toTextRows_mapsButtonTexts() {
+        MenuScreen screen = MenuScreen.normal("T", "C", List.of(
+                List.of(MenuButton.of("A", "a1"), MenuButton.of("B", "b1")),
+                List.of(MenuButton.of("C", "c1"))
+        ));
+
+        List<List<String>> textRows = screen.toTextRows();
+
+        assertThat(textRows).containsExactly(
+                List.of("A", "B"),
+                List.of("C")
+        );
+    }
+
+    @Test
+    @DisplayName("toActions maps buttons to NamedAction with null callback")
+    void toActions_mapsToNamedAction() {
+        MenuScreen screen = MenuScreen.normal("T", "C", List.of(
+                List.of(MenuButton.of("A", "a1"))
+        ));
+
+        List<MenuAction> actions = screen.toActions();
+
+        assertThat(actions).hasSize(1);
+        MenuAction action = actions.get(0);
+        assertThat(action).isInstanceOf(MenuAction.NamedAction.class);
+        assertThat(((MenuAction.NamedAction) action).id()).isEqualTo("a1");
+        // should not NPE when run without callback
+        action.run();
+    }
+
+    @Test
+    @DisplayName("actionIdAt returns correct id for valid index")
+    void actionIdAt_returnsCorrectId() {
+        MenuScreen screen = MenuScreen.normal("T", "C", List.of(
+                List.of(MenuButton.of("A", "a1"), MenuButton.of("B", "b1")),
+                List.of(MenuButton.of("C", "c1"))
+        ));
+
+        assertThat(screen.actionIdAt(0)).isEqualTo("a1");
+        assertThat(screen.actionIdAt(1)).isEqualTo("b1");
+        assertThat(screen.actionIdAt(2)).isEqualTo("c1");
+    }
+
+    @Test
+    @DisplayName("actionIdAt returns null for invalid index")
+    void actionIdAt_returnsNullForInvalidIndex() {
+        MenuScreen screen = MenuScreen.normal("T", "C", List.of());
+        assertThat(screen.actionIdAt(0)).isNull();
+        assertThat(screen.actionIdAt(-1)).isNull();
+    }
+
+    @Test
+    @DisplayName("actionCount sums all buttons")
+    void actionCount_sumsAllButtons() {
+        MenuScreen screen = MenuScreen.normal("T", "C", List.of(
+                List.of(MenuButton.of("A", "a1"), MenuButton.of("B", "b1")),
+                List.of(MenuButton.of("C", "c1"))
+        ));
+        assertThat(screen.actionCount()).isEqualTo(3);
+    }
+}

--- a/src/test/java/org/xcore/plugin/ui/menu/PlayerMenuTest.java
+++ b/src/test/java/org/xcore/plugin/ui/menu/PlayerMenuTest.java
@@ -1,0 +1,221 @@
+package org.xcore.plugin.ui;
+
+import com.ospx.flubundle.Bundle;
+import jakarta.inject.Provider;
+import mindustry.gen.Player;
+import mindustry.net.NetConnection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.xcore.plugin.config.Config;
+import org.xcore.plugin.config.GlobalConfig;
+import org.xcore.plugin.database.repository.GameDataRepository;
+import org.xcore.plugin.database.repository.PlayerDataRepository;
+import org.xcore.plugin.localization.Localization;
+import org.xcore.plugin.model.AggregatedPlayerStats;
+import org.xcore.plugin.model.ModeStatsSummary;
+import org.xcore.plugin.model.PlayerData;
+import org.xcore.plugin.model.PlayerStatsOverview;
+import org.xcore.plugin.service.PlayerDisplayService;
+import org.xcore.plugin.service.PlayerProfileSettingsService;
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.MenuService;
+import org.xcore.plugin.ui.MindustryMenuGateway;
+import org.xcore.plugin.ui.menu.AuditHistoryMenu;
+import org.xcore.plugin.ui.menu.PlayerMenu;
+
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PlayerMenuTest {
+
+    private SessionService sessionService;
+    private GameDataRepository gameDataRepository;
+    private PlayerDisplayService playerDisplayService;
+    private PlayerProfileSettingsService profileSettings;
+    private AuditHistoryMenu auditHistoryMenu;
+    private MindustryMenuGateway gateway;
+    private MenuService menuService;
+    private PlayerMenu playerMenu;
+    private Session session;
+    private PlayerData targetData;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        sessionService = mock(SessionService.class);
+        gameDataRepository = mock(GameDataRepository.class);
+        playerDisplayService = mock(PlayerDisplayService.class);
+        profileSettings = mock(PlayerProfileSettingsService.class);
+        auditHistoryMenu = mock(AuditHistoryMenu.class);
+        gateway = mock(MindustryMenuGateway.class);
+
+        Provider<SessionService> sessionProvider = mock(Provider.class);
+        when(sessionProvider.get()).thenReturn(sessionService);
+        menuService = new MenuService(sessionProvider, gateway);
+
+        Config config = new Config();
+        config.server = "mini-pvp";
+        GlobalConfig globalConfig = new GlobalConfig();
+
+        playerMenu = new PlayerMenu(
+                config, globalConfig, sessionService,
+                gameDataRepository,
+                mock(Bundle.class),
+                playerDisplayService, profileSettings,
+                auditHistoryMenu);
+
+        session = session();
+        targetData = session.data;
+
+        when(sessionService.get("viewer-1")).thenReturn(session);
+        when(gameDataRepository.aggregatePlayerStatsOverview(anyString()))
+                .thenReturn(new PlayerStatsOverview(
+                        AggregatedPlayerStats.EMPTY,
+                        ModeStatsSummary.EMPTY,
+                        ModeStatsSummary.EMPTY,
+                        ModeStatsSummary.EMPTY));
+        when(profileSettings.validateCustomNickname(anyString()))
+                .thenReturn(PlayerProfileSettingsService.NicknameValidationResult.ok());
+    }
+
+    @Test
+    @DisplayName("custom nickname button opens active prompt and leaves textHandler null")
+    void customNicknameButton_opensActivePromptAndLeavesTextHandlerNull() {
+        playerMenu.settings("viewer-1", targetData);
+        menuService.onMenuOption(session, 0);
+
+        assertThat(session.activePrompt()).isNotNull();
+        assertThat(session.textHandler).isNull();
+        verify(gateway).textInput(eq(session.player), eq(0),
+                eq("player-menu-settings-customNickname-title"),
+                eq("player-menu-settings-customNickname-message"),
+                eq(256), eq(targetData.customNickname), eq(false));
+    }
+
+    @Test
+    @DisplayName("custom nickname prompt submit validates and updates via service")
+    void customNicknamePromptSubmit_validatesAndUpdatesViaService() {
+        playerMenu.settings("viewer-1", targetData);
+        menuService.onMenuOption(session, 0);
+
+        menuService.onTextInput(session, "new nick");
+
+        verify(profileSettings).validateCustomNickname("new nick");
+        verify(profileSettings).updateCustomNickname(targetData, "new nick", true, true);
+        assertThat(session.activePrompt()).isNull();
+    }
+
+    @Test
+    @DisplayName("custom nickname prompt cancel returns to settings without updating")
+    void customNicknamePromptCancel_returnsWithoutUpdating() {
+        playerMenu.settings("viewer-1", targetData);
+        menuService.onMenuOption(session, 0);
+
+        menuService.onTextInput(session, null);
+
+        verify(profileSettings, never()).updateCustomNickname(any(), anyString(), anyBoolean(), anyBoolean());
+        assertThat(session.activePrompt()).isNull();
+    }
+
+    @Test
+    @DisplayName("custom nickname prompt rejects invalid nickname and returns to settings")
+    void customNicknamePromptSubmit_invalidNickname_returnsWithoutUpdating() {
+        when(profileSettings.validateCustomNickname("bad"))
+                .thenReturn(PlayerProfileSettingsService.NicknameValidationResult.tooLong(40));
+
+        playerMenu.settings("viewer-1", targetData);
+        menuService.onMenuOption(session, 0);
+
+        menuService.onTextInput(session, "bad");
+
+        verify(profileSettings, never()).updateCustomNickname(any(), anyString(), anyBoolean(), anyBoolean());
+        assertThat(session.activePrompt()).isNull();
+    }
+
+    @Test
+    @DisplayName("description button opens active prompt and leaves textHandler null")
+    void descriptionButton_opensActivePromptAndLeavesTextHandlerNull() {
+        playerMenu.settings("viewer-1", targetData);
+        menuService.onMenuOption(session, 2);
+
+        assertThat(session.activePrompt()).isNotNull();
+        assertThat(session.textHandler).isNull();
+        verify(gateway).textInput(eq(session.player), eq(0),
+                eq("player-menu-settings-description-title"),
+                eq(""),
+                eq(1000), eq(targetData.description), eq(false));
+    }
+
+    @Test
+    @DisplayName("description prompt submit updates via service")
+    void descriptionPromptSubmit_updatesViaService() {
+        playerMenu.settings("viewer-1", targetData);
+        menuService.onMenuOption(session, 2);
+
+        menuService.onTextInput(session, "new description");
+
+        verify(profileSettings).updateDescription(targetData, "new description");
+        assertThat(session.activePrompt()).isNull();
+    }
+
+    @Test
+    @DisplayName("description prompt cancel returns without updating")
+    void descriptionPromptCancel_returnsWithoutUpdating() {
+        playerMenu.settings("viewer-1", targetData);
+        menuService.onMenuOption(session, 2);
+
+        menuService.onTextInput(session, null);
+
+        verify(profileSettings, never()).updateDescription(any(), anyString());
+        assertThat(session.activePrompt()).isNull();
+    }
+
+    private Session session() {
+        Player player = Player.create();
+        player.con = mock(NetConnection.class);
+        PlayerData data = new PlayerData("viewer-1", true);
+        data.uuid = "viewer-1";
+        data.pid = 7;
+        data.customNickname = "old nick";
+        data.description = "old desc";
+        data.language = "auto";
+        data.translatorLanguage = "off";
+        data.globalChatVisible = true;
+        data.discordRelayVisible = true;
+        data.leaderboard = true;
+        data.activeBadge = "";
+        data.badgeSymbolColorMode = "default";
+
+        Session session = new Session(
+                new GlobalConfig(),
+                mock(Bundle.class),
+                menuService,
+                mock(PlayerDataRepository.class),
+                player,
+                data
+        );
+
+        Localization localization = mock(Localization.class);
+        when(localization.t(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.t(anyString(), anyMap())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.format(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.format(anyString(), anyMap())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.getLocale()).thenReturn(Locale.US);
+        when(localization.getLanguageName(anyString(), anyString())).thenReturn("English");
+        session.localization = localization;
+
+        return session;
+    }
+}

--- a/src/test/java/org/xcore/plugin/ui/menu/TopMenuTest.java
+++ b/src/test/java/org/xcore/plugin/ui/menu/TopMenuTest.java
@@ -1,8 +1,12 @@
-package org.xcore.plugin.ui.menu;
+package org.xcore.plugin.ui;
 
+import com.ospx.flubundle.Bundle;
+import mindustry.gen.Player;
+import mindustry.net.NetConnection;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.xcore.plugin.config.Config;
 import org.xcore.plugin.config.GlobalConfig;
 import org.xcore.plugin.localization.Localization;
@@ -12,25 +16,30 @@ import org.xcore.plugin.model.enums.TopCategory;
 import org.xcore.plugin.service.TopMenuService;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
-import org.xcore.plugin.ui.MenuBuilder;
+import org.xcore.plugin.ui.menu.PlayerMenu;
+import org.xcore.plugin.ui.menu.TopMenu;
+import org.xcore.plugin.ui.flow.ActiveMenuScreen;
+import org.xcore.plugin.ui.flow.MenuMode;
+import org.xcore.plugin.database.repository.PlayerDataRepository;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 class TopMenuTest {
+
+    private MindustryMenuGateway gateway;
+    private MenuService menuService;
+
+    @BeforeEach
+    void setUp() {
+        gateway = mock(MindustryMenuGateway.class);
+        menuService = new MenuService(null, gateway);
+    }
 
     @Test
     @DisplayName("top hides previous on first cursor page and exposes next when available")
@@ -41,8 +50,6 @@ class TopMenuTest {
         TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, topMenuService, playerMenu);
 
         Session session = session("viewer-1");
-        MenuBuilder builder = builder();
-        when(session.builder()).thenReturn(builder);
         when(sessionService.get("viewer-1")).thenReturn(session);
 
         LeaderboardCursor nextCursor = new LeaderboardCursor(1400, 0, 10);
@@ -62,12 +69,19 @@ class TopMenuTest {
 
         menu.top("viewer-1", TopCategory.MINI_PVP, 1);
 
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
+        verify(gateway).followUpMenu(eq(session.player), eq(menuService.getMenuId()), any(), any(), any());
+
         TopMenu.TopMenuState state = session.getDraft(TopMenu.TopMenuState.class);
         assertThat(state.currentPage).isEqualTo(1);
         assertThat(state.currentCursor).isNull();
         assertThat(state.nextCursor).isEqualTo(nextCursor);
-        verify(builder).ifAddLocal(eq(false), eq("previous"), any(Runnable.class));
-        verify(builder).ifAddLocal(eq(true), eq("next"), any(Runnable.class));
+
+        ActiveMenuScreen screen = session.activeScreen();
+        assertThat(screen).isNotNull();
+        assertThat(screen.hasFlow()).isTrue();
+        assertThat(optionIndexOf(screen, "previous")).isEqualTo(-1);
+        assertThat(optionIndexOf(screen, "next")).isGreaterThanOrEqualTo(0);
     }
 
     @Test
@@ -79,10 +93,6 @@ class TopMenuTest {
         TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, topMenuService, playerMenu);
 
         Session session = session("viewer-1");
-        MenuBuilder firstBuilder = builder();
-        MenuBuilder secondBuilder = builder();
-        MenuBuilder thirdBuilder = builder();
-        when(session.builder()).thenReturn(firstBuilder, secondBuilder, thirdBuilder);
         when(sessionService.get("viewer-1")).thenReturn(session);
 
         LeaderboardCursor secondPageCursor = new LeaderboardCursor(1400, 0, 10);
@@ -99,19 +109,22 @@ class TopMenuTest {
         when(topMenuService.loadCursorPage(TopCategory.MINI_PVP, null, 1, 10, session.data)).thenReturn(firstPage, firstPage);
         when(topMenuService.loadCursorPage(TopCategory.MINI_PVP, secondPageCursor, 2, 10, session.data)).thenReturn(secondPage);
 
-        AtomicReference<Runnable> firstNextAction = new AtomicReference<>();
-        AtomicReference<Runnable> secondPreviousAction = new AtomicReference<>();
-        captureIfAddLocal(firstBuilder, "next", firstNextAction, new AtomicReference<>());
-        captureIfAddLocal(secondBuilder, "next", new AtomicReference<>(), secondPreviousAction);
-
         menu.top("viewer-1", TopCategory.MINI_PVP, 1);
-        firstNextAction.get().run();
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
+
+        ActiveMenuScreen firstScreen = session.activeScreen();
+        int nextIndex = optionIndexOf(firstScreen, "next");
+        menuService.onMenuOption(session, nextIndex);
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
 
         TopMenu.TopMenuState state = session.getDraft(TopMenu.TopMenuState.class);
         assertThat(state.backStack).hasSize(1);
         assertThat(state.backStack.getLast().pid()).isEqualTo(-2);
 
-        secondPreviousAction.get().run();
+        ActiveMenuScreen secondScreen = session.activeScreen();
+        int previousIndex = optionIndexOf(secondScreen, "previous");
+        menuService.onMenuOption(session, previousIndex);
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
 
         assertThat(state.currentPage).isEqualTo(1);
         assertThat(state.currentCursor).isNull();
@@ -127,9 +140,6 @@ class TopMenuTest {
         TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, topMenuService, playerMenu);
 
         Session session = session("viewer-1");
-        MenuBuilder firstBuilder = builder();
-        MenuBuilder secondBuilder = builder();
-        when(session.builder()).thenReturn(firstBuilder, secondBuilder);
         when(sessionService.get("viewer-1")).thenReturn(session);
 
         LeaderboardCursor currentCursor = new LeaderboardCursor(1500, 0, 15);
@@ -146,11 +156,13 @@ class TopMenuTest {
         when(topMenuService.loadCursorPage(TopCategory.MINI_PVP, null, 2, 10, session.data)).thenReturn(currentPage);
         when(topMenuService.loadCursorPage(TopCategory.MINI_PVP, nextCursor, 3, 10, session.data)).thenReturn(nextPage);
 
-        AtomicReference<Runnable> nextAction = new AtomicReference<>();
-        captureIfAddLocal(firstBuilder, "next", nextAction, new AtomicReference<>());
-
         menu.top("viewer-1", TopCategory.MINI_PVP, 2);
-        nextAction.get().run();
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
+
+        ActiveMenuScreen screen = session.activeScreen();
+        int nextIndex = optionIndexOf(screen, "next");
+        menuService.onMenuOption(session, nextIndex);
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
 
         TopMenu.TopMenuState state = session.getDraft(TopMenu.TopMenuState.class);
         assertThat(state.backStack).containsExactly(currentCursor);
@@ -168,10 +180,6 @@ class TopMenuTest {
         TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, topMenuService, playerMenu);
 
         Session session = session("viewer-1");
-        MenuBuilder firstBuilder = builder();
-        MenuBuilder secondBuilder = builder();
-        MenuBuilder thirdBuilder = builder();
-        when(session.builder()).thenReturn(firstBuilder, secondBuilder, thirdBuilder);
         when(sessionService.get("viewer-1")).thenReturn(session);
 
         LeaderboardCursor currentCursor = new LeaderboardCursor(1500, 0, 15);
@@ -196,14 +204,18 @@ class TopMenuTest {
         when(topMenuService.loadCursorPage(TopCategory.MINI_PVP, nextCursor, 3, 10, session.data)).thenReturn(page3);
         when(topMenuService.loadCursorPage(TopCategory.MINI_PVP, previousCursor, 2, 10, session.data)).thenReturn(backToPage2);
 
-        AtomicReference<Runnable> firstNextAction = new AtomicReference<>();
-        AtomicReference<Runnable> secondPreviousAction = new AtomicReference<>();
-        captureIfAddLocal(firstBuilder, "next", firstNextAction, new AtomicReference<>());
-        captureIfAddLocal(secondBuilder, "next", new AtomicReference<>(), secondPreviousAction);
-
         menu.top("viewer-1", TopCategory.MINI_PVP, 2);
-        firstNextAction.get().run();
-        secondPreviousAction.get().run();
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
+
+        ActiveMenuScreen firstScreen = session.activeScreen();
+        int nextIndex = optionIndexOf(firstScreen, "next");
+        menuService.onMenuOption(session, nextIndex);
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
+
+        ActiveMenuScreen secondScreen = session.activeScreen();
+        int previousIndex = optionIndexOf(secondScreen, "previous");
+        menuService.onMenuOption(session, previousIndex);
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
 
         TopMenu.TopMenuState state = session.getDraft(TopMenu.TopMenuState.class);
         assertThat(state.currentCursor).isEqualTo(previousCursor);
@@ -228,8 +240,6 @@ class TopMenuTest {
         state.nextCursor = new LeaderboardCursor(1350, 0, 21);
         state.backStack.addLast(new LeaderboardCursor(1450, 0, 5));
 
-        MenuBuilder builder = builder();
-        when(session.builder()).thenReturn(builder);
         when(sessionService.get("viewer-1")).thenReturn(session);
 
         TopMenuService.TopCursorPage topPage = new TopMenuService.TopCursorPage(
@@ -239,6 +249,7 @@ class TopMenuTest {
         when(topMenuService.loadCursorPage(TopCategory.PLAYTIME, null, 1, 10, session.data)).thenReturn(topPage);
 
         menu.top("viewer-1", TopCategory.PLAYTIME, 1);
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
 
         assertThat(state.category).isEqualTo(TopCategory.PLAYTIME);
         assertThat(state.currentPage).isEqualTo(1);
@@ -255,12 +266,10 @@ class TopMenuTest {
         TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, topMenuService, playerMenu);
 
         Session session = session("viewer-1");
-        MenuBuilder firstBuilder = builder();
-        MenuBuilder secondBuilder = builder();
-        when(session.builder()).thenReturn(firstBuilder, secondBuilder);
+        PlayerData target = player("target-1", 14);
+        when(session.playerDataRepository.findByUuid("target-1")).thenReturn(target);
         when(sessionService.get("viewer-1")).thenReturn(session);
 
-        PlayerData target = player("target-1", 14);
         LeaderboardCursor currentCursor = new LeaderboardCursor(1500, 0, 14);
         TopMenuService.TopCursorPage topPage = new TopMenuService.TopCursorPage(
                 TopCategory.MINI_PVP, 2, 5, 10, 50, 4,
@@ -269,20 +278,22 @@ class TopMenuTest {
         when(topMenuService.loadCursorPage(TopCategory.MINI_PVP, null, 2, 10, session.data)).thenReturn(topPage);
         when(topMenuService.loadCursorPage(TopCategory.MINI_PVP, currentCursor, 2, 10, session.data)).thenReturn(topPage);
 
-        AtomicReference<Runnable> rowAction = new AtomicReference<>();
-        doAnswer(invocation -> {
-            rowAction.set(invocation.getArgument(1));
-            return firstBuilder;
-        }).when(firstBuilder).addRow(anyString(), any(Runnable.class));
-
         menu.top("viewer-1", TopCategory.MINI_PVP, 2);
-        rowAction.get().run();
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
 
-        ArgumentCaptor<Runnable> historyCaptor = ArgumentCaptor.forClass(Runnable.class);
-        verify(session).pushHistory(historyCaptor.capture());
-        verify(playerMenu).player("viewer-1", target);
+        ActiveMenuScreen screen = session.activeScreen();
+        int profileIndex = optionIndexOf(screen, "profile:target-1");
+        menuService.onMenuOption(session, profileIndex);
 
-        historyCaptor.getValue().run();
+        assertThat(session.hasHistory()).isTrue();
+        Runnable historyCallback = session.popHistory();
+
+        InOrder inOrder = inOrder(gateway, playerMenu);
+        inOrder.verify(gateway).hideFollowUpMenu(eq(session.player), eq(menuService.getMenuId()));
+        inOrder.verify(playerMenu).player("viewer-1", target);
+
+        historyCallback.run();
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
         verify(topMenuService, times(1)).loadCursorPage(TopCategory.MINI_PVP, currentCursor, 2, 10, session.data);
     }
 
@@ -295,10 +306,6 @@ class TopMenuTest {
         TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, topMenuService, playerMenu);
 
         Session session = session("viewer-1");
-        MenuBuilder firstBuilder = builder();
-        MenuBuilder secondBuilder = builder();
-        MenuBuilder thirdBuilder = builder();
-        when(session.builder()).thenReturn(firstBuilder, secondBuilder, thirdBuilder);
         when(sessionService.get("viewer-1")).thenReturn(session);
 
         LeaderboardCursor miniCursor = new LeaderboardCursor(1500, 0, 15);
@@ -316,67 +323,129 @@ class TopMenuTest {
         when(topMenuService.loadCursorPage(TopCategory.PLAYTIME, null, 1, 10, session.data)).thenReturn(playtimePage);
         when(topMenuService.loadCursorPage(TopCategory.MINI_PVP, miniCursor, 2, 10, session.data)).thenReturn(miniPage);
 
-        AtomicReference<Runnable> categoryAction = new AtomicReference<>();
-        doAnswer(invocation -> {
-            String label = invocation.getArgument(0);
-            Runnable action = invocation.getArgument(1);
-            if ("top-menu-category-button".equals(label)) {
-                categoryAction.set(action);
-            }
-            return firstBuilder;
-        }).when(firstBuilder).add(anyString(), any(Runnable.class));
-
         menu.top("viewer-1", TopCategory.MINI_PVP, 2);
-        categoryAction.get().run();
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
 
-        ArgumentCaptor<Runnable> historyCaptor = ArgumentCaptor.forClass(Runnable.class);
-        verify(session).pushHistory(historyCaptor.capture());
+        ActiveMenuScreen screen = session.activeScreen();
+        int categoryIndex = optionIndexOf(screen, "category");
+        menuService.onMenuOption(session, categoryIndex);
+
+        InOrder inOrder = inOrder(gateway);
+        inOrder.verify(gateway).hideFollowUpMenu(eq(session.player), eq(menuService.getMenuId()));
+        inOrder.verify(gateway).menu(eq(session.player), eq(menuService.getMenuId()), any(), any(), any());
+
+        assertThat(session.hasHistory()).isTrue();
+        Runnable historyCallback = session.popHistory();
 
         menu.top("viewer-1", TopCategory.PLAYTIME, 1);
-        historyCaptor.getValue().run();
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
+
+        historyCallback.run();
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
 
         verify(topMenuService, times(1)).loadCursorPage(TopCategory.MINI_PVP, miniCursor, 2, 10, session.data);
         verify(topMenuService, times(1)).loadCursorPage(TopCategory.PLAYTIME, null, 1, 10, session.data);
     }
 
-    private static void captureIfAddLocal(MenuBuilder builder,
-                                          String labelToCaptureAsNext,
-                                          AtomicReference<Runnable> nextAction,
-                                          AtomicReference<Runnable> previousAction) {
-        doAnswer(invocation -> {
-            boolean visible = invocation.getArgument(0);
-            String label = invocation.getArgument(1);
-            Runnable action = invocation.getArgument(2);
-            if (visible && label.equals(labelToCaptureAsNext)) {
-                nextAction.set(action);
-            }
-            if (visible && label.equals("previous")) {
-                previousAction.set(action);
-            }
-            return builder;
-        }).when(builder).ifAddLocal(anyBoolean(), anyString(), any(Runnable.class));
+    @Test
+    @DisplayName("close action clears active screen")
+    void closeAction_clearsActiveScreen() {
+        SessionService sessionService = mock(SessionService.class);
+        TopMenuService topMenuService = mock(TopMenuService.class);
+        PlayerMenu playerMenu = mock(PlayerMenu.class);
+        TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, topMenuService, playerMenu);
+
+        Session session = session("viewer-1");
+        when(sessionService.get("viewer-1")).thenReturn(session);
+
+        TopMenuService.TopCursorPage topPage = new TopMenuService.TopCursorPage(
+                TopCategory.MINI_PVP, 1, 1, 10, 0, null,
+                List.of(), null, null, false
+        );
+        when(topMenuService.loadCursorPage(TopCategory.MINI_PVP, null, 1, 10, session.data)).thenReturn(topPage);
+
+        menu.top("viewer-1", TopCategory.MINI_PVP, 1);
+
+        ActiveMenuScreen screen = session.activeScreen();
+        assertThat(screen).isNotNull();
+
+        int closeIndex = optionIndexOf(screen, "close");
+        menuService.onMenuOption(session, closeIndex);
+
+        verify(gateway).hideFollowUpMenu(eq(session.player), eq(menuService.getMenuId()));
+        assertThat(session.activeScreen()).isNull();
     }
 
-    private static Session session(String uuid) {
-        Session session = mock(Session.class);
-        session.data = player(uuid, 1);
-        session.data.uuid = uuid;
+    @Test
+    @DisplayName("back action hides follow-up before restoring previous normal menu")
+    void backAction_hidesFollowUpBeforeRestoringPreviousMenu() {
+        SessionService sessionService = mock(SessionService.class);
+        TopMenuService topMenuService = mock(TopMenuService.class);
+        PlayerMenu playerMenu = mock(PlayerMenu.class);
+        TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, topMenuService, playerMenu);
+
+        Session session = session("viewer-1");
+        when(sessionService.get("viewer-1")).thenReturn(session);
+
+        Runnable previousMenu = mock(Runnable.class);
+        session.pushHistory(previousMenu);
+
+        TopMenuService.TopCursorPage topPage = new TopMenuService.TopCursorPage(
+                TopCategory.MINI_PVP, 1, 1, 10, 0, null,
+                List.of(), null, null, false
+        );
+        when(topMenuService.loadCursorPage(TopCategory.MINI_PVP, null, 1, 10, session.data)).thenReturn(topPage);
+
+        menu.top("viewer-1", TopCategory.MINI_PVP, 1);
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
+
+        ActiveMenuScreen screen = session.activeScreen();
+        int backIndex = optionIndexOf(screen, "back");
+        menuService.onMenuOption(session, backIndex);
+
+        InOrder inOrder = inOrder(gateway, previousMenu);
+        inOrder.verify(gateway).hideFollowUpMenu(eq(session.player), eq(menuService.getMenuId()));
+        inOrder.verify(previousMenu).run();
+    }
+
+    private static int optionIndexOf(ActiveMenuScreen screen, String actionId) {
+        if (screen == null) return -1;
+        for (int i = 0; i < screen.actionCount(); i++) {
+            if (actionId.equals(screen.actionIdAt(i))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private Session session(String uuid) {
+        return session(uuid, menuService);
+    }
+
+    private static Session session(String uuid, MenuService menuService) {
+        Player player = Player.create();
+        player.con = mock(NetConnection.class);
+        PlayerData data = player(uuid, 1);
+        data.uuid = uuid;
+
+        PlayerDataRepository repository = mock(PlayerDataRepository.class);
+
+        Session session = new Session(
+                new GlobalConfig(),
+                mock(Bundle.class),
+                menuService,
+                repository,
+                player,
+                data
+        );
 
         Localization localization = mock(Localization.class);
         when(localization.t(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
         when(localization.t(anyString(), anyMap())).thenAnswer(invocation -> invocation.getArgument(0));
         when(localization.getLocale()).thenReturn(Locale.US);
-        when(session.locale()).thenReturn(localization);
+        session.localization = localization;
 
-        TopMenu.TopMenuState state = new TopMenu.TopMenuState();
-        when(session.getDraft(TopMenu.TopMenuState.class)).thenReturn(state);
         return session;
-    }
-
-    private static MenuBuilder builder() {
-        MenuBuilder builder = mock(MenuBuilder.class, org.mockito.Mockito.RETURNS_SELF);
-        when(builder.show()).thenReturn(true);
-        return builder;
     }
 
     private static PlayerData player(String uuid, int pid) {


### PR DESCRIPTION
## Summary
- Introduce explicit menu runtime primitives for screens, prompts, active UI state, flow dispatch, follow-up lifecycle, and the Mindustry UI gateway boundary.
- Move menu text input flows from raw `session.textHandler` / direct `Call.textInput` to `MenuPrompt` lifecycle and centralize direct UI `Call.*` usage in `DefaultMindustryMenuGateway`.
- Extract player profile settings mutations and event editor/view responsibilities into focused services with dedicated tests.
- Adopt `followUpMenu` for overlay-style screens: Top leaderboard pages, audit details, information links, Discord link code, and ban confirmation.

## Validation
- `./gradlew test shadowJar`
- `git diff --check`

## Boundary Checks
- Direct UI `Call.*` usage is centralized in `DefaultMindustryMenuGateway`.
- Menu classes no longer use raw `setTextHandler` or direct `Call.textInput`.
- `EventMenu` no longer depends directly on event/map/player repositories.