### PR TITLE
refactor(ui): split routed menu flows into focused helpers

### DIFF
--- a/src/main/java/org/xcore/plugin/service/EventViewService.java
+++ b/src/main/java/org/xcore/plugin/service/EventViewService.java
@@ -42,6 +42,10 @@ public class EventViewService {
         return new EventDetails(event, findMap(event.map), findAuthor(event.author));
     }
 
+    public EventData findById(ObjectId id) {
+        return eventDataRepository.findById(id);
+    }
+
     public EventPage page(int requestedPage, int perPage, Map<String, StatusEnum> filters) {
         int total = (int) eventDataRepository.count(filters);
         var pagination = CustomGatherers.calculatePagination(total, perPage);

--- a/src/main/java/org/xcore/plugin/session/Session.java
+++ b/src/main/java/org/xcore/plugin/session/Session.java
@@ -15,6 +15,7 @@ import org.xcore.plugin.ui.MenuBuilder;
 import org.xcore.plugin.ui.MenuService;
 import org.xcore.plugin.ui.flow.ActiveMenuPrompt;
 import org.xcore.plugin.ui.flow.ActiveMenuScreen;
+import org.xcore.plugin.ui.route.MenuRoute;
 
 import java.util.ArrayList;
 import java.util.*;
@@ -36,6 +37,7 @@ public class Session {
     public final List<Runnable> actions = new ArrayList<>();
     public final Map<String, StatusEnum> sortStatus = new HashMap<>();
     public final Deque<Runnable> history = new ArrayDeque<>();
+    public final Deque<MenuRoute> routeHistory = new ArrayDeque<>();
     public final Map<Class<?>, Object> drafts = new HashMap<>();
     public Consumer<String> textHandler;
     public Integer lastPrivateTargetPid;
@@ -154,6 +156,12 @@ public class Session {
         }
     }
 
+    public <T> void setDraft(Class<T> clazz, T draft) {
+        if (clazz != null && draft != null) {
+            drafts.put(clazz, draft);
+        }
+    }
+
     public void clearDraft(Class<?> clazz) {
         drafts.remove(clazz);
     }
@@ -177,12 +185,34 @@ public class Session {
         return !history.isEmpty();
     }
 
+    public void pushRouteHistory(MenuRoute route) {
+        if (route == null) {
+            return;
+        }
+        if (routeHistory.size() >= globalConfig.maxHistory) {
+            routeHistory.removeFirst();
+        }
+        routeHistory.addLast(route);
+    }
+
+    public MenuRoute popRouteHistory() {
+        return routeHistory.pollLast();
+    }
+
+    public boolean hasRouteHistory() {
+        return !routeHistory.isEmpty();
+    }
+
     public void resetSender() {
         sender = null;
     }
 
     public void clearHistory() {
         history.clear();
+    }
+
+    public void clearRouteHistory() {
+        routeHistory.clear();
     }
 
     public void clearSortStatus() {

--- a/src/main/java/org/xcore/plugin/session/Session.java
+++ b/src/main/java/org/xcore/plugin/session/Session.java
@@ -203,6 +203,10 @@ public class Session {
         return !routeHistory.isEmpty();
     }
 
+    public boolean canGoBack(boolean routeAwareScreen) {
+        return hasHistory() || routeAwareScreen && hasRouteHistory();
+    }
+
     public void resetSender() {
         sender = null;
     }

--- a/src/main/java/org/xcore/plugin/session/Session.java
+++ b/src/main/java/org/xcore/plugin/session/Session.java
@@ -150,6 +150,7 @@ public class Session {
         });
     }
 
+    @Deprecated
     public void setDraft(Object draft) {
         if (draft != null) {
             drafts.put(draft.getClass(), draft);
@@ -203,8 +204,8 @@ public class Session {
         return !routeHistory.isEmpty();
     }
 
-    public boolean canGoBack(boolean routeAwareScreen) {
-        return hasHistory() || routeAwareScreen && hasRouteHistory();
+    public boolean canGoBack() {
+        return hasHistory() || hasRouteHistory();
     }
 
     public void resetSender() {

--- a/src/main/java/org/xcore/plugin/ui/MenuBuilder.java
+++ b/src/main/java/org/xcore/plugin/ui/MenuBuilder.java
@@ -165,7 +165,7 @@ public class MenuBuilder {
     public MenuBuilder addNavigationRow() {
         start();
 
-        if (session.hasHistory() || session.hasRouteHistory()) {
+        if (session.canGoBack(false)) {
             row.add(session.add(localization.format("back", args()), () -> {
                 service.goBack(session);
             }));

--- a/src/main/java/org/xcore/plugin/ui/MenuBuilder.java
+++ b/src/main/java/org/xcore/plugin/ui/MenuBuilder.java
@@ -79,18 +79,6 @@ public class MenuBuilder {
         return this;
     }
 
-    public MenuBuilder addRow(String buttonText, Runnable action) {
-        return addRowText(buttonText, action);
-    }
-
-    public MenuBuilder addRow(String btn1, Runnable action1, String btn2, Runnable action2) {
-        return addRowText(btn1, action1, btn2, action2);
-    }
-
-    public MenuBuilder addRow(List<MenuBuilder.ButtonDef> buttons) {
-        return addRowText(buttons);
-    }
-
     public MenuBuilder addRowKey(String buttonKey, Runnable action) {
         rows.add(List.of(session.add(localization.t(buttonKey), action)));
         return this;
@@ -109,18 +97,6 @@ public class MenuBuilder {
         return this;
     }
 
-    public MenuBuilder addLocalRow(String buttonText, Runnable action) {
-        return addRowKey(buttonText, action);
-    }
-
-    public MenuBuilder addLocalRow(String btn1, Runnable action1, String btn2, Runnable action2) {
-        return addRowKey(btn1, action1, btn2, action2);
-    }
-
-    public MenuBuilder addLocalRow(List<MenuBuilder.ButtonDef> buttons) {
-        return addRowKey(buttons);
-    }
-
     public MenuBuilder addButtonText(String buttonText, Runnable action) {
         row.add(session.add(buttonText, action));
         return this;
@@ -134,19 +110,6 @@ public class MenuBuilder {
     public MenuBuilder addButtonKey(String buttonKey, Runnable action, Map<String, Object> args) {
         row.add(session.add(localization.t(buttonKey, args), action));
         return this;
-    }
-
-    public MenuBuilder add(String buttonText, Runnable action) {
-        return addButtonText(buttonText, action);
-    }
-
-
-    public MenuBuilder addLocal(String buttonText, Runnable action) {
-        return addButtonKey(buttonText, action);
-    }
-
-    public MenuBuilder addLocal(String buttonText, Runnable action, Map<String, Object> args) {
-        return addButtonKey(buttonText, action, args);
     }
 
     public MenuBuilder start() {
@@ -165,7 +128,7 @@ public class MenuBuilder {
     public MenuBuilder addNavigationRow() {
         start();
 
-        if (session.canGoBack(false)) {
+        if (session.canGoBack()) {
             row.add(session.add(localization.format("back", args()), () -> {
                 service.goBack(session);
             }));
@@ -261,18 +224,6 @@ public class MenuBuilder {
             row.add(session.add(localization.t(buttonKey, args), action));
         }
         return this;
-    }
-
-    public MenuBuilder ifAdd(boolean bool, String buttonText, Runnable action) {
-        return ifAddButtonText(bool, buttonText, action);
-    }
-
-    public MenuBuilder ifAddLocal(boolean bool, String buttonText, Runnable action) {
-        return ifAddButtonKey(bool, buttonText, action);
-    }
-
-    public MenuBuilder ifAddLocal(boolean bool, String buttonText, Runnable action, Map<String, Object> args) {
-        return ifAddButtonKey(bool, buttonText, action, args);
     }
 
     public MenuBuilder ifElseAdd(boolean bool, String buttonText1, Runnable action1, String buttonText2, Runnable action2) {

--- a/src/main/java/org/xcore/plugin/ui/MenuBuilder.java
+++ b/src/main/java/org/xcore/plugin/ui/MenuBuilder.java
@@ -61,17 +61,17 @@ public class MenuBuilder {
         return this;
     }
 
-    public MenuBuilder addRow(String buttonText, Runnable action) {
+    public MenuBuilder addRowText(String buttonText, Runnable action) {
         rows.add(List.of(session.add(buttonText, action)));
         return this;
     }
 
-    public MenuBuilder addRow(String btn1, Runnable action1, String btn2, Runnable action2) {
+    public MenuBuilder addRowText(String btn1, Runnable action1, String btn2, Runnable action2) {
         rows.add(List.of(session.add(btn1, action1), session.add(btn2, action2)));
         return this;
     }
 
-    public MenuBuilder addRow(List<MenuBuilder.ButtonDef> buttons) {
+    public MenuBuilder addRowText(List<MenuBuilder.ButtonDef> buttons) {
         String[] row = buttons.stream()
                 .map(b -> session.add(b.text, b.action))
                 .toArray(String[]::new);
@@ -79,17 +79,29 @@ public class MenuBuilder {
         return this;
     }
 
-    public MenuBuilder addLocalRow(String buttonText, Runnable action) {
-        rows.add(List.of(session.add(localization.t(buttonText), action)));
+    public MenuBuilder addRow(String buttonText, Runnable action) {
+        return addRowText(buttonText, action);
+    }
+
+    public MenuBuilder addRow(String btn1, Runnable action1, String btn2, Runnable action2) {
+        return addRowText(btn1, action1, btn2, action2);
+    }
+
+    public MenuBuilder addRow(List<MenuBuilder.ButtonDef> buttons) {
+        return addRowText(buttons);
+    }
+
+    public MenuBuilder addRowKey(String buttonKey, Runnable action) {
+        rows.add(List.of(session.add(localization.t(buttonKey), action)));
         return this;
     }
 
-    public MenuBuilder addLocalRow(String btn1, Runnable action1, String btn2, Runnable action2) {
-        rows.add(List.of(session.add(localization.t(btn1), action1), session.add(localization.t(btn2), action2)));
+    public MenuBuilder addRowKey(String btn1Key, Runnable action1, String btn2Key, Runnable action2) {
+        rows.add(List.of(session.add(localization.t(btn1Key), action1), session.add(localization.t(btn2Key), action2)));
         return this;
     }
 
-    public MenuBuilder addLocalRow(List<MenuBuilder.ButtonDef> buttons) {
+    public MenuBuilder addRowKey(List<MenuBuilder.ButtonDef> buttons) {
         String[] row = buttons.stream()
                 .map(b -> session.add(localization.t(b.text), b.action))
                 .toArray(String[]::new);
@@ -97,20 +109,44 @@ public class MenuBuilder {
         return this;
     }
 
-    public MenuBuilder add(String buttonText, Runnable action) {
+    public MenuBuilder addLocalRow(String buttonText, Runnable action) {
+        return addRowKey(buttonText, action);
+    }
+
+    public MenuBuilder addLocalRow(String btn1, Runnable action1, String btn2, Runnable action2) {
+        return addRowKey(btn1, action1, btn2, action2);
+    }
+
+    public MenuBuilder addLocalRow(List<MenuBuilder.ButtonDef> buttons) {
+        return addRowKey(buttons);
+    }
+
+    public MenuBuilder addButtonText(String buttonText, Runnable action) {
         row.add(session.add(buttonText, action));
         return this;
     }
 
-
-    public MenuBuilder addLocal(String buttonText, Runnable action) {
-        row.add(session.add(localization.t(buttonText), action));
+    public MenuBuilder addButtonKey(String buttonKey, Runnable action) {
+        row.add(session.add(localization.t(buttonKey), action));
         return this;
     }
 
-    public MenuBuilder addLocal(String buttonText, Runnable action, Map<String, Object> args) {
-        row.add(session.add(localization.t(buttonText, args), action));
+    public MenuBuilder addButtonKey(String buttonKey, Runnable action, Map<String, Object> args) {
+        row.add(session.add(localization.t(buttonKey, args), action));
         return this;
+    }
+
+    public MenuBuilder add(String buttonText, Runnable action) {
+        return addButtonText(buttonText, action);
+    }
+
+
+    public MenuBuilder addLocal(String buttonText, Runnable action) {
+        return addButtonKey(buttonText, action);
+    }
+
+    public MenuBuilder addLocal(String buttonText, Runnable action, Map<String, Object> args) {
+        return addButtonKey(buttonText, action, args);
     }
 
     public MenuBuilder start() {
@@ -129,10 +165,9 @@ public class MenuBuilder {
     public MenuBuilder addNavigationRow() {
         start();
 
-        if (session.hasHistory()) {
+        if (session.hasHistory() || session.hasRouteHistory()) {
             row.add(session.add(localization.format("back", args()), () -> {
-                Runnable previousMenu = session.popHistory();
-                if (previousMenu != null) previousMenu.run();
+                service.goBack(session);
             }));
         }
 
@@ -207,25 +242,37 @@ public class MenuBuilder {
         row.clear();
     }
 
-    public MenuBuilder ifAdd(boolean bool, String buttonText, Runnable action) {
+    public MenuBuilder ifAddButtonText(boolean bool, String buttonText, Runnable action) {
         if (bool) {
             row.add(session.add(buttonText, action));
         }
         return this;
     }
 
-    public MenuBuilder ifAddLocal(boolean bool, String buttonText, Runnable action) {
+    public MenuBuilder ifAddButtonKey(boolean bool, String buttonKey, Runnable action) {
         if (bool) {
-            row.add(session.add(localization.t(buttonText), action));
+            row.add(session.add(localization.t(buttonKey), action));
         }
         return this;
     }
 
-    public MenuBuilder ifAddLocal(boolean bool, String buttonText, Runnable action, Map<String, Object> args) {
+    public MenuBuilder ifAddButtonKey(boolean bool, String buttonKey, Runnable action, Map<String, Object> args) {
         if (bool) {
-            row.add(session.add(localization.t(buttonText, args), action));
+            row.add(session.add(localization.t(buttonKey, args), action));
         }
         return this;
+    }
+
+    public MenuBuilder ifAdd(boolean bool, String buttonText, Runnable action) {
+        return ifAddButtonText(bool, buttonText, action);
+    }
+
+    public MenuBuilder ifAddLocal(boolean bool, String buttonText, Runnable action) {
+        return ifAddButtonKey(bool, buttonText, action);
+    }
+
+    public MenuBuilder ifAddLocal(boolean bool, String buttonText, Runnable action, Map<String, Object> args) {
+        return ifAddButtonKey(bool, buttonText, action, args);
     }
 
     public MenuBuilder ifElseAdd(boolean bool, String buttonText1, Runnable action1, String buttonText2, Runnable action2) {

--- a/src/main/java/org/xcore/plugin/ui/MenuService.java
+++ b/src/main/java/org/xcore/plugin/ui/MenuService.java
@@ -15,8 +15,12 @@ import org.xcore.plugin.ui.flow.MenuMode;
 import org.xcore.plugin.ui.flow.MenuPrompt;
 import org.xcore.plugin.ui.flow.MenuRenderContext;
 import org.xcore.plugin.ui.flow.MenuScreen;
+import org.xcore.plugin.ui.route.MenuRoute;
+import org.xcore.plugin.ui.route.RoutedMenuFlow;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 @Singleton
@@ -24,6 +28,7 @@ public class MenuService {
 
     private final Provider<SessionService> sessionService;
     private final MindustryMenuGateway gateway;
+    private final Map<String, RoutedMenuFlow<?>> routedFlows = new HashMap<>();
 
     private int globalMenuId;
     private int globalTextId;
@@ -84,6 +89,10 @@ public class MenuService {
     }
 
     public <TState> void show(Session session, MenuScreen screen, MenuFlow<TState> flow, TState state) {
+        show(session, screen, flow, state, null);
+    }
+
+    public <TState> void show(Session session, MenuScreen screen, MenuFlow<TState> flow, TState state, MenuRoute route) {
         if (session == null || session.player == null || session.player.con == null) return;
 
         long version = session.nextUiVersion();
@@ -91,7 +100,7 @@ public class MenuService {
         List<String> actionIds = screen.rows().stream()
                 .flatMap(row -> row.stream().map(MenuButton::actionId))
                 .toList();
-        var active = ActiveMenuScreen.create(version, screen.mode(), actions, flow, state, actionIds);
+        var active = ActiveMenuScreen.create(version, screen.mode(), actions, flow, state, actionIds, route);
         session.setActiveScreen(active);
 
         String[][] buttons = convertListToArray(screen.toTextRows());
@@ -104,9 +113,74 @@ public class MenuService {
 
     public <TState> void renderFlow(Session session, MenuFlow<TState> flow) {
         TState state = session.getDraft(flow.stateType());
-        var context = new MenuRenderContext<>(this, session, flow, state);
+        renderFlow(session, flow, state, null);
+    }
+
+    public <TState> void renderFlow(Session session, MenuFlow<TState> flow, TState state, MenuRoute route) {
+        var context = new MenuRenderContext<>(this, session, flow, state, route);
         MenuScreen screen = flow.render(context);
-        show(session, screen, flow, state);
+        show(session, screen, flow, state, route);
+    }
+
+    public void registerRoute(RoutedMenuFlow<?> flow) {
+        RoutedMenuFlow<?> previous = routedFlows.putIfAbsent(flow.routeId(), flow);
+        if (previous != null) {
+            throw new IllegalStateException("Duplicate menu route id: " + flow.routeId());
+        }
+    }
+
+    public void renderRoute(Session session, MenuRoute route) {
+        if (session == null || route == null) return;
+
+        RoutedMenuFlow<?> flow = routedFlows.get(route.id());
+        if (flow == null) {
+            throw new IllegalArgumentException("Unknown menu route: " + route.id());
+        }
+
+        renderResolvedRoute(session, route, flow);
+    }
+
+    public void openRoute(Session session, MenuRoute route) {
+        if (session == null || route == null) return;
+
+        var activeScreen = session.activeScreen();
+        if (activeScreen != null && activeScreen.hasRoute()) {
+            session.pushRouteHistory(activeScreen.route());
+        }
+
+        renderRoute(session, route);
+    }
+
+    public boolean goBack(Session session) {
+        if (session == null) {
+            return false;
+        }
+
+        var activeScreen = session.activeScreen();
+        if (session.hasRouteHistory() && (activeScreen == null || activeScreen.hasRoute())) {
+            if (activeScreen != null && activeScreen.mode() == MenuMode.FOLLOW_UP && session.player != null) {
+                gateway.hideFollowUpMenu(session.player, globalMenuId);
+            }
+            renderRoute(session, session.popRouteHistory());
+            return true;
+        }
+
+        Runnable previousMenu = session.popHistory();
+        if (previousMenu != null) {
+            if (activeScreen != null && activeScreen.mode() == MenuMode.FOLLOW_UP && session.player != null) {
+                gateway.hideFollowUpMenu(session.player, globalMenuId);
+            }
+            session.clearActivePrompt();
+            session.textHandler = null;
+            session.actions.clear();
+            if (session.activeScreen() == activeScreen) {
+                session.clearActiveScreen();
+            }
+            previousMenu.run();
+            return true;
+        }
+
+        return false;
     }
 
     public void hideFollowUp(Session session) {
@@ -174,7 +248,8 @@ public class MenuService {
         if (session == null || session.player == null || session.player.con == null) return;
 
         long version = session.nextUiVersion();
-        var active = ActiveMenuPrompt.create(version, globalTextId, null, null, flow, state, prompt.promptId());
+        MenuRoute route = session.activeScreen() != null ? session.activeScreen().route() : null;
+        var active = ActiveMenuPrompt.create(version, globalTextId, null, null, flow, state, prompt.promptId(), route);
         session.setActivePrompt(active);
 
         gateway.textInput(session.player, globalTextId, prompt.title(), prompt.content(), prompt.length(), prompt.defaultValue(), prompt.numeric());
@@ -249,7 +324,7 @@ public class MenuService {
     private void dispatchFlowClose(ActiveMenuScreen screen, Session session) {
         var flow = (MenuFlow<Object>) screen.flow();
         var state = screen.state();
-        var context = new MenuRenderContext<>(this, session, flow, state);
+        var context = new MenuRenderContext<>(this, session, flow, state, screen.route());
         flow.onClose(context);
     }
 
@@ -257,7 +332,7 @@ public class MenuService {
     private void dispatchFlowAction(ActiveMenuScreen screen, Session session, int option) {
         var flow = (MenuFlow<Object>) screen.flow();
         var state = screen.state();
-        var context = new MenuRenderContext<>(this, session, flow, state);
+        var context = new MenuRenderContext<>(this, session, flow, state, screen.route());
         String actionId = screen.actionIdAt(option);
         if (actionId != null) {
             flow.onAction(context, actionId);
@@ -268,11 +343,25 @@ public class MenuService {
     private void dispatchFlowPrompt(ActiveMenuPrompt prompt, Session session, String text) {
         var flow = (MenuFlow<Object>) prompt.flow();
         var state = prompt.state();
-        var context = new MenuRenderContext<>(this, session, flow, state);
+        var context = new MenuRenderContext<>(this, session, flow, state, prompt.route());
         if (text == null) {
             flow.onPromptCancel(context, prompt.promptIdString());
         } else {
             flow.onPromptSubmit(context, prompt.promptIdString(), text);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <TState> void renderResolvedRoute(Session session, MenuRoute route, RoutedMenuFlow<?> routedFlow) {
+        RoutedMenuFlow<TState> flow = (RoutedMenuFlow<TState>) routedFlow;
+        TState currentState = session.getDraft(flow.stateType());
+        TState state = flow.createState(session, route, currentState);
+        if (state != null) {
+            session.setDraft(flow.stateType(), state);
+        }
+
+        var context = new MenuRenderContext<>(this, session, flow, state, route);
+        MenuScreen screen = flow.render(context);
+        show(session, screen, flow, state, route);
     }
 }

--- a/src/main/java/org/xcore/plugin/ui/flow/ActiveMenuPrompt.java
+++ b/src/main/java/org/xcore/plugin/ui/flow/ActiveMenuPrompt.java
@@ -1,5 +1,7 @@
 package org.xcore.plugin.ui.flow;
 
+import org.xcore.plugin.ui.route.MenuRoute;
+
 import java.util.function.Consumer;
 
 public class ActiveMenuPrompt {
@@ -10,8 +12,9 @@ public class ActiveMenuPrompt {
     private final MenuFlow<?> flow;
     private final Object state;
     private final String promptIdString;
+    private final MenuRoute route;
 
-    private ActiveMenuPrompt(long version, int promptId, Consumer<String> onSubmit, Runnable onCancel, MenuFlow<?> flow, Object state, String promptIdString) {
+    private ActiveMenuPrompt(long version, int promptId, Consumer<String> onSubmit, Runnable onCancel, MenuFlow<?> flow, Object state, String promptIdString, MenuRoute route) {
         this.version = version;
         this.promptId = promptId;
         this.onSubmit = onSubmit;
@@ -19,14 +22,19 @@ public class ActiveMenuPrompt {
         this.flow = flow;
         this.state = state;
         this.promptIdString = promptIdString;
+        this.route = route;
     }
 
     public static ActiveMenuPrompt create(long version, int promptId, Consumer<String> onSubmit, Runnable onCancel) {
-        return new ActiveMenuPrompt(version, promptId, onSubmit, onCancel, null, null, null);
+        return new ActiveMenuPrompt(version, promptId, onSubmit, onCancel, null, null, null, null);
     }
 
     public static ActiveMenuPrompt create(long version, int promptId, Consumer<String> onSubmit, Runnable onCancel, MenuFlow<?> flow, Object state, String promptIdString) {
-        return new ActiveMenuPrompt(version, promptId, onSubmit, onCancel, flow, state, promptIdString);
+        return new ActiveMenuPrompt(version, promptId, onSubmit, onCancel, flow, state, promptIdString, null);
+    }
+
+    public static ActiveMenuPrompt create(long version, int promptId, Consumer<String> onSubmit, Runnable onCancel, MenuFlow<?> flow, Object state, String promptIdString, MenuRoute route) {
+        return new ActiveMenuPrompt(version, promptId, onSubmit, onCancel, flow, state, promptIdString, route);
     }
 
     public long version() {
@@ -59,6 +67,14 @@ public class ActiveMenuPrompt {
 
     public Object state() {
         return state;
+    }
+
+    public boolean hasRoute() {
+        return route != null;
+    }
+
+    public MenuRoute route() {
+        return route;
     }
 
     public String promptIdString() {

--- a/src/main/java/org/xcore/plugin/ui/flow/ActiveMenuScreen.java
+++ b/src/main/java/org/xcore/plugin/ui/flow/ActiveMenuScreen.java
@@ -1,5 +1,7 @@
 package org.xcore.plugin.ui.flow;
 
+import org.xcore.plugin.ui.route.MenuRoute;
+
 import java.util.List;
 
 public class ActiveMenuScreen {
@@ -9,22 +11,28 @@ public class ActiveMenuScreen {
     private final MenuFlow<?> flow;
     private final Object state;
     private final List<String> actionIds;
+    private final MenuRoute route;
 
-    private ActiveMenuScreen(long version, MenuMode mode, List<MenuAction> actions, MenuFlow<?> flow, Object state, List<String> actionIds) {
+    private ActiveMenuScreen(long version, MenuMode mode, List<MenuAction> actions, MenuFlow<?> flow, Object state, List<String> actionIds, MenuRoute route) {
         this.version = version;
         this.mode = mode;
         this.actions = List.copyOf(actions);
         this.flow = flow;
         this.state = state;
         this.actionIds = actionIds == null ? List.of() : List.copyOf(actionIds);
+        this.route = route;
     }
 
     public static ActiveMenuScreen create(long version, MenuMode mode, List<MenuAction> actions) {
-        return new ActiveMenuScreen(version, mode, actions, null, null, null);
+        return new ActiveMenuScreen(version, mode, actions, null, null, null, null);
     }
 
     public static ActiveMenuScreen create(long version, MenuMode mode, List<MenuAction> actions, MenuFlow<?> flow, Object state, List<String> actionIds) {
-        return new ActiveMenuScreen(version, mode, actions, flow, state, actionIds);
+        return new ActiveMenuScreen(version, mode, actions, flow, state, actionIds, null);
+    }
+
+    public static ActiveMenuScreen create(long version, MenuMode mode, List<MenuAction> actions, MenuFlow<?> flow, Object state, List<String> actionIds, MenuRoute route) {
+        return new ActiveMenuScreen(version, mode, actions, flow, state, actionIds, route);
     }
 
     public long version() {
@@ -63,6 +71,14 @@ public class ActiveMenuScreen {
 
     public Object state() {
         return state;
+    }
+
+    public boolean hasRoute() {
+        return route != null;
+    }
+
+    public MenuRoute route() {
+        return route;
     }
 
     public String actionIdAt(int index) {

--- a/src/main/java/org/xcore/plugin/ui/flow/MenuRenderContext.java
+++ b/src/main/java/org/xcore/plugin/ui/flow/MenuRenderContext.java
@@ -3,18 +3,25 @@ package org.xcore.plugin.ui.flow;
 import org.xcore.plugin.localization.Localization;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.ui.MenuService;
+import org.xcore.plugin.ui.route.MenuRoute;
 
 public class MenuRenderContext<TState> {
     private final MenuService menuService;
     private final Session session;
     private final MenuFlow<TState> flow;
     private final TState state;
+    private final MenuRoute route;
 
     public MenuRenderContext(MenuService menuService, Session session, MenuFlow<TState> flow, TState state) {
+        this(menuService, session, flow, state, null);
+    }
+
+    public MenuRenderContext(MenuService menuService, Session session, MenuFlow<TState> flow, TState state, MenuRoute route) {
         this.menuService = menuService;
         this.session = session;
         this.flow = flow;
         this.state = state;
+        this.route = route;
     }
 
     public Session session() {
@@ -29,8 +36,24 @@ public class MenuRenderContext<TState> {
         return session.locale();
     }
 
+    public boolean hasRoute() {
+        return route != null;
+    }
+
+    public MenuRoute route() {
+        return route;
+    }
+
     public void render() {
-        menuService.renderFlow(session, flow);
+        menuService.renderFlow(session, flow, state, route);
+    }
+
+    public void openRoute(MenuRoute route) {
+        menuService.openRoute(session, route);
+    }
+
+    public boolean goBack() {
+        return menuService.goBack(session);
     }
 
     public void openPrompt(MenuPrompt prompt) {

--- a/src/main/java/org/xcore/plugin/ui/menu/AuditHistoryFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/AuditHistoryFlows.java
@@ -110,7 +110,7 @@ final class AuditHistoryFlows {
             }
 
             List<MenuButton> navRow = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navRow.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navRow.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -203,7 +203,7 @@ final class AuditHistoryFlows {
 
             List<List<MenuButton>> rows = new ArrayList<>();
             List<MenuButton> navRow = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navRow.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navRow.add(MenuButton.of(local.t("close"), ACTION_CLOSE));

--- a/src/main/java/org/xcore/plugin/ui/menu/AuditHistoryFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/AuditHistoryFlows.java
@@ -110,7 +110,7 @@ final class AuditHistoryFlows {
             }
 
             List<MenuButton> navRow = new ArrayList<>();
-            if (session.canGoBack(true)) {
+            if (session.canGoBack()) {
                 navRow.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navRow.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -203,7 +203,7 @@ final class AuditHistoryFlows {
 
             List<List<MenuButton>> rows = new ArrayList<>();
             List<MenuButton> navRow = new ArrayList<>();
-            if (session.canGoBack(true)) {
+            if (session.canGoBack()) {
                 navRow.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navRow.add(MenuButton.of(local.t("close"), ACTION_CLOSE));

--- a/src/main/java/org/xcore/plugin/ui/menu/AuditHistoryFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/AuditHistoryFlows.java
@@ -1,0 +1,237 @@
+package org.xcore.plugin.ui.menu;
+
+import org.xcore.plugin.localization.Localization;
+import org.xcore.plugin.model.AuditActorType;
+import org.xcore.plugin.model.AuditCursor;
+import org.xcore.plugin.model.AuditRecord;
+import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuRenderContext;
+import org.xcore.plugin.ui.flow.MenuScreen;
+import org.xcore.plugin.ui.route.MenuRoute;
+import org.xcore.plugin.ui.route.RoutedMenuFlow;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.ospx.flubundle.Bundle.args;
+
+final class AuditHistoryFlows {
+
+    static final String ROUTE_HISTORY = "audit.history";
+    static final String ROUTE_DETAILS = "audit.details";
+
+    private static final String ACTION_PREVIOUS = "previous";
+    private static final String ACTION_NEXT = "next";
+    private static final String ACTION_DETAILS_PREFIX = "details:";
+    private static final String ACTION_BACK = "back";
+    private static final String ACTION_CLOSE = "close";
+
+    private AuditHistoryFlows() {
+    }
+
+    static final class HistoryFlow implements RoutedMenuFlow<AuditHistoryMenu.AuditHistoryState> {
+        private final AuditHistoryMenu menu;
+
+        HistoryFlow(AuditHistoryMenu menu) {
+            this.menu = menu;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_HISTORY;
+        }
+
+        @Override
+        public AuditHistoryMenu.AuditHistoryState createState(org.xcore.plugin.session.Session session,
+                                                              MenuRoute route,
+                                                              AuditHistoryMenu.AuditHistoryState currentState) {
+            if (AuditHistoryMenu.shouldReuseHistoryState(session, route, currentState)) {
+                return currentState;
+            }
+            AuditHistoryMenu.AuditHistoryState state = new AuditHistoryMenu.AuditHistoryState();
+            state.targetUuid = route.param("targetUuid");
+            state.targetNickname = route.param("targetNickname");
+            state.targetPid = route.intParam("targetPid", 0);
+            state.targetDiscordId = route.param("targetDiscordId");
+            state.mode = AuditHistoryMenu.parseMode(route.param("mode"));
+            return state;
+        }
+
+        @Override
+        public Class<AuditHistoryMenu.AuditHistoryState> stateType() {
+            return AuditHistoryMenu.AuditHistoryState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<AuditHistoryMenu.AuditHistoryState> context) {
+            var session = context.session();
+            var state = context.state();
+            Localization local = context.locale();
+
+            if (state.targetUuid == null) {
+                return MenuScreen.normal(
+                        local.t(state.mode == AuditHistoryMenu.AuditViewMode.TARGET ? "audit-menu-history-title" : "audit-menu-actions-title"),
+                        local.t("error-internal"),
+                        List.of(List.of(MenuButton.of(local.t("close"), ACTION_CLOSE)))
+                );
+            }
+
+            var slice = switch (state.mode) {
+                case TARGET -> menu.auditService.findSummaryByTargetUuid(state.targetUuid, state.currentCursor, menu.globalConfig.eventsPerPage);
+                case ACTOR -> menu.findSummaryByActor(
+                        AuditActorType.PLAYER_ADMIN,
+                        menu.actorLookupIds(state.targetDiscordId, state.targetNickname),
+                        state.currentCursor,
+                        menu.globalConfig.eventsPerPage
+                );
+            };
+            state.nextCursor = slice.nextCursor();
+
+            String content = menu.buildSummaryContent(session, state.targetNickname, state.targetPid, state.mode, slice.items().size(), state.currentCursor, slice.hasNext());
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+
+            List<MenuButton> paginationRow = new ArrayList<>();
+            if (!state.backStack.isEmpty()) {
+                paginationRow.add(MenuButton.of(local.t("previous"), ACTION_PREVIOUS));
+            }
+            if (slice.hasNext() && state.nextCursor != null) {
+                paginationRow.add(MenuButton.of(local.t("next"), ACTION_NEXT));
+            }
+            if (!paginationRow.isEmpty()) {
+                rows.add(paginationRow);
+            }
+
+            for (var item : slice.items()) {
+                rows.add(List.of(MenuButton.of(
+                        AuditHistoryMenu.formatSummaryRow(local, item, state.mode),
+                        ACTION_DETAILS_PREFIX + item.auditId()
+                )));
+            }
+
+            List<MenuButton> navRow = new ArrayList<>();
+            if (session.hasHistory() || session.hasRouteHistory()) {
+                navRow.add(MenuButton.of(local.t("back"), ACTION_BACK));
+            }
+            navRow.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
+            rows.add(navRow);
+
+            return MenuScreen.normal(
+                    local.t(state.mode == AuditHistoryMenu.AuditViewMode.TARGET ? "audit-menu-history-title" : "audit-menu-actions-title"),
+                    content,
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<AuditHistoryMenu.AuditHistoryState> context, String actionId) {
+            var state = context.state();
+            var session = context.session();
+
+            switch (actionId) {
+                case ACTION_PREVIOUS -> {
+                    AuditCursor previous = state.backStack.pollLast();
+                    state.currentCursor = AuditHistoryMenu.restoreCursor(previous);
+                    context.render();
+                }
+                case ACTION_NEXT -> {
+                    state.backStack.addLast(state.currentCursor == null ? AuditHistoryMenu.FIRST_PAGE_MARKER : state.currentCursor);
+                    state.currentCursor = state.nextCursor;
+                    context.render();
+                }
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                default -> {
+                    if (actionId.startsWith(ACTION_DETAILS_PREFIX)) {
+                        String auditId = actionId.substring(ACTION_DETAILS_PREFIX.length());
+                        AuditRecord record = menu.auditService.findByAuditId(auditId).orElse(null);
+                        if (record == null) {
+                            session.locale().send("error-processing-request", args());
+                            context.render();
+                        } else {
+                            context.openRoute(MenuRoute.of(ROUTE_DETAILS).withParam("auditId", auditId));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    static final class DetailsFlow implements RoutedMenuFlow<AuditHistoryMenu.AuditHistoryState> {
+        private final AuditHistoryMenu menu;
+
+        DetailsFlow(AuditHistoryMenu menu) {
+            this.menu = menu;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_DETAILS;
+        }
+
+        @Override
+        public AuditHistoryMenu.AuditHistoryState createState(org.xcore.plugin.session.Session session,
+                                                              MenuRoute route,
+                                                              AuditHistoryMenu.AuditHistoryState currentState) {
+            return currentState != null ? currentState : new AuditHistoryMenu.AuditHistoryState();
+        }
+
+        @Override
+        public Class<AuditHistoryMenu.AuditHistoryState> stateType() {
+            return AuditHistoryMenu.AuditHistoryState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<AuditHistoryMenu.AuditHistoryState> context) {
+            var session = context.session();
+            var state = context.state();
+            Localization local = context.locale();
+            String auditId = context.route().param("auditId");
+
+            if (auditId == null || auditId.isBlank()) {
+                session.locale().send("error-processing-request", args());
+                return errorScreen(local);
+            }
+
+            AuditRecord record = menu.auditService.findByAuditId(auditId).orElse(null);
+            if (record == null) {
+                session.locale().send("error-processing-request", args());
+                return errorScreen(local);
+            }
+
+            String content = menu.formatDetailsContent(session, state.targetNickname, state.targetPid, record);
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+            List<MenuButton> navRow = new ArrayList<>();
+            if (session.hasHistory() || session.hasRouteHistory()) {
+                navRow.add(MenuButton.of(local.t("back"), ACTION_BACK));
+            }
+            navRow.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
+            rows.add(navRow);
+
+            return MenuScreen.followUp(
+                    local.t("audit-menu-details-title"),
+                    content,
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<AuditHistoryMenu.AuditHistoryState> context, String actionId) {
+            switch (actionId) {
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+            }
+        }
+
+        private MenuScreen errorScreen(Localization local) {
+            List<List<MenuButton>> rows = new ArrayList<>();
+            rows.add(List.of(MenuButton.of(local.t("back"), ACTION_BACK)));
+            return MenuScreen.followUp(
+                    local.t("audit-menu-details-title"),
+                    local.t("error-processing-request"),
+                    rows
+            );
+        }
+    }
+}

--- a/src/main/java/org/xcore/plugin/ui/menu/AuditHistoryMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/AuditHistoryMenu.java
@@ -1,85 +1,78 @@
 package org.xcore.plugin.ui.menu;
 
+import io.avaje.inject.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.xcore.plugin.config.Config;
 import org.xcore.plugin.config.GlobalConfig;
-import org.xcore.plugin.model.AuditCursor;
+import org.xcore.plugin.localization.Localization;
 import org.xcore.plugin.model.AuditActorType;
+import org.xcore.plugin.model.AuditCursor;
 import org.xcore.plugin.model.AuditRecord;
 import org.xcore.plugin.model.AuditRecordSummary;
 import org.xcore.plugin.model.PlayerData;
 import org.xcore.plugin.model.Slice;
-import org.xcore.plugin.localization.Localization;
 import org.xcore.plugin.service.moderation.AuditService;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.MenuService;
+import org.xcore.plugin.ui.route.MenuRoute;
 
 import java.time.Instant;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
-
-import org.xcore.plugin.ui.flow.MenuButton;
-import org.xcore.plugin.ui.flow.MenuFlow;
-import org.xcore.plugin.ui.flow.MenuRenderContext;
-import org.xcore.plugin.ui.flow.MenuScreen;
 
 import static com.ospx.flubundle.Bundle.args;
 
 @Singleton
 public class AuditHistoryMenu extends Menu {
 
-    private static final String ACTION_PREVIOUS = "previous";
-    private static final String ACTION_NEXT = "next";
-    private static final String ACTION_DETAILS_PREFIX = "details:";
-    private static final String ACTION_BACK = "back";
-    private static final String ACTION_CLOSE = "close";
-    private static final AuditCursor FIRST_PAGE_MARKER = new AuditCursor(Long.MIN_VALUE, "__first_page__");
+    static final AuditCursor FIRST_PAGE_MARKER = new AuditCursor(Long.MIN_VALUE, "__first_page__");
 
-    private final AuditService auditService;
+    final AuditService auditService;
+    private final MenuService menuService;
 
     @Inject
     public AuditHistoryMenu(Config config,
                             GlobalConfig globalConfig,
                             SessionService sessionService,
-                            AuditService auditService) {
+                            AuditService auditService,
+                            MenuService menuService) {
         super(config, globalConfig, sessionService);
         this.auditService = auditService;
+        this.menuService = menuService;
+    }
+
+    @PostConstruct
+    public void init() {
+        menuService.registerRoute(new AuditHistoryFlows.HistoryFlow(this));
+        menuService.registerRoute(new AuditHistoryFlows.DetailsFlow(this));
     }
 
     public void history(String viewerUuid, PlayerData targetData) {
-        history(viewerUuid, targetData, AuditViewMode.TARGET, null, true);
+        openHistory(viewerUuid, targetData, AuditViewMode.TARGET);
     }
 
     public void actions(String viewerUuid, PlayerData targetData) {
-        history(viewerUuid, targetData, AuditViewMode.ACTOR, null, true);
+        openHistory(viewerUuid, targetData, AuditViewMode.ACTOR);
     }
 
-    private void history(String viewerUuid, PlayerData targetData, AuditViewMode mode, AuditCursor cursor, boolean resetState) {
+    private void openHistory(String viewerUuid, PlayerData targetData, AuditViewMode mode) {
         Session session = sessionService.get(viewerUuid);
         if (session == null || session.data == null || targetData == null) {
             return;
         }
-        session.clear();
-
-        AuditHistoryState state = session.getDraft(AuditHistoryState.class);
-        if (state == null) {
-            session.locale().send("error-internal", args());
-            return;
+        MenuRoute route = MenuRoute.of(AuditHistoryFlows.ROUTE_HISTORY)
+                .withParam("targetUuid", targetData.uuid)
+                .withParam("targetNickname", targetData.nickname == null ? "" : targetData.nickname)
+                .withParam("targetPid", String.valueOf(targetData.pid))
+                .withParam("mode", mode.name());
+        if (targetData.discordId != null && !targetData.discordId.isBlank()) {
+            route = route.withParam("targetDiscordId", targetData.discordId);
         }
 
-        if (resetState || !targetData.uuid.equals(state.targetUuid) || state.mode != mode) {
-            state.targetUuid = targetData.uuid;
-            state.mode = mode;
-            state.backStack.clear();
-            state.currentCursor = null;
-            state.nextCursor = null;
-        }
-        state.currentCursor = cursor;
-
-        session.menuService.renderFlow(session, new HistoryFlow(viewerUuid, targetData));
+        session.menuService.openRoute(session, route);
     }
 
     public void details(String viewerUuid, PlayerData targetData, String auditId) {
@@ -92,27 +85,25 @@ public class AuditHistoryMenu extends Menu {
         AuditRecord record = auditService.findByAuditId(auditId).orElse(null);
         if (record == null) {
             session.locale().send("error-processing-request", args());
-            Runnable previous = session.popHistory();
-            if (previous != null) {
-                previous.run();
-            }
+            menuService.goBack(session);
             return;
         }
 
-        var builder = session.builder()
-                .title("audit-menu-details-title")
-                .rawContent(formatDetailsContent(session, targetData, record));
-
-        if (session.hasHistory()) {
-            builder.addLocal("back", () -> {
-                session.menuService.hideFollowUp(session);
-                Runnable previousMenu = session.popHistory();
-                if (previousMenu != null) previousMenu.run();
-            });
+        AuditHistoryState state = session.getDraft(AuditHistoryState.class);
+        if (state == null) {
+            session.locale().send("error-internal", args());
+            return;
         }
 
-        builder.addLocal("close", () -> session.menuService.close(session));
-        builder.showFollowUp();
+        state.targetUuid = targetData.uuid;
+        state.targetNickname = targetData.nickname;
+        state.targetPid = targetData.pid;
+        state.targetDiscordId = targetData.discordId;
+        if (state.mode == null) {
+            state.mode = AuditViewMode.TARGET;
+        }
+
+        session.menuService.renderRoute(session, MenuRoute.of(AuditHistoryFlows.ROUTE_DETAILS).withParam("auditId", auditId));
     }
 
     static String formatSummaryRow(Localization local, AuditRecordSummary item) {
@@ -144,12 +135,13 @@ public class AuditHistoryMenu extends Menu {
         return reason.length() <= 48 ? reason : reason.substring(0, 45) + "...";
     }
 
-    private String buildSummaryContent(Session session,
-                                       PlayerData targetData,
-                                       AuditViewMode mode,
-                                       int itemCount,
-                                       AuditCursor cursor,
-                                       boolean hasNext) {
+    String buildSummaryContent(Session session,
+                               String targetNickname,
+                               int targetPid,
+                               AuditViewMode mode,
+                               int itemCount,
+                               AuditCursor cursor,
+                               boolean hasNext) {
         Localization local = session.locale();
         String pageHint = cursor == null
                 ? local.t("audit-menu-history-page-first")
@@ -162,8 +154,8 @@ public class AuditHistoryMenu extends Menu {
                 : local.t(mode == AuditViewMode.TARGET ? "audit-menu-history-hint" : "audit-menu-actions-hint");
 
         return local.t(mode == AuditViewMode.TARGET ? "audit-menu-history-content" : "audit-menu-actions-content", args(
-                "player", targetData.nickname,
-                "pid", targetData.pid,
+                "player", targetNickname,
+                "pid", targetPid,
                 "entriesShown", itemCount,
                 "pageState", pageHint,
                 "nextState", nextHint,
@@ -171,7 +163,7 @@ public class AuditHistoryMenu extends Menu {
         ));
     }
 
-    private String formatDetailsContent(Session session, PlayerData targetData, AuditRecord record) {
+    String formatDetailsContent(Session session, String targetNickname, int targetPid, AuditRecord record) {
         Localization local = session.locale();
         String actor = record.actor == null || record.actor.nameSnapshot == null || record.actor.nameSnapshot.isBlank()
                 ? local.t("audit-menu-unknown-actor")
@@ -186,8 +178,8 @@ public class AuditHistoryMenu extends Menu {
                 : formatDuration(record.details.durationMs, local);
 
         return local.t("audit-menu-details-content", args(
-                "player", targetData.nickname,
-                "pid", targetData.pid,
+                "player", targetNickname,
+                "pid", targetPid,
                 "action", actionLabel(local, record.action.name()),
                 "actor", actor,
                 "reason", reason,
@@ -214,111 +206,11 @@ public class AuditHistoryMenu extends Menu {
         return local.t("audit-menu-action-" + action.toLowerCase());
     }
 
-    private final class HistoryFlow implements MenuFlow<AuditHistoryState> {
-        private final String viewerUuid;
-        private final PlayerData targetData;
-
-        HistoryFlow(String viewerUuid, PlayerData targetData) {
-            this.viewerUuid = viewerUuid;
-            this.targetData = targetData;
-        }
-
-        @Override
-        public Class<AuditHistoryState> stateType() {
-            return AuditHistoryState.class;
-        }
-
-        @Override
-        public MenuScreen render(MenuRenderContext<AuditHistoryState> context) {
-            Session session = context.session();
-            AuditHistoryState state = context.state();
-            Localization local = context.locale();
-
-            var slice = switch (state.mode) {
-                case TARGET -> auditService.findSummaryByTargetUuid(targetData.uuid, state.currentCursor, globalConfig.eventsPerPage);
-                case ACTOR -> findSummaryByActor(AuditActorType.PLAYER_ADMIN, actorLookupIds(targetData), state.currentCursor, globalConfig.eventsPerPage);
-            };
-            state.nextCursor = slice.nextCursor();
-
-            String content = buildSummaryContent(session, targetData, state.mode, slice.items().size(), state.currentCursor, slice.hasNext());
-
-            List<List<MenuButton>> rows = new ArrayList<>();
-
-            List<MenuButton> paginationRow = new ArrayList<>();
-            if (!state.backStack.isEmpty()) {
-                paginationRow.add(MenuButton.of(local.t("previous"), ACTION_PREVIOUS));
-            }
-            if (slice.hasNext() && state.nextCursor != null) {
-                paginationRow.add(MenuButton.of(local.t("next"), ACTION_NEXT));
-            }
-            if (!paginationRow.isEmpty()) {
-                rows.add(paginationRow);
-            }
-
-            for (var item : slice.items()) {
-                rows.add(List.of(MenuButton.of(
-                        formatSummaryRow(local, item, state.mode),
-                        ACTION_DETAILS_PREFIX + item.auditId()
-                )));
-            }
-
-            List<MenuButton> navRow = new ArrayList<>();
-            if (session.hasHistory()) {
-                navRow.add(MenuButton.of(local.t("back"), ACTION_BACK));
-            }
-            navRow.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
-            rows.add(navRow);
-
-            return MenuScreen.normal(
-                    local.t(state.mode == AuditViewMode.TARGET ? "audit-menu-history-title" : "audit-menu-actions-title"),
-                    content,
-                    rows
-            );
-        }
-
-        @Override
-        public void onAction(MenuRenderContext<AuditHistoryState> context, String actionId) {
-            AuditHistoryState state = context.state();
-            Session session = context.session();
-
-            switch (actionId) {
-                case ACTION_PREVIOUS -> {
-                    AuditCursor previous = state.backStack.pollLast();
-                    state.currentCursor = restoreCursor(previous);
-                    context.render();
-                }
-                case ACTION_NEXT -> {
-                    state.backStack.addLast(state.currentCursor == null ? FIRST_PAGE_MARKER : state.currentCursor);
-                    state.currentCursor = state.nextCursor;
-                    context.render();
-                }
-                case ACTION_BACK -> {
-                    Runnable previousMenu = session.popHistory();
-                    if (previousMenu != null) previousMenu.run();
-                }
-                case ACTION_CLOSE -> context.close();
-                default -> {
-                    if (actionId.startsWith(ACTION_DETAILS_PREFIX)) {
-                        String auditId = actionId.substring(ACTION_DETAILS_PREFIX.length());
-                        session.pushHistory(() -> {
-                            session.clear();
-                            AuditHistoryState histState = session.getDraft(AuditHistoryState.class);
-                            histState.targetUuid = state.targetUuid;
-                            histState.mode = state.mode;
-                            histState.backStack = new ArrayDeque<>(state.backStack);
-                            histState.currentCursor = state.currentCursor;
-                            histState.nextCursor = state.nextCursor;
-                            session.menuService.renderFlow(session, new HistoryFlow(viewerUuid, targetData));
-                        });
-                        details(viewerUuid, targetData, auditId);
-                    }
-                }
-            }
-        }
-    }
-
     public static final class AuditHistoryState {
         public String targetUuid;
+        public String targetNickname;
+        public int targetPid;
+        public String targetDiscordId;
         public AuditViewMode mode = AuditViewMode.TARGET;
         public Deque<AuditCursor> backStack = new ArrayDeque<>();
         public AuditCursor currentCursor;
@@ -330,14 +222,37 @@ public class AuditHistoryMenu extends Menu {
         ACTOR
     }
 
-    private static AuditCursor restoreCursor(AuditCursor cursor) {
+    static boolean shouldReuseHistoryState(Session session, MenuRoute route, AuditHistoryState currentState) {
+        if (currentState == null) {
+            return false;
+        }
+        var activeScreen = session.activeScreen();
+        if (activeScreen == null || !activeScreen.hasRoute() || !AuditHistoryFlows.ROUTE_DETAILS.equals(activeScreen.route().id())) {
+            return false;
+        }
+        return route.param("targetUuid").equals(currentState.targetUuid)
+                && parseMode(route.param("mode")) == currentState.mode;
+    }
+
+    static AuditViewMode parseMode(String modeParam) {
+        if (modeParam == null) {
+            return AuditViewMode.TARGET;
+        }
+        try {
+            return AuditViewMode.valueOf(modeParam);
+        } catch (IllegalArgumentException ignored) {
+            return AuditViewMode.TARGET;
+        }
+    }
+
+    static AuditCursor restoreCursor(AuditCursor cursor) {
         return FIRST_PAGE_MARKER.equals(cursor) ? null : cursor;
     }
 
-    private Slice<AuditRecordSummary> findSummaryByActor(AuditActorType actorType,
-                                                         List<String> actorIds,
-                                                         AuditCursor cursor,
-                                                         int limit) {
+    Slice<AuditRecordSummary> findSummaryByActor(AuditActorType actorType,
+                                                 List<String> actorIds,
+                                                 AuditCursor cursor,
+                                                 int limit) {
         if (auditService instanceof org.xcore.plugin.service.moderation.DefaultAuditService defaultAuditService) {
             return defaultAuditService.findSummaryByActor(actorType, actorIds, cursor, limit);
         }
@@ -352,9 +267,7 @@ public class AuditHistoryMenu extends Menu {
         return new Slice<>(List.of(), false, null);
     }
 
-    private static List<String> actorLookupIds(PlayerData targetData) {
-        String discordId = targetData.discordId;
-        String nickname = targetData.nickname;
+    List<String> actorLookupIds(String discordId, String nickname) {
         if (discordId != null && !discordId.isBlank()) {
             return List.of(discordId, nickname);
         }

--- a/src/main/java/org/xcore/plugin/ui/menu/BanMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/BanMenu.java
@@ -1,19 +1,26 @@
 package org.xcore.plugin.ui.menu;
 
+import io.avaje.inject.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import mindustry.gen.Player;
 import org.xcore.plugin.config.Config;
 import org.xcore.plugin.config.GlobalConfig;
 import org.xcore.plugin.model.BanData;
-import org.xcore.plugin.model.PlayerData;
 import org.xcore.plugin.service.TimeService;
 import org.xcore.plugin.service.moderation.ModerationService;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.MenuService;
+import org.xcore.plugin.ui.flow.MenuButton;
 import org.xcore.plugin.ui.flow.MenuPrompt;
+import org.xcore.plugin.ui.flow.MenuRenderContext;
+import org.xcore.plugin.ui.flow.MenuScreen;
+import org.xcore.plugin.ui.route.MenuRoute;
+import org.xcore.plugin.ui.route.RoutedMenuFlow;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static com.ospx.flubundle.Bundle.args;
@@ -21,21 +28,32 @@ import static com.ospx.flubundle.Bundle.args;
 @Singleton
 public class BanMenu extends Menu {
 
+    private static final String ROUTE_FLOW = "ban.flow";
     private static final String PROMPT_DURATION = "ban-duration";
     private static final String PROMPT_REASON = "ban-reason";
+    private static final String ACTION_APPLY = "apply";
+    private static final String ACTION_CANCEL = "cancel";
 
     private final ModerationService moderationService;
     private final TimeService timeService;
+    private final MenuService menuService;
 
     @Inject
     public BanMenu(Config config,
                    GlobalConfig globalConfig,
                    SessionService sessionService,
                    ModerationService moderationService,
-                   TimeService timeService) {
+                   TimeService timeService,
+                   MenuService menuService) {
         super(config, globalConfig, sessionService);
         this.moderationService = moderationService;
         this.timeService = timeService;
+        this.menuService = menuService;
+    }
+
+    @PostConstruct
+    public void init() {
+        menuService.registerRoute(new BanFlow());
     }
 
     public void open(Player admin, Player target) {
@@ -48,131 +66,192 @@ public class BanMenu extends Menu {
             return;
         }
 
-        session.setDraft(new BanDraft(target.uuid(), targetData.pid, target.coloredName(), target.plainName()));
-        askDuration(session);
-    }
-
-    private void askDuration(Session session) {
-        var draft = session.getDraft(BanDraft.class);
-        if (draft == null) {
-            session.locale().send("error-internal", args());
-            return;
-        }
-
-        var prompt = new MenuPrompt(
-                PROMPT_DURATION,
-                session.locale().t("ban-menu-duration-title"),
-                session.locale().t("ban-menu-duration-message", args("nickname", draft.targetColoredName)),
-                64,
-                draft.durationInput,
-                false
-        );
-
-        session.menuService.openPrompt(session, prompt, text -> {
-            String durationInput = text == null ? "" : text.trim();
-            var parsed = timeService.parsePeriod(durationInput, TimeUnit.DAYS);
-            if (parsed == null || parsed.toEpochMilli() <= 0) {
-                session.locale().send("error-wrong-period-format", args());
-                askDuration(session);
-                return;
-            }
-
-            draft.durationInput = durationInput;
-            draft.duration = Duration.ofMillis(parsed.toEpochMilli());
-            askReason(session);
-        }, () -> cancel(session));
-    }
-
-    private void askReason(Session session) {
-        var draft = session.getDraft(BanDraft.class);
-        if (draft == null) {
-            session.locale().send("error-internal", args());
-            return;
-        }
-
-        var prompt = new MenuPrompt(
-                PROMPT_REASON,
-                session.locale().t("ban-menu-reason-title"),
-                session.locale().t("ban-menu-reason-message", args("nickname", draft.targetColoredName)),
-                256,
-                draft.reason == null ? "" : draft.reason,
-                false
-        );
-
-        session.menuService.openPrompt(session, prompt, text -> {
-            draft.reason = (text == null || text.trim().isEmpty()) ? null : text.trim();
-            confirm(session);
-        }, () -> askDuration(session));
-    }
-
-    private void confirm(Session session) {
-        var draft = session.getDraft(BanDraft.class);
-        if (draft == null || draft.duration == null) {
-            session.locale().send("error-internal", args());
-            return;
-        }
+        var state = new BanFlowState();
+        state.targetUuid = target.uuid();
+        state.targetPid = targetData.pid;
+        state.targetColoredName = target.coloredName();
+        state.targetPlainName = target.plainName();
+        state.step = BanFlowState.Step.DURATION;
 
         session.clear();
-        session.builder()
-                .title("ban-menu-confirm-title")
-                .content("ban-menu-confirm-content", args(
-                        "nickname", draft.targetColoredName,
-                        "duration", draft.durationInput,
-                        "reason", draft.reason == null ? session.locale().t("none") : draft.reason
-                ))
-                .addLocalRow("ban-menu-confirm-action", () -> applyBan(session), "cancel", () -> cancel(session))
-                .showFollowUp();
+        session.setDraft(BanFlowState.class, state);
+        session.menuService.renderRoute(session, MenuRoute.of(ROUTE_FLOW));
     }
 
-    private void applyBan(Session session) {
-        var draft = session.getDraft(BanDraft.class);
-        if (draft == null || draft.duration == null) {
+    private final class BanFlow implements RoutedMenuFlow<BanFlowState> {
+        @Override
+        public String routeId() {
+            return ROUTE_FLOW;
+        }
+
+        @Override
+        public BanFlowState createState(Session session, MenuRoute route, BanFlowState currentState) {
+            return currentState == null ? new BanFlowState() : currentState;
+        }
+
+        @Override
+        public Class<BanFlowState> stateType() {
+            return BanFlowState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<BanFlowState> context) {
+            var state = context.state();
+            var local = context.locale();
+            var session = context.session();
+
+            if (state.targetUuid == null) {
+                context.close();
+                return placeholderScreen();
+            }
+
+            switch (state.step) {
+                case DURATION -> {
+                    context.openPrompt(new MenuPrompt(
+                            PROMPT_DURATION,
+                            local.t("ban-menu-duration-title"),
+                            local.t("ban-menu-duration-message", args("nickname", state.targetColoredName)),
+                            64,
+                            state.durationInput,
+                            false
+                    ));
+                    return placeholderScreen();
+                }
+                case REASON -> {
+                    context.openPrompt(new MenuPrompt(
+                            PROMPT_REASON,
+                            local.t("ban-menu-reason-title"),
+                            local.t("ban-menu-reason-message", args("nickname", state.targetColoredName)),
+                            256,
+                            state.reason == null ? "" : state.reason,
+                            false
+                    ));
+                    return placeholderScreen();
+                }
+                case CONFIRM -> {
+                    return MenuScreen.followUp(
+                            local.t("ban-menu-confirm-title"),
+                            local.t("ban-menu-confirm-content", args(
+                                    "nickname", state.targetColoredName,
+                                    "duration", state.durationInput,
+                                    "reason", state.reason == null ? local.t("none") : state.reason
+                            )),
+                            List.of(List.of(
+                                    MenuButton.of(local.t("ban-menu-confirm-action"), ACTION_APPLY),
+                                    MenuButton.of(local.t("cancel"), ACTION_CANCEL)
+                            ))
+                    );
+                }
+                default -> {
+                    return placeholderScreen();
+                }
+            }
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<BanFlowState> context, String actionId) {
+            switch (actionId) {
+                case ACTION_APPLY -> applyBan(context);
+                case ACTION_CANCEL -> cancel(context);
+            }
+        }
+
+        @Override
+        public void onPromptSubmit(MenuRenderContext<BanFlowState> context, String promptId, String text) {
+            var state = context.state();
+            var session = context.session();
+
+            switch (promptId) {
+                case PROMPT_DURATION -> {
+                    String durationInput = text == null ? "" : text.trim();
+                    var parsed = timeService.parsePeriod(durationInput, TimeUnit.DAYS);
+                    if (parsed == null || parsed.toEpochMilli() <= 0) {
+                        session.locale().send("error-wrong-period-format", args());
+                        context.render();
+                        return;
+                    }
+                    state.durationInput = durationInput;
+                    state.duration = Duration.ofMillis(parsed.toEpochMilli());
+                    state.step = BanFlowState.Step.REASON;
+                    context.render();
+                }
+                case PROMPT_REASON -> {
+                    state.reason = (text == null || text.trim().isEmpty()) ? null : text.trim();
+                    state.step = BanFlowState.Step.CONFIRM;
+                    context.render();
+                }
+            }
+        }
+
+        @Override
+        public void onPromptCancel(MenuRenderContext<BanFlowState> context, String promptId) {
+            var state = context.state();
+
+            switch (promptId) {
+                case PROMPT_DURATION -> cancel(context);
+                case PROMPT_REASON -> {
+                    state.step = BanFlowState.Step.DURATION;
+                    context.render();
+                }
+            }
+        }
+
+        private MenuScreen placeholderScreen() {
+            return MenuScreen.normal("", "", List.of());
+        }
+    }
+
+    private void applyBan(MenuRenderContext<BanFlowState> context) {
+        var session = context.session();
+        var state = context.state();
+        if (state.duration == null) {
             session.locale().send("error-internal", args());
-            session.menuService.close(session);
+            context.close();
             return;
         }
 
-        var result = moderationService.banById(draft.targetPid, session.player.name, session.data.discordId, draft.reason, draft.duration, true);
-        session.clearDraft(BanDraft.class);
+        var result = moderationService.banById(state.targetPid, session.player.name, session.data.discordId, state.reason, state.duration, true);
+        session.clearDraft(BanFlowState.class);
 
         if (!result.isSuccess() || result.getData().isEmpty()) {
             session.locale().send("error-player-not-found", args());
-            session.menuService.close(session);
+            context.close();
             return;
         }
 
         BanData ban = result.getData().get();
         sessionService.broadcast("tempban-player-banned", args(
                 "adminName", session.player.coloredName(),
-                "playerName", draft.targetColoredName
+                "playerName", state.targetColoredName
         ));
-        arc.util.Log.info("@ banned @ (@) for @", session.player.plainName(), draft.targetPlainName, draft.targetUuid, draft.durationInput);
+        arc.util.Log.info("@ banned @ (@) for @", session.player.plainName(), state.targetPlainName, state.targetUuid, state.durationInput);
         session.locale().send("commands-ban-success", args("nickname", ban.name));
-        session.menuService.close(session);
+        context.close();
     }
 
-    private void cancel(Session session) {
-        var draft = session.getDraft(BanDraft.class);
-        String nickname = draft == null ? session.locale().t("none") : draft.targetColoredName;
-        session.clearDraft(BanDraft.class);
+    private void cancel(MenuRenderContext<BanFlowState> context) {
+        var session = context.session();
+        var state = context.state();
+        String nickname = state.targetColoredName == null ? session.locale().t("none") : state.targetColoredName;
+        session.clearDraft(BanFlowState.class);
         session.locale().send("ban-cancelled", args("nickname", nickname));
-        session.menuService.close(session);
+        context.close();
     }
 
-    private static final class BanDraft {
-        private final String targetUuid;
-        private final int targetPid;
-        private final String targetColoredName;
-        private final String targetPlainName;
-        private String durationInput = "1d";
-        private Duration duration;
-        private String reason;
+    public static final class BanFlowState {
+        public String targetUuid;
+        public int targetPid;
+        public String targetColoredName;
+        public String targetPlainName;
+        public String durationInput = "1d";
+        public Duration duration;
+        public String reason;
+        public Step step = Step.DURATION;
 
-        private BanDraft(String targetUuid, int targetPid, String targetColoredName, String targetPlainName) {
-            this.targetUuid = targetUuid;
-            this.targetPid = targetPid;
-            this.targetColoredName = targetColoredName;
-            this.targetPlainName = targetPlainName;
+        public enum Step {
+            DURATION,
+            REASON,
+            CONFIRM
         }
     }
 }

--- a/src/main/java/org/xcore/plugin/ui/menu/DiscordFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/DiscordFlows.java
@@ -80,7 +80,7 @@ final class DiscordFlows {
             }
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack(true)) {
+            if (session.canGoBack()) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -164,7 +164,7 @@ final class DiscordFlows {
                 List<List<MenuButton>> rows = new ArrayList<>();
                 rows.add(List.of(MenuButton.of(local.t("discord-link-menu-status"), ACTION_STATUS)));
                 List<MenuButton> nav = new ArrayList<>();
-                if (session.canGoBack(true)) {
+                if (session.canGoBack()) {
                     nav.add(MenuButton.of(local.t("back"), ACTION_BACK));
                 }
                 nav.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -192,7 +192,7 @@ final class DiscordFlows {
             ));
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack(true)) {
+            if (session.canGoBack()) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));

--- a/src/main/java/org/xcore/plugin/ui/menu/DiscordFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/DiscordFlows.java
@@ -80,7 +80,7 @@ final class DiscordFlows {
             }
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -164,7 +164,7 @@ final class DiscordFlows {
                 List<List<MenuButton>> rows = new ArrayList<>();
                 rows.add(List.of(MenuButton.of(local.t("discord-link-menu-status"), ACTION_STATUS)));
                 List<MenuButton> nav = new ArrayList<>();
-                if (session.hasHistory() || session.hasRouteHistory()) {
+                if (session.canGoBack(true)) {
                     nav.add(MenuButton.of(local.t("back"), ACTION_BACK));
                 }
                 nav.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -192,7 +192,7 @@ final class DiscordFlows {
             ));
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));

--- a/src/main/java/org/xcore/plugin/ui/menu/DiscordFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/DiscordFlows.java
@@ -1,0 +1,256 @@
+package org.xcore.plugin.ui.menu;
+
+import org.xcore.plugin.service.DiscordLinkService;
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuRenderContext;
+import org.xcore.plugin.ui.flow.MenuScreen;
+import org.xcore.plugin.ui.route.MenuRoute;
+import org.xcore.plugin.ui.route.RoutedMenuFlow;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.ospx.flubundle.Bundle.args;
+
+final class DiscordFlows {
+
+    static final String ROUTE_MAIN = "discord.main";
+    static final String ROUTE_LINKING = "discord.linking";
+
+    private static final String ACTION_OPEN = "open";
+    private static final String ACTION_STATUS = "status";
+    private static final String ACTION_LINK = "link";
+    private static final String ACTION_UNLINK = "unlink";
+    private static final String ACTION_COPY = "copy";
+    private static final String ACTION_REFRESH = "refresh";
+    private static final String ACTION_REGENERATE = "regenerate";
+    private static final String ACTION_BACK = "back";
+    private static final String ACTION_CLOSE = "close";
+
+    private DiscordFlows() {
+    }
+
+    static final class MainFlow implements RoutedMenuFlow<MainState> {
+        private final DiscordMenu menu;
+        private final DiscordLinkService discordLinkService;
+
+        MainFlow(DiscordMenu menu, DiscordLinkService discordLinkService) {
+            this.menu = menu;
+            this.discordLinkService = discordLinkService;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_MAIN;
+        }
+
+        @Override
+        public MainState createState(Session session, MenuRoute route, MainState currentState) {
+            return currentState == null ? new MainState() : currentState;
+        }
+
+        @Override
+        public Class<MainState> stateType() {
+            return MainState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<MainState> context) {
+            Session session = context.session();
+            var local = context.locale();
+            var status = discordLinkService.status(session);
+            String statusText = status.linked()
+                    ? local.t("discord-menu-status-linked", args(
+                            "discordId", status.discordId(),
+                            "discordUsername", status.displayName()
+                    ))
+                    : local.t("discord-menu-status-not-linked", args());
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+            rows.add(List.of(
+                    MenuButton.of(local.t("discord-menu-open"), ACTION_OPEN),
+                    MenuButton.of(local.t("discord-menu-status"), ACTION_STATUS)
+            ));
+
+            if (!status.linked()) {
+                rows.add(List.of(MenuButton.of(local.t("discord-menu-link"), ACTION_LINK)));
+            } else {
+                rows.add(List.of(MenuButton.of(local.t("discord-menu-unlink"), ACTION_UNLINK)));
+            }
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.hasHistory() || session.hasRouteHistory()) {
+                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.normal(
+                    local.t("discord-menu-title"),
+                    local.t("discord-menu-content", args(
+                            "status", statusText,
+                            "discordUrl", menu.globalConfig.discordUrl
+                    )),
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<MainState> context, String actionId) {
+            Session session = context.session();
+            switch (actionId) {
+                case ACTION_OPEN -> session.menuService.openUri(session, menu.globalConfig.discordUrl);
+                case ACTION_STATUS -> context.render();
+                case ACTION_LINK -> {
+                    session.clearDraft(LinkingState.class);
+                    context.openRoute(MenuRoute.of(ROUTE_LINKING).withParam("regenerate", "false"));
+                }
+                case ACTION_UNLINK -> {
+                    var local = session.locale();
+                    if (!discordLinkService.unlink(session)) {
+                        local.send("commands-discord-unlink-not-linked", args());
+                    } else {
+                        local.send("commands-discord-unlink-success", args());
+                    }
+                    context.render();
+                }
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                default -> {
+                }
+            }
+        }
+    }
+
+    static final class LinkingFlow implements RoutedMenuFlow<LinkingState> {
+        private final DiscordMenu menu;
+        private final DiscordLinkService discordLinkService;
+
+        LinkingFlow(DiscordMenu menu, DiscordLinkService discordLinkService) {
+            this.menu = menu;
+            this.discordLinkService = discordLinkService;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_LINKING;
+        }
+
+        @Override
+        public LinkingState createState(Session session, MenuRoute route, LinkingState currentState) {
+            if (currentState != null && currentState.result != null && currentState.result.success()) {
+                return currentState;
+            }
+            boolean regenerate = Boolean.parseBoolean(route.param("regenerate"));
+            var result = regenerate
+                    ? discordLinkService.createCode(session)
+                    : discordLinkService.getOrCreateActiveCode(session);
+            return new LinkingState(result);
+        }
+
+        @Override
+        public Class<LinkingState> stateType() {
+            return LinkingState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<LinkingState> context) {
+            Session session = context.session();
+            var local = context.locale();
+            var result = context.state().result;
+
+            if (result == null || !result.success()) {
+                List<List<MenuButton>> rows = new ArrayList<>();
+                rows.add(List.of(MenuButton.of(local.t("discord-link-menu-status"), ACTION_STATUS)));
+                List<MenuButton> nav = new ArrayList<>();
+                if (session.hasHistory() || session.hasRouteHistory()) {
+                    nav.add(MenuButton.of(local.t("back"), ACTION_BACK));
+                }
+                nav.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
+                rows.add(nav);
+                return MenuScreen.followUp(
+                        local.t("discord-link-menu-title"),
+                        local.t("discord-link-menu-content", args(
+                                "code", "----",
+                                "expireMinutes", 0,
+                                "discordUrl", menu.globalConfig.discordUrl
+                        )),
+                        rows
+                );
+            }
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+            rows.add(List.of(
+                    MenuButton.of(local.t("discord-menu-open"), ACTION_OPEN),
+                    MenuButton.of(local.t("discord-link-menu-copy"), ACTION_COPY)
+            ));
+            rows.add(List.of(
+                    MenuButton.of(local.t("discord-link-menu-refresh"), ACTION_REFRESH),
+                    MenuButton.of(local.t("discord-link-menu-regenerate"), ACTION_REGENERATE),
+                    MenuButton.of(local.t("discord-link-menu-status"), ACTION_STATUS)
+            ));
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.hasHistory() || session.hasRouteHistory()) {
+                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.followUp(
+                    local.t("discord-link-menu-title"),
+                    local.t("discord-link-menu-content", args(
+                            "code", result.code(),
+                            "expireMinutes", result.remainingMinutes(System.currentTimeMillis()),
+                            "discordUrl", menu.globalConfig.discordUrl
+                    )),
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<LinkingState> context, String actionId) {
+            Session session = context.session();
+            var result = context.state().result;
+            switch (actionId) {
+                case ACTION_OPEN -> session.menuService.openUri(session, menu.globalConfig.discordUrl);
+                case ACTION_COPY -> {
+                    if (result != null && result.success()) {
+                        session.menuService.copyToClipboard(session, result.code());
+                    }
+                }
+                case ACTION_REFRESH -> {
+                    session.clearDraft(LinkingState.class);
+                    context.openRoute(MenuRoute.of(ROUTE_LINKING).withParam("regenerate", "false"));
+                }
+                case ACTION_REGENERATE -> {
+                    session.clearDraft(LinkingState.class);
+                    context.openRoute(MenuRoute.of(ROUTE_LINKING).withParam("regenerate", "true"));
+                }
+                case ACTION_STATUS -> {
+                    context.close();
+                    context.openRoute(MenuRoute.of(ROUTE_MAIN));
+                }
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                default -> {
+                }
+            }
+        }
+    }
+
+    static final class MainState {
+    }
+
+    static final class LinkingState {
+        public DiscordLinkService.LinkCodeResult result;
+
+        LinkingState() {
+        }
+
+        LinkingState(DiscordLinkService.LinkCodeResult result) {
+            this.result = result;
+        }
+    }
+}

--- a/src/main/java/org/xcore/plugin/ui/menu/DiscordMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/DiscordMenu.java
@@ -65,7 +65,7 @@ public class DiscordMenu extends Menu {
             return;
         }
 
-        session.setDraft(new DiscordFlows.LinkingState(result));
+        session.setDraft(DiscordFlows.LinkingState.class, new DiscordFlows.LinkingState(result));
         session.menuService.renderRoute(session, MenuRoute.of(DiscordFlows.ROUTE_LINKING).withParam("regenerate", String.valueOf(regenerate)));
     }
 }

--- a/src/main/java/org/xcore/plugin/ui/menu/DiscordMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/DiscordMenu.java
@@ -1,5 +1,6 @@
 package org.xcore.plugin.ui.menu;
 
+import io.avaje.inject.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.xcore.plugin.config.Config;
@@ -7,6 +8,8 @@ import org.xcore.plugin.config.GlobalConfig;
 import org.xcore.plugin.service.DiscordLinkService;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.MenuService;
+import org.xcore.plugin.ui.route.MenuRoute;
 
 import static com.ospx.flubundle.Bundle.args;
 
@@ -14,14 +17,23 @@ import static com.ospx.flubundle.Bundle.args;
 public class DiscordMenu extends Menu {
 
     private final DiscordLinkService discordLinkService;
+    private final MenuService menuService;
 
     @Inject
     public DiscordMenu(Config config,
                        GlobalConfig globalConfig,
                        SessionService sessionService,
-                       DiscordLinkService discordLinkService) {
+                       DiscordLinkService discordLinkService,
+                       MenuService menuService) {
         super(config, globalConfig, sessionService);
         this.discordLinkService = discordLinkService;
+        this.menuService = menuService;
+    }
+
+    @PostConstruct
+    public void init() {
+        menuService.registerRoute(new DiscordFlows.MainFlow(this, discordLinkService));
+        menuService.registerRoute(new DiscordFlows.LinkingFlow(this, discordLinkService));
     }
 
     public void main(String uuid) {
@@ -29,39 +41,7 @@ public class DiscordMenu extends Menu {
         if (session == null || session.data == null) return;
         session.clear();
 
-        var local = session.locale();
-        var status = discordLinkService.status(session);
-        String statusText = status.linked()
-                ? local.t("discord-menu-status-linked", args(
-                "discordId", status.discordId(),
-                "discordUsername", status.displayName()
-        ))
-                : local.t("discord-menu-status-not-linked", args());
-
-        session.builder()
-                .title("discord-menu-title")
-                .content("discord-menu-content", args(
-                        "status", statusText,
-                        "discordUrl", globalConfig.discordUrl
-                ))
-                .addLocal("discord-menu-open", () -> session.menuService.openUri(session, globalConfig.discordUrl))
-                .addLocal("discord-menu-status", () -> main(uuid))
-                .end()
-                .ifAddLocal(!status.linked(), "discord-menu-link", () -> {
-                    session.pushHistory(() -> main(uuid));
-                    linking(uuid, false);
-                })
-                .ifAddLocal(status.linked(), "discord-menu-unlink", () -> {
-                    if (!discordLinkService.unlink(session)) {
-                        local.send("commands-discord-unlink-not-linked", args());
-                    } else {
-                        local.send("commands-discord-unlink-success", args());
-                    }
-                    main(uuid);
-                })
-                .end()
-                .addNavigationRow()
-                .show();
+        session.menuService.renderRoute(session, MenuRoute.of(DiscordFlows.ROUTE_MAIN));
     }
 
     public void linking(String uuid, boolean regenerate) {
@@ -69,12 +49,12 @@ public class DiscordMenu extends Menu {
         if (session == null || session.data == null) return;
         session.clear();
 
-        var local = session.locale();
         var result = regenerate
                 ? discordLinkService.createCode(session)
                 : discordLinkService.getOrCreateActiveCode(session);
 
         if (!result.success()) {
+            var local = session.locale();
             if (result.isError("already-linked")) {
                 local.send("commands-discord-link-already-linked", args());
             } else {
@@ -85,33 +65,7 @@ public class DiscordMenu extends Menu {
             return;
         }
 
-        session.builder()
-                .title("discord-link-menu-title")
-                .content("discord-link-menu-content", args(
-                        "code", result.code(),
-                        "expireMinutes", result.remainingMinutes(System.currentTimeMillis()),
-                        "discordUrl", globalConfig.discordUrl
-                ))
-                .addLocal("discord-menu-open", () -> session.menuService.openUri(session, globalConfig.discordUrl))
-                .addLocal("discord-link-menu-copy", () -> session.menuService.copyToClipboard(session, result.code()))
-                .addLocal("discord-link-menu-refresh", () -> linking(uuid, false))
-                .end()
-                .addLocal("discord-link-menu-regenerate", () -> linking(uuid, true))
-                .addLocal("discord-link-menu-status", () -> {
-                    session.menuService.close(session);
-                    main(uuid);
-                })
-                .end()
-                .apply(builder -> {
-                    if (session.hasHistory()) {
-                        builder.addLocal("back", () -> {
-                            session.menuService.close(session);
-                            Runnable previousMenu = session.popHistory();
-                            if (previousMenu != null) previousMenu.run();
-                        });
-                    }
-                    builder.addLocal("close", () -> session.menuService.close(session));
-                })
-                .showFollowUp();
+        session.setDraft(new DiscordFlows.LinkingState(result));
+        session.menuService.renderRoute(session, MenuRoute.of(DiscordFlows.ROUTE_LINKING).withParam("regenerate", String.valueOf(regenerate)));
     }
 }

--- a/src/main/java/org/xcore/plugin/ui/menu/EventDraftFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/EventDraftFlows.java
@@ -1,0 +1,418 @@
+package org.xcore.plugin.ui.menu;
+
+import arc.struct.Seq;
+import mindustry.Vars;
+import mindustry.maps.Map;
+import org.xcore.plugin.common.CustomGatherers;
+import org.xcore.plugin.common.SeqStream;
+import org.xcore.plugin.model.EventData;
+import org.xcore.plugin.model.MapData;
+import org.xcore.plugin.model.PlayerData;
+import org.xcore.plugin.service.EventEditorService;
+import org.xcore.plugin.service.MapService;
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuPrompt;
+import org.xcore.plugin.ui.flow.MenuRenderContext;
+import org.xcore.plugin.ui.flow.MenuScreen;
+import org.xcore.plugin.ui.route.MenuRoute;
+import org.xcore.plugin.ui.route.RoutedMenuFlow;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.ospx.flubundle.Bundle.args;
+
+final class EventDraftFlows {
+
+    static final String ROUTE_CREATE_START = "event.create-start";
+    static final String ROUTE_EDIT = "event.edit";
+    static final String ROUTE_MAP_SELECTION = "event.map-selection";
+
+    private static final String ACTION_EDIT_NAME = "edit-name";
+    private static final String ACTION_EDIT_NAME_RESET = "edit-name-reset";
+    private static final String ACTION_EDIT_DESCRIPTION = "edit-description";
+    private static final String ACTION_EDIT_MAP = "edit-map";
+    private static final String ACTION_TOGGLE_TEMPORARY = "toggle-temporary";
+    private static final String ACTION_EDIT_PLANNED_START = "edit-planned-start";
+    private static final String ACTION_EDIT_PLANNED_END = "edit-planned-end";
+    private static final String ACTION_SAVE = "save";
+    private static final String ACTION_CANCEL_EDIT = "cancel-edit";
+    private static final String ACTION_TOGGLE_MAJOR = "toggle-major";
+    private static final String ACTION_PREVIOUS = "previous";
+    private static final String ACTION_NEXT = "next";
+    private static final String ACTION_BACK = "back";
+    private static final String ACTION_CLOSE = "close";
+    private static final String ACTION_MAP_PREFIX = "map:";
+
+    private static final String PROMPT_CREATE_NAME = "event-create-name";
+    private static final String PROMPT_EDIT_NAME = "event-edit-name";
+    private static final String PROMPT_EDIT_DESCRIPTION = "event-edit-description";
+    private static final String PROMPT_EDIT_PLANNED_START = "event-edit-planned-start";
+    private static final String PROMPT_EDIT_PLANNED_END = "event-edit-planned-end";
+
+    private EventDraftFlows() {
+    }
+
+    static final class CreateStartFlow implements RoutedMenuFlow<CreateStartState> {
+        private final EventMenu menu;
+        private final EventEditorService eventEditorService;
+
+        CreateStartFlow(EventMenu menu, EventEditorService eventEditorService) {
+            this.menu = menu;
+            this.eventEditorService = eventEditorService;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_CREATE_START;
+        }
+
+        @Override
+        public CreateStartState createState(Session session, MenuRoute route, CreateStartState currentState) {
+            return currentState == null ? new CreateStartState() : currentState;
+        }
+
+        @Override
+        public Class<CreateStartState> stateType() {
+            return CreateStartState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<CreateStartState> context) {
+            Session session = context.session();
+            if (!session.hasDraft(EventData.class)) {
+                return placeholderScreen();
+            }
+
+            context.openPrompt(new MenuPrompt(
+                    PROMPT_CREATE_NAME,
+                    session.locale().t("event-menu-create-start-title"),
+                    session.locale().t("event-menu-create-start-message"),
+                    20,
+                    session.locale().t("event-menu-create-start-default", args("playerName", session.player.name)),
+                    false
+            ));
+            return placeholderScreen();
+        }
+
+        @Override
+        public void onPromptSubmit(MenuRenderContext<CreateStartState> context, String promptId, String text) {
+            if (!PROMPT_CREATE_NAME.equals(promptId)) {
+                return;
+            }
+
+            Session session = context.session();
+            EventData draft = session.getDraft(EventData.class);
+            eventEditorService.updateName(draft, text);
+            menu.edit(menu.getUuid(session));
+        }
+
+        @Override
+        public void onPromptCancel(MenuRenderContext<CreateStartState> context, String promptId) {
+            if (!PROMPT_CREATE_NAME.equals(promptId)) {
+                return;
+            }
+
+            Session session = context.session();
+            eventEditorService.cancelDraft(session);
+            menu.main(menu.getUuid(session));
+        }
+    }
+
+    static final class EditFlow implements RoutedMenuFlow<EditState> {
+        private final EventMenu menu;
+        private final EventEditorService eventEditorService;
+
+        EditFlow(EventMenu menu, EventEditorService eventEditorService) {
+            this.menu = menu;
+            this.eventEditorService = eventEditorService;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_EDIT;
+        }
+
+        @Override
+        public EditState createState(Session session, MenuRoute route, EditState currentState) {
+            return currentState == null ? new EditState() : currentState;
+        }
+
+        @Override
+        public Class<EditState> stateType() {
+            return EditState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<EditState> context) {
+            Session session = context.session();
+            EventData draft = session.getDraft(EventData.class);
+            MapData mapData = eventEditorService.findMapForDraft(draft);
+            PlayerData authorData = eventEditorService.findAuthorForDraft(draft);
+
+            String yes = session.locale().t("yes");
+            String no = session.locale().t("no");
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+            rows.add(List.of(
+                    MenuButton.of(session.locale().t("event-menu-edit-name"), ACTION_EDIT_NAME),
+                    MenuButton.of(session.locale().t("event-menu-edit-name-reset"), ACTION_EDIT_NAME_RESET),
+                    MenuButton.of(session.locale().t("event-menu-edit-description"), ACTION_EDIT_DESCRIPTION)
+            ));
+            rows.add(List.of(
+                    MenuButton.of(session.locale().t("event-menu-edit-map"), ACTION_EDIT_MAP),
+                    MenuButton.of(session.locale().t(draft.isTemporary ? "event-menu-edit-temporary-active" : "event-menu-edit-temporary-inactive"), ACTION_TOGGLE_TEMPORARY)
+            ));
+            rows.add(List.of(
+                    MenuButton.of(session.locale().t("event-menu-edit-planned-start"), ACTION_EDIT_PLANNED_START),
+                    MenuButton.of(session.locale().t("event-menu-edit-planned-end"), ACTION_EDIT_PLANNED_END)
+            ));
+            rows.add(List.of(
+                    MenuButton.of("[green]" + session.locale().t("save"), ACTION_SAVE),
+                    MenuButton.of("[red]" + session.locale().t("cancel"), ACTION_CANCEL_EDIT)
+            ));
+            if (session.player.admin) {
+                rows.add(List.of(MenuButton.of(
+                        session.locale().t(draft.isMajor ? "event-menu-edit-major-active" : "event-menu-edit-major-inactive"),
+                        ACTION_TOGGLE_MAJOR
+                )));
+            }
+
+            return MenuScreen.normal(
+                    session.locale().t("event-menu-edit-title"),
+                    session.locale().t("event-menu-edit-content", args(
+                            "name", draft.name,
+                            "description", draft.description,
+                            "author", (authorData == null) ? "Unknown" : authorData.nickname,
+                            "mapName", (mapData == null) ? "" : mapData.name,
+                            "isMajor", draft.isMajor ? yes : no,
+                            "isTemporary", draft.isTemporary ? yes : no,
+                            "plannedStartTime", menu.formatTime(draft.plannedStartTime, session),
+                            "plannedEndTime", menu.formatTime(draft.plannedEndTime, session)
+                    )),
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<EditState> context, String actionId) {
+            Session session = context.session();
+            EventData draft = session.getDraft(EventData.class);
+            String uuid = menu.getUuid(session);
+
+            switch (actionId) {
+                case ACTION_EDIT_NAME -> context.openPrompt(new MenuPrompt(
+                        PROMPT_EDIT_NAME,
+                        session.locale().t("event-menu-edit-name-title"),
+                        "",
+                        24,
+                        draft.name,
+                        false
+                ));
+                case ACTION_EDIT_NAME_RESET -> {
+                    eventEditorService.resetName(draft);
+                    context.render();
+                }
+                case ACTION_EDIT_DESCRIPTION -> context.openPrompt(new MenuPrompt(
+                        PROMPT_EDIT_DESCRIPTION,
+                        session.locale().t("event-menu-edit-description-title"),
+                        "",
+                        1000,
+                        draft.description,
+                        false
+                ));
+                case ACTION_EDIT_MAP -> context.openRoute(MenuRoute.of(ROUTE_MAP_SELECTION).withParam("page", "1"));
+                case ACTION_TOGGLE_TEMPORARY -> {
+                    eventEditorService.toggleTemporary(draft);
+                    context.render();
+                }
+                case ACTION_EDIT_PLANNED_START -> context.openPrompt(new MenuPrompt(
+                        PROMPT_EDIT_PLANNED_START,
+                        session.locale().t("event-menu-edit-planned-start-title"),
+                        "",
+                        64,
+                        "",
+                        false
+                ));
+                case ACTION_EDIT_PLANNED_END -> context.openPrompt(new MenuPrompt(
+                        PROMPT_EDIT_PLANNED_END,
+                        session.locale().t("event-menu-edit-planned-end-title"),
+                        "",
+                        10,
+                        "",
+                        false
+                ));
+                case ACTION_SAVE -> {
+                    if (eventEditorService.saveDraft(session)) {
+                        menu.events(uuid, 1);
+                    }
+                }
+                case ACTION_CANCEL_EDIT -> {
+                    eventEditorService.cancelDraft(session);
+                    menu.main(uuid);
+                }
+                case ACTION_TOGGLE_MAJOR -> {
+                    eventEditorService.toggleMajor(draft);
+                    context.render();
+                }
+                default -> {
+                }
+            }
+        }
+
+        @Override
+        public void onPromptSubmit(MenuRenderContext<EditState> context, String promptId, String text) {
+            Session session = context.session();
+            EventData draft = session.getDraft(EventData.class);
+
+            switch (promptId) {
+                case PROMPT_EDIT_NAME -> eventEditorService.updateName(draft, text);
+                case PROMPT_EDIT_DESCRIPTION -> eventEditorService.updateDescription(draft, text);
+                case PROMPT_EDIT_PLANNED_START -> eventEditorService.updatePlannedStartTime(draft, text);
+                case PROMPT_EDIT_PLANNED_END -> eventEditorService.updatePlannedEndTime(draft, text);
+                default -> {
+                    return;
+                }
+            }
+
+            context.render();
+        }
+
+        @Override
+        public void onPromptCancel(MenuRenderContext<EditState> context, String promptId) {
+            switch (promptId) {
+                case PROMPT_EDIT_NAME, PROMPT_EDIT_DESCRIPTION, PROMPT_EDIT_PLANNED_START, PROMPT_EDIT_PLANNED_END -> context.render();
+                default -> {
+                }
+            }
+        }
+    }
+
+    static final class MapSelectionFlow implements RoutedMenuFlow<MapSelectionState> {
+        private final EventMenu menu;
+        private final EventEditorService eventEditorService;
+        private final MapService mapService;
+
+        MapSelectionFlow(EventMenu menu, EventEditorService eventEditorService, MapService mapService) {
+            this.menu = menu;
+            this.eventEditorService = eventEditorService;
+            this.mapService = mapService;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_MAP_SELECTION;
+        }
+
+        @Override
+        public MapSelectionState createState(Session session, MenuRoute route, MapSelectionState currentState) {
+            MapSelectionState state = currentState == null ? new MapSelectionState() : currentState;
+            state.page = route.intParam("page", 1);
+            return state;
+        }
+
+        @Override
+        public Class<MapSelectionState> stateType() {
+            return MapSelectionState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<MapSelectionState> context) {
+            Session session = context.session();
+            Seq<Map> maps = mapService.getAvailableMaps();
+            var pagination = CustomGatherers.calculatePagination(maps.size, menu.globalConfig.mapsPerPage);
+
+            int validPage = pagination.clampPage(Math.max(1, context.state().page));
+            List<Map> pagedMaps = SeqStream.of(maps)
+                    .gather(CustomGatherers.page(menu.globalConfig.mapsPerPage, validPage))
+                    .flatMap(List::stream)
+                    .toList();
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+
+            List<MenuButton> paginationRow = new ArrayList<>();
+            if (validPage > 1) {
+                paginationRow.add(MenuButton.of(session.locale().t("previous"), ACTION_PREVIOUS));
+            }
+            if (validPage < pagination.totalPages()) {
+                paginationRow.add(MenuButton.of(session.locale().t("next"), ACTION_NEXT));
+            }
+            if (!paginationRow.isEmpty()) {
+                rows.add(paginationRow);
+            }
+
+            for (int i = 0; i < pagedMaps.size(); i++) {
+                Map map = pagedMaps.get(i);
+                rows.add(List.of(MenuButton.of(map.name(), ACTION_MAP_PREFIX + i)));
+            }
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.hasHistory() || session.hasRouteHistory()) {
+                navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.normal(
+                    session.locale().t("event-menu-maps-title"),
+                    session.locale().t("event-menu-maps-content", args("page", validPage, "total", pagination.totalPages())),
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<MapSelectionState> context, String actionId) {
+            Session session = context.session();
+            String uuid = menu.getUuid(session);
+            int currentPage = Math.max(1, context.state().page);
+
+            switch (actionId) {
+                case ACTION_PREVIOUS -> session.menuService.renderRoute(session,
+                        MenuRoute.of(ROUTE_MAP_SELECTION).withParam("page", String.valueOf(currentPage - 1)));
+                case ACTION_NEXT -> session.menuService.renderRoute(session,
+                        MenuRoute.of(ROUTE_MAP_SELECTION).withParam("page", String.valueOf(currentPage + 1)));
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                default -> {
+                    if (!actionId.startsWith(ACTION_MAP_PREFIX)) {
+                        return;
+                    }
+
+                    int index;
+                    try {
+                        index = Integer.parseInt(actionId.substring(ACTION_MAP_PREFIX.length()));
+                    } catch (NumberFormatException ignored) {
+                        return;
+                    }
+
+                    List<Map> pagedMaps = SeqStream.of(mapService.getAvailableMaps())
+                            .gather(CustomGatherers.page(menu.globalConfig.mapsPerPage, currentPage))
+                            .flatMap(List::stream)
+                            .toList();
+                    if (index < 0 || index >= pagedMaps.size()) {
+                        return;
+                    }
+
+                    Map map = pagedMaps.get(index);
+                    eventEditorService.selectMapForDraft(session, map.plainName(), map.file.name(), map.author(), Vars.state.rules.mode().name());
+                    menu.edit(uuid);
+                }
+            }
+        }
+    }
+
+    static final class CreateStartState {
+    }
+
+    static final class EditState {
+    }
+
+    static final class MapSelectionState {
+        public int page = 1;
+    }
+
+    private static MenuScreen placeholderScreen() {
+        return MenuScreen.normal("", "", List.of());
+    }
+}

--- a/src/main/java/org/xcore/plugin/ui/menu/EventDraftFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/EventDraftFlows.java
@@ -348,7 +348,7 @@ final class EventDraftFlows {
             }
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));

--- a/src/main/java/org/xcore/plugin/ui/menu/EventDraftFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/EventDraftFlows.java
@@ -348,7 +348,7 @@ final class EventDraftFlows {
             }
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack(true)) {
+            if (session.canGoBack()) {
                 navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));

--- a/src/main/java/org/xcore/plugin/ui/menu/EventFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/EventFlows.java
@@ -1,0 +1,451 @@
+package org.xcore.plugin.ui.menu;
+
+import org.bson.types.ObjectId;
+import org.xcore.plugin.common.StatusEnum;
+import org.xcore.plugin.model.EventData;
+import org.xcore.plugin.model.MapData;
+import org.xcore.plugin.model.PlayerData;
+import org.xcore.plugin.service.EventService;
+import org.xcore.plugin.service.EventViewService;
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuRenderContext;
+import org.xcore.plugin.ui.flow.MenuScreen;
+import org.xcore.plugin.ui.route.MenuRoute;
+import org.xcore.plugin.ui.route.RoutedMenuFlow;
+import org.xcore.plugin.vote.VoteEvent;
+import org.xcore.plugin.vote.VoteService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.ospx.flubundle.Bundle.args;
+
+final class EventFlows {
+
+    static final String ROUTE_MAIN = "event.main";
+    static final String ROUTE_EVENTS = "event.events";
+    static final String ROUTE_EVENT = "event.details";
+
+    private static final String ACTION_CREATE_START = "create-start";
+    private static final String ACTION_EVENTS = "events";
+    private static final String ACTION_THIS_EVENT = "this-event";
+    private static final String ACTION_VOTE_STOP = "vote-stop";
+    private static final String ACTION_STOP = "stop";
+    private static final String ACTION_LIKE = "like";
+    private static final String ACTION_DISLIKE = "dislike";
+    private static final String ACTION_VOTE = "vote";
+    private static final String ACTION_ADMIN_VOTE = "admin-vote";
+    private static final String ACTION_EDIT = "edit";
+    private static final String ACTION_EVENT_MAP = "event-map";
+    private static final String ACTION_PREVIOUS = "previous";
+    private static final String ACTION_NEXT = "next";
+    private static final String ACTION_BACK = "back";
+    private static final String ACTION_CLOSE = "close";
+    private static final String ACTION_MAIN = "main";
+    private static final String ACTION_STATUS_PREFIX = "status:";
+    private static final String ACTION_EVENT_PREFIX = "event:";
+
+    private EventFlows() {
+    }
+
+    static final class MainFlow implements RoutedMenuFlow<MainState> {
+        private final EventMenu menu;
+        private final EventViewService eventViewService;
+        private final VoteService voteService;
+        private final EventService eventService;
+
+        MainFlow(EventMenu menu, EventViewService eventViewService, VoteService voteService, EventService eventService) {
+            this.menu = menu;
+            this.eventViewService = eventViewService;
+            this.voteService = voteService;
+            this.eventService = eventService;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_MAIN;
+        }
+
+        @Override
+        public MainState createState(Session session, MenuRoute route, MainState currentState) {
+            return currentState == null ? new MainState() : currentState;
+        }
+
+        @Override
+        public Class<MainState> stateType() {
+            return MainState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<MainState> context) {
+            Session session = context.session();
+            var local = context.locale();
+            EventData active = eventViewService.activeEvent();
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+            rows.add(List.of(
+                    MenuButton.of(local.t("event-menu-create-start"), ACTION_CREATE_START),
+                    MenuButton.of(local.t("event-menu-events"), ACTION_EVENTS)
+            ));
+
+            if (active != null) {
+                rows.add(List.of(MenuButton.of(local.t("event-menu-this-event"), ACTION_THIS_EVENT)));
+            }
+
+            if (session.player.admin) {
+                List<MenuButton> adminRow = new ArrayList<>();
+                if (voteService.getCurrentSession() instanceof VoteEvent) {
+                    adminRow.add(MenuButton.of(local.t("event-menu-vote-stop"), ACTION_VOTE_STOP));
+                }
+                if (active != null && active.isActive) {
+                    adminRow.add(MenuButton.of(local.t("event-menu-stop"), ACTION_STOP));
+                }
+                if (!adminRow.isEmpty()) {
+                    rows.add(adminRow);
+                }
+            }
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.canGoBack()) {
+                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.normal(
+                    local.t("event-menu-main-title"),
+                    local.t("event-menu-main-content"),
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<MainState> context, String actionId) {
+            Session session = context.session();
+            String uuid = menu.getUuid(session);
+            EventData active = eventViewService.activeEvent();
+
+            switch (actionId) {
+                case ACTION_CREATE_START -> menu.createStart(uuid, null);
+                case ACTION_EVENTS -> context.openRoute(MenuRoute.of(ROUTE_EVENTS).withParam("page", "1"));
+                case ACTION_THIS_EVENT -> {
+                    if (active != null && active.id != null) {
+                        context.openRoute(MenuRoute.of(ROUTE_EVENT).withParam("eventId", active.id.toHexString()));
+                    }
+                }
+                case ACTION_VOTE_STOP -> voteService.endVote();
+                case ACTION_STOP -> eventService.finishActiveEvent();
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                default -> {
+                }
+            }
+        }
+    }
+
+    static final class EventsFlow implements RoutedMenuFlow<EventsState> {
+        private final EventMenu menu;
+        private final EventViewService eventViewService;
+
+        EventsFlow(EventMenu menu, EventViewService eventViewService) {
+            this.menu = menu;
+            this.eventViewService = eventViewService;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_EVENTS;
+        }
+
+        @Override
+        public EventsState createState(Session session, MenuRoute route, EventsState currentState) {
+            EventsState state = currentState == null ? new EventsState() : currentState;
+            state.page = route.intParam("page", 1);
+            return state;
+        }
+
+        @Override
+        public Class<EventsState> stateType() {
+            return EventsState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<EventsState> context) {
+            Session session = context.session();
+            String uuid = menu.getUuid(session);
+            int requestedPage = Math.max(1, context.state().page);
+            int perPage = menu.globalConfig.eventsPerPage;
+            EventViewService.EventPage eventPage = eventViewService.page(requestedPage, perPage, session.sortStatus);
+
+            String menuContent;
+            if (eventPage.isEmpty()) {
+                menuContent = session.locale().t("event-menu-events-empty");
+            } else {
+                menuContent = session.locale().t("event-menu-events-content", args(
+                        "page", eventPage.page(),
+                        "total", eventPage.totalPages()
+                ));
+            }
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+
+            rows.add(List.of(MenuButton.of(
+                    session.locale().t("finished-" + session.sortStatus.getOrDefault("finished", StatusEnum.Neutral).name().toLowerCase()),
+                    ACTION_STATUS_PREFIX + "finished")));
+            rows.add(List.of(MenuButton.of(
+                    session.locale().t("major-" + session.sortStatus.getOrDefault("major", StatusEnum.Neutral).name().toLowerCase()),
+                    ACTION_STATUS_PREFIX + "major")));
+            rows.add(List.of(MenuButton.of(
+                    session.locale().t("active-" + session.sortStatus.getOrDefault("active", StatusEnum.Neutral).name().toLowerCase()),
+                    ACTION_STATUS_PREFIX + "active")));
+
+            List<MenuButton> paginationRow = new ArrayList<>();
+            if (eventPage.hasPrevious()) {
+                paginationRow.add(MenuButton.of(session.locale().t("previous"), ACTION_PREVIOUS));
+            }
+            if (eventPage.hasNext()) {
+                paginationRow.add(MenuButton.of(session.locale().t("next"), ACTION_NEXT));
+            }
+            if (!paginationRow.isEmpty()) {
+                rows.add(paginationRow);
+            }
+
+            for (EventData e : eventPage.events()) {
+                String text = e.isActive ? session.locale().t("event-menu-events-selected", args("name", e.name)) : e.name;
+                rows.add(List.of(MenuButton.of(text, ACTION_EVENT_PREFIX + e.id.toHexString())));
+            }
+
+            rows.add(List.of(MenuButton.of(session.locale().t("event-menu-main"), ACTION_MAIN)));
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.canGoBack()) {
+                navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.normal(
+                    session.locale().t("event-menu-events-title"),
+                    menuContent,
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<EventsState> context, String actionId) {
+            Session session = context.session();
+            String uuid = menu.getUuid(session);
+            int currentPage = Math.max(1, context.state().page);
+
+            switch (actionId) {
+                case ACTION_PREVIOUS -> session.menuService.renderRoute(session,
+                        MenuRoute.of(ROUTE_EVENTS).withParam("page", String.valueOf(currentPage - 1)));
+                case ACTION_NEXT -> session.menuService.renderRoute(session,
+                        MenuRoute.of(ROUTE_EVENTS).withParam("page", String.valueOf(currentPage + 1)));
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                case ACTION_MAIN -> {
+                    menu.main(uuid);
+                }
+                default -> {
+                    if (actionId.startsWith(ACTION_STATUS_PREFIX)) {
+                        String statusKey = actionId.substring(ACTION_STATUS_PREFIX.length());
+                        session.setNextStatus(statusKey);
+                        session.menuService.renderRoute(session, MenuRoute.of(ROUTE_EVENTS).withParam("page", "1"));
+                    } else if (actionId.startsWith(ACTION_EVENT_PREFIX)) {
+                        String eventId = actionId.substring(ACTION_EVENT_PREFIX.length());
+                        EventData event = eventViewService.findById(new ObjectId(eventId));
+                        if (event != null) {
+                            context.openRoute(MenuRoute.of(ROUTE_EVENT).withParam("eventId", eventId));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    static final class EventFlow implements RoutedMenuFlow<EventState> {
+        private final EventMenu menu;
+        private final EventViewService eventViewService;
+        private final VoteService voteService;
+        private final EventService eventService;
+
+        EventFlow(EventMenu menu, EventViewService eventViewService, VoteService voteService, EventService eventService) {
+            this.menu = menu;
+            this.eventViewService = eventViewService;
+            this.voteService = voteService;
+            this.eventService = eventService;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_EVENT;
+        }
+
+        @Override
+        public EventState createState(Session session, MenuRoute route, EventState currentState) {
+            EventState state = currentState == null ? new EventState() : currentState;
+            String eventId = route.param("eventId");
+            state.eventId = eventId == null ? "" : eventId;
+            return state;
+        }
+
+        @Override
+        public Class<EventState> stateType() {
+            return EventState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<EventState> context) {
+            Session session = context.session();
+            EventViewService.EventDetails details = resolveEventDetails(eventViewService, context.state().eventId);
+            if (details == null || details.event() == null) {
+                return eventNotFoundScreen(session);
+            }
+
+            EventData event = details.event();
+            MapData mapData = details.map();
+            PlayerData authorData = details.author();
+
+            String yes = session.locale().t("yes");
+            String no = session.locale().t("no");
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+            Boolean currentVote = session.data.eventVotes.get(event.id.toString());
+            String likeTxt = Boolean.TRUE.equals(currentVote) ? session.locale().t("map-vote-like-selected") : session.locale().t("map-vote-like");
+            String dislikeTxt = Boolean.FALSE.equals(currentVote) ? session.locale().t("map-vote-dislike-selected") : session.locale().t("map-vote-dislike");
+            rows.add(List.of(
+                    MenuButton.of(likeTxt, ACTION_LIKE),
+                    MenuButton.of(dislikeTxt, ACTION_DISLIKE)
+            ));
+
+            if (!voteService.isVoting()) {
+                List<MenuButton> voteRow = new ArrayList<>();
+                voteRow.add(MenuButton.of(session.locale().t("event-vote"), ACTION_VOTE));
+                if (session.player.admin) {
+                    voteRow.add(MenuButton.of(session.locale().t("event-avote"), ACTION_ADMIN_VOTE));
+                }
+                rows.add(voteRow);
+            }
+
+            boolean isOwner = session.data.id != null && session.data.id.equals(event.author);
+            if (!event.isFinished && !event.isActive && (!event.isMajor || session.player.admin) && (isOwner || session.player.admin)) {
+                rows.add(List.of(MenuButton.of(session.locale().t("event-menu-edit"), ACTION_EDIT)));
+            }
+
+            rows.add(List.of(MenuButton.of(session.locale().t("event-menu-events"), ACTION_EVENTS)));
+
+            if (mapData != null) {
+                rows.add(List.of(MenuButton.of(session.locale().t("event-menu-event-map"), ACTION_EVENT_MAP)));
+            }
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.canGoBack()) {
+                navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.normal(
+                    session.locale().t("event-menu-event-title"),
+                    session.locale().t("event-menu-event-content", args(
+                            "name", event.name,
+                            "description", event.description,
+                            "author", (authorData == null) ? "Unknown" : authorData.nickname,
+                            "mapName", (mapData == null) ? "" : mapData.name,
+                            "isMajor", event.isMajor ? yes : no,
+                            "isConducted", event.isFinished ? yes : no,
+                            "isActive", event.isActive ? yes : no,
+                            "isTemporary", event.isTemporary ? yes : no,
+                            "createdEventTime", menu.formatTime(event.createdModelTime, session),
+                            "plannedStartTime", menu.formatTime(event.plannedStartTime, session),
+                            "plannedEndTime", menu.formatTime(event.plannedEndTime, session),
+                            "like", event.like,
+                            "dislike", event.dislike
+                    )),
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<EventState> context, String actionId) {
+            Session session = context.session();
+            EventViewService.EventDetails details = resolveEventDetails(eventViewService, context.state().eventId);
+            if (details == null || details.event() == null) {
+                switch (actionId) {
+                    case ACTION_BACK -> context.goBack();
+                    case ACTION_CLOSE -> context.close();
+                    default -> {
+                    }
+                }
+                return;
+            }
+
+            EventData event = details.event();
+            MapData mapData = details.map();
+            String uuid = menu.getUuid(session);
+
+            switch (actionId) {
+                case ACTION_LIKE -> {
+                    eventService.handleReputation(session.player, true, event);
+                    context.render();
+                }
+                case ACTION_DISLIKE -> {
+                    eventService.handleReputation(session.player, false, event);
+                    context.render();
+                }
+                case ACTION_VOTE -> eventService.startVoteSession(session.player, event, false);
+                case ACTION_ADMIN_VOTE -> eventService.startVoteSession(session.player, event, true);
+                case ACTION_EDIT -> {
+                    session.setDraft(EventData.class, event);
+                    menu.edit(uuid);
+                }
+                case ACTION_EVENTS -> context.openRoute(MenuRoute.of(ROUTE_EVENTS).withParam("page", "1"));
+                case ACTION_EVENT_MAP -> {
+                    if (mapData != null && mapData.id != null) {
+                        context.openRoute(MenuRoute.of("map.details").withParam("mapId", mapData.id.toHexString()));
+                    }
+                }
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                default -> {
+                }
+            }
+        }
+    }
+
+    static EventViewService.EventDetails resolveEventDetails(EventViewService eventViewService, String eventId) {
+        try {
+            ObjectId id = new ObjectId(eventId);
+            return eventViewService.details(eventViewService.findById(id));
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+
+    static MenuScreen eventNotFoundScreen(Session session) {
+        List<MenuButton> navigation = new ArrayList<>();
+        if (session.canGoBack()) {
+            navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
+        }
+        navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
+
+        return MenuScreen.normal(
+                session.locale().t("event-menu-event-title"),
+                session.locale().t("error-internal"),
+                List.of(navigation)
+        );
+    }
+
+    static final class MainState {
+    }
+
+    static final class EventsState {
+        public int page = 1;
+    }
+
+    static final class EventState {
+        public String eventId = "";
+    }
+}

--- a/src/main/java/org/xcore/plugin/ui/menu/EventMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/EventMenu.java
@@ -145,7 +145,7 @@ public class EventMenu extends Menu {
             }
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -283,7 +283,7 @@ public class EventMenu extends Menu {
             rows.add(List.of(MenuButton.of(session.locale().t("event-menu-main"), ACTION_MAIN)));
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
@@ -394,7 +394,7 @@ public class EventMenu extends Menu {
             }
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
@@ -479,7 +479,7 @@ public class EventMenu extends Menu {
 
     private MenuScreen eventNotFoundScreen(Session session) {
         List<MenuButton> navigation = new ArrayList<>();
-        if (session.hasHistory() || session.hasRouteHistory()) {
+        if (session.canGoBack(true)) {
             navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
         }
         navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));

--- a/src/main/java/org/xcore/plugin/ui/menu/EventMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/EventMenu.java
@@ -1,18 +1,13 @@
 package org.xcore.plugin.ui.menu;
 
-import arc.struct.Seq;
-import mindustry.maps.Map;
 import io.avaje.inject.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
-import org.bson.types.ObjectId;
-import org.xcore.plugin.common.StatusEnum;
 import org.xcore.plugin.config.Config;
 import org.xcore.plugin.config.GlobalConfig;
 import org.xcore.plugin.model.EventData;
 import org.xcore.plugin.model.MapData;
-import org.xcore.plugin.model.PlayerData;
 import org.xcore.plugin.service.EventEditorService;
 import org.xcore.plugin.service.EventService;
 import org.xcore.plugin.service.EventViewService;
@@ -20,43 +15,11 @@ import org.xcore.plugin.service.MapService;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
 import org.xcore.plugin.ui.MenuService;
-import org.xcore.plugin.ui.flow.MenuButton;
-import org.xcore.plugin.ui.flow.MenuRenderContext;
-import org.xcore.plugin.ui.flow.MenuScreen;
 import org.xcore.plugin.ui.route.MenuRoute;
-import org.xcore.plugin.ui.route.RoutedMenuFlow;
-import org.xcore.plugin.vote.VoteEvent;
 import org.xcore.plugin.vote.VoteService;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static com.ospx.flubundle.Bundle.args;
 
 @Singleton
 public class EventMenu extends Menu {
-
-    private static final String ROUTE_MAIN = "event.main";
-    private static final String ROUTE_EVENTS = "event.events";
-    private static final String ROUTE_EVENT = "event.details";
-    private static final String ACTION_CREATE_START = "create-start";
-    private static final String ACTION_EVENTS = "events";
-    private static final String ACTION_THIS_EVENT = "this-event";
-    private static final String ACTION_VOTE_STOP = "vote-stop";
-    private static final String ACTION_STOP = "stop";
-    private static final String ACTION_LIKE = "like";
-    private static final String ACTION_DISLIKE = "dislike";
-    private static final String ACTION_VOTE = "vote";
-    private static final String ACTION_ADMIN_VOTE = "admin-vote";
-    private static final String ACTION_EDIT = "edit";
-    private static final String ACTION_EVENT_MAP = "event-map";
-    private static final String ACTION_PREVIOUS = "previous";
-    private static final String ACTION_NEXT = "next";
-    private static final String ACTION_BACK = "back";
-    private static final String ACTION_CLOSE = "close";
-    private static final String ACTION_MAIN = "main";
-    private static final String ACTION_STATUS_PREFIX = "status:";
-    private static final String ACTION_EVENT_PREFIX = "event:";
 
     private final MapService mapService;
     private final EventService eventService;
@@ -83,10 +46,10 @@ public class EventMenu extends Menu {
 
     @PostConstruct
     public void init() {
-        menuService.registerRoute(new MainFlow());
+        menuService.registerRoute(new EventFlows.MainFlow(this, eventViewService, voteService, eventService));
         menuService.registerRoute(new EventDraftFlows.CreateStartFlow(this, eventEditorService));
-        menuService.registerRoute(new EventsFlow());
-        menuService.registerRoute(new EventFlow());
+        menuService.registerRoute(new EventFlows.EventsFlow(this, eventViewService));
+        menuService.registerRoute(new EventFlows.EventFlow(this, eventViewService, voteService, eventService));
         menuService.registerRoute(new EventDraftFlows.EditFlow(this, eventEditorService));
         menuService.registerRoute(new EventDraftFlows.MapSelectionFlow(this, eventEditorService, mapService));
     }
@@ -96,90 +59,7 @@ public class EventMenu extends Menu {
         if (session == null || session.data == null) return;
         session.clear();
 
-        session.menuService.renderRoute(session, MenuRoute.of(ROUTE_MAIN));
-    }
-
-    private final class MainFlow implements RoutedMenuFlow<MainState> {
-        @Override
-        public String routeId() {
-            return ROUTE_MAIN;
-        }
-
-        @Override
-        public MainState createState(Session session, MenuRoute route, MainState currentState) {
-            return currentState == null ? new MainState() : currentState;
-        }
-
-        @Override
-        public Class<MainState> stateType() {
-            return MainState.class;
-        }
-
-        @Override
-        public MenuScreen render(MenuRenderContext<MainState> context) {
-            Session session = context.session();
-            var local = context.locale();
-            EventData active = eventViewService.activeEvent();
-
-            List<List<MenuButton>> rows = new ArrayList<>();
-            rows.add(List.of(
-                    MenuButton.of(local.t("event-menu-create-start"), ACTION_CREATE_START),
-                    MenuButton.of(local.t("event-menu-events"), ACTION_EVENTS)
-            ));
-
-            if (active != null) {
-                rows.add(List.of(MenuButton.of(local.t("event-menu-this-event"), ACTION_THIS_EVENT)));
-            }
-
-            if (session.player.admin) {
-                List<MenuButton> adminRow = new ArrayList<>();
-                if (voteService.getCurrentSession() instanceof VoteEvent) {
-                    adminRow.add(MenuButton.of(local.t("event-menu-vote-stop"), ACTION_VOTE_STOP));
-                }
-                if (active != null && active.isActive) {
-                    adminRow.add(MenuButton.of(local.t("event-menu-stop"), ACTION_STOP));
-                }
-                if (!adminRow.isEmpty()) {
-                    rows.add(adminRow);
-                }
-            }
-
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack(true)) {
-                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
-            rows.add(navigation);
-
-            return MenuScreen.normal(
-                    local.t("event-menu-main-title"),
-                    local.t("event-menu-main-content"),
-                    rows
-            );
-        }
-
-        @Override
-        public void onAction(MenuRenderContext<MainState> context, String actionId) {
-            Session session = context.session();
-            String uuid = getUuid(session);
-            EventData active = eventViewService.activeEvent();
-
-            switch (actionId) {
-                case ACTION_CREATE_START -> createStart(uuid, null);
-                case ACTION_EVENTS -> context.openRoute(MenuRoute.of(ROUTE_EVENTS).withParam("page", "1"));
-                case ACTION_THIS_EVENT -> {
-                    if (active != null && active.id != null) {
-                        context.openRoute(MenuRoute.of(ROUTE_EVENT).withParam("eventId", active.id.toHexString()));
-                    }
-                }
-                case ACTION_VOTE_STOP -> voteService.endVote();
-                case ACTION_STOP -> eventService.finishActiveEvent();
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                default -> {
-                }
-            }
-        }
+        session.menuService.renderRoute(session, MenuRoute.of(EventFlows.ROUTE_MAIN));
     }
 
     public void createStart(String uuid, MapData map) {
@@ -204,7 +84,7 @@ public class EventMenu extends Menu {
         if (session == null || session.data == null) return;
         session.clear();
         String eventId = event != null && event.id != null ? event.id.toHexString() : "";
-        session.menuService.renderRoute(session, MenuRoute.of(ROUTE_EVENT).withParam("eventId", eventId));
+        session.menuService.renderRoute(session, MenuRoute.of(EventFlows.ROUTE_EVENT).withParam("eventId", eventId));
     }
 
     public void events(String uuid, int page) {
@@ -212,297 +92,8 @@ public class EventMenu extends Menu {
         if (session == null || session.data == null) return;
         session.clear();
 
-        session.menuService.renderRoute(session, MenuRoute.of(ROUTE_EVENTS)
+        session.menuService.renderRoute(session, MenuRoute.of(EventFlows.ROUTE_EVENTS)
                 .withParam("page", String.valueOf(page)));
-    }
-
-    private final class EventsFlow implements RoutedMenuFlow<EventsState> {
-        @Override
-        public String routeId() {
-            return ROUTE_EVENTS;
-        }
-
-        @Override
-        public EventsState createState(Session session, MenuRoute route, EventsState currentState) {
-            EventsState state = currentState == null ? new EventsState() : currentState;
-            state.page = route.intParam("page", 1);
-            return state;
-        }
-
-        @Override
-        public Class<EventsState> stateType() {
-            return EventsState.class;
-        }
-
-        @Override
-        public MenuScreen render(MenuRenderContext<EventsState> context) {
-            Session session = context.session();
-            String uuid = getUuid(session);
-            int requestedPage = Math.max(1, context.state().page);
-            int perPage = globalConfig.eventsPerPage;
-            EventViewService.EventPage eventPage = eventViewService.page(requestedPage, perPage, session.sortStatus);
-
-            String menuContent;
-            if (eventPage.isEmpty()) {
-                menuContent = session.locale().t("event-menu-events-empty");
-            } else {
-                menuContent = session.locale().t("event-menu-events-content", args(
-                        "page", eventPage.page(),
-                        "total", eventPage.totalPages()
-                ));
-            }
-
-            List<List<MenuButton>> rows = new ArrayList<>();
-
-            rows.add(List.of(MenuButton.of(
-                    session.locale().t("finished-" + session.sortStatus.getOrDefault("finished", StatusEnum.Neutral).name().toLowerCase()),
-                    ACTION_STATUS_PREFIX + "finished")));
-            rows.add(List.of(MenuButton.of(
-                    session.locale().t("major-" + session.sortStatus.getOrDefault("major", StatusEnum.Neutral).name().toLowerCase()),
-                    ACTION_STATUS_PREFIX + "major")));
-            rows.add(List.of(MenuButton.of(
-                    session.locale().t("active-" + session.sortStatus.getOrDefault("active", StatusEnum.Neutral).name().toLowerCase()),
-                    ACTION_STATUS_PREFIX + "active")));
-
-            List<MenuButton> paginationRow = new ArrayList<>();
-            if (eventPage.hasPrevious()) {
-                paginationRow.add(MenuButton.of(session.locale().t("previous"), ACTION_PREVIOUS));
-            }
-            if (eventPage.hasNext()) {
-                paginationRow.add(MenuButton.of(session.locale().t("next"), ACTION_NEXT));
-            }
-            if (!paginationRow.isEmpty()) {
-                rows.add(paginationRow);
-            }
-
-            for (EventData e : eventPage.events()) {
-                String text = e.isActive ? session.locale().t("event-menu-events-selected", args("name", e.name)) : e.name;
-                rows.add(List.of(MenuButton.of(text, ACTION_EVENT_PREFIX + e.id.toHexString())));
-            }
-
-            rows.add(List.of(MenuButton.of(session.locale().t("event-menu-main"), ACTION_MAIN)));
-
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack(true)) {
-                navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
-            rows.add(navigation);
-
-            return MenuScreen.normal(
-                    session.locale().t("event-menu-events-title"),
-                    menuContent,
-                    rows
-            );
-        }
-
-        @Override
-        public void onAction(MenuRenderContext<EventsState> context, String actionId) {
-            Session session = context.session();
-            String uuid = getUuid(session);
-            int currentPage = Math.max(1, context.state().page);
-
-            switch (actionId) {
-                case ACTION_PREVIOUS -> session.menuService.renderRoute(session,
-                        MenuRoute.of(ROUTE_EVENTS).withParam("page", String.valueOf(currentPage - 1)));
-                case ACTION_NEXT -> session.menuService.renderRoute(session,
-                        MenuRoute.of(ROUTE_EVENTS).withParam("page", String.valueOf(currentPage + 1)));
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                case ACTION_MAIN -> {
-                    session.clearHistory();
-                    main(uuid);
-                }
-                default -> {
-                    if (actionId.startsWith(ACTION_STATUS_PREFIX)) {
-                        String statusKey = actionId.substring(ACTION_STATUS_PREFIX.length());
-                        session.setNextStatus(statusKey);
-                        session.menuService.renderRoute(session, MenuRoute.of(ROUTE_EVENTS).withParam("page", "1"));
-                    } else if (actionId.startsWith(ACTION_EVENT_PREFIX)) {
-                        String eventId = actionId.substring(ACTION_EVENT_PREFIX.length());
-                        EventData event = eventViewService.findById(new ObjectId(eventId));
-                        if (event != null) {
-                            context.openRoute(MenuRoute.of(ROUTE_EVENT).withParam("eventId", eventId));
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    private final class EventFlow implements RoutedMenuFlow<EventState> {
-        @Override
-        public String routeId() {
-            return ROUTE_EVENT;
-        }
-
-        @Override
-        public EventState createState(Session session, MenuRoute route, EventState currentState) {
-            EventState state = currentState == null ? new EventState() : currentState;
-            String eventId = route.param("eventId");
-            state.eventId = eventId == null ? "" : eventId;
-            return state;
-        }
-
-        @Override
-        public Class<EventState> stateType() {
-            return EventState.class;
-        }
-
-        @Override
-        public MenuScreen render(MenuRenderContext<EventState> context) {
-            Session session = context.session();
-            EventViewService.EventDetails details = resolveEventDetails(context.state().eventId);
-            if (details == null || details.event() == null) {
-                return eventNotFoundScreen(session);
-            }
-
-            EventData event = details.event();
-            MapData mapData = details.map();
-            PlayerData authorData = details.author();
-
-            String yes = session.locale().t("yes");
-            String no = session.locale().t("no");
-
-            List<List<MenuButton>> rows = new ArrayList<>();
-            Boolean currentVote = session.data.eventVotes.get(event.id.toString());
-            String likeTxt = Boolean.TRUE.equals(currentVote) ? session.locale().t("map-vote-like-selected") : session.locale().t("map-vote-like");
-            String dislikeTxt = Boolean.FALSE.equals(currentVote) ? session.locale().t("map-vote-dislike-selected") : session.locale().t("map-vote-dislike");
-            rows.add(List.of(
-                    MenuButton.of(likeTxt, ACTION_LIKE),
-                    MenuButton.of(dislikeTxt, ACTION_DISLIKE)
-            ));
-
-            if (!voteService.isVoting()) {
-                List<MenuButton> voteRow = new ArrayList<>();
-                voteRow.add(MenuButton.of(session.locale().t("event-vote"), ACTION_VOTE));
-                if (session.player.admin) {
-                    voteRow.add(MenuButton.of(session.locale().t("event-avote"), ACTION_ADMIN_VOTE));
-                }
-                rows.add(voteRow);
-            }
-
-            boolean isOwner = session.data.id != null && session.data.id.equals(event.author);
-            if (!event.isFinished && !event.isActive && (!event.isMajor || session.player.admin) && (isOwner || session.player.admin)) {
-                rows.add(List.of(MenuButton.of(session.locale().t("event-menu-edit"), ACTION_EDIT)));
-            }
-
-            rows.add(List.of(MenuButton.of(session.locale().t("event-menu-events"), ACTION_EVENTS)));
-
-            if (mapData != null) {
-                rows.add(List.of(MenuButton.of(session.locale().t("event-menu-event-map"), ACTION_EVENT_MAP)));
-            }
-
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack(true)) {
-                navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
-            rows.add(navigation);
-
-            return MenuScreen.normal(
-                    session.locale().t("event-menu-event-title"),
-                    session.locale().t("event-menu-event-content", args(
-                            "name", event.name,
-                            "description", event.description,
-                            "author", (authorData == null) ? "Unknown" : authorData.nickname,
-                            "mapName", (mapData == null) ? "" : mapData.name,
-                            "isMajor", event.isMajor ? yes : no,
-                            "isConducted", event.isFinished ? yes : no,
-                            "isActive", event.isActive ? yes : no,
-                            "isTemporary", event.isTemporary ? yes : no,
-                            "createdEventTime", formatTime(event.createdModelTime, session),
-                            "plannedStartTime", formatTime(event.plannedStartTime, session),
-                            "plannedEndTime", formatTime(event.plannedEndTime, session),
-                            "like", event.like,
-                            "dislike", event.dislike
-                    )),
-                    rows
-            );
-        }
-
-        @Override
-        public void onAction(MenuRenderContext<EventState> context, String actionId) {
-            Session session = context.session();
-            EventViewService.EventDetails details = resolveEventDetails(context.state().eventId);
-            if (details == null || details.event() == null) {
-                switch (actionId) {
-                    case ACTION_BACK -> context.goBack();
-                    case ACTION_CLOSE -> context.close();
-                    default -> {
-                    }
-                }
-                return;
-            }
-
-            EventData event = details.event();
-            MapData mapData = details.map();
-            String uuid = getUuid(session);
-
-            switch (actionId) {
-                case ACTION_LIKE -> {
-                    eventService.handleReputation(session.player, true, event);
-                    context.render();
-                }
-                case ACTION_DISLIKE -> {
-                    eventService.handleReputation(session.player, false, event);
-                    context.render();
-                }
-                case ACTION_VOTE -> eventService.startVoteSession(session.player, event, false);
-                case ACTION_ADMIN_VOTE -> eventService.startVoteSession(session.player, event, true);
-                case ACTION_EDIT -> {
-                    session.setDraft(event);
-                    edit(uuid);
-                }
-                case ACTION_EVENTS -> context.openRoute(MenuRoute.of(ROUTE_EVENTS).withParam("page", "1"));
-                case ACTION_EVENT_MAP -> {
-                    if (mapData != null && mapData.id != null) {
-                        context.openRoute(MenuRoute.of("map.details").withParam("mapId", mapData.id.toHexString()));
-                    }
-                }
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                default -> {
-                }
-            }
-        }
-    }
-
-    private EventViewService.EventDetails resolveEventDetails(String eventId) {
-        try {
-            ObjectId id = new ObjectId(eventId);
-            return eventViewService.details(eventViewService.findById(id));
-        } catch (IllegalArgumentException ignored) {
-            return null;
-        }
-    }
-
-    private MenuScreen eventNotFoundScreen(Session session) {
-        List<MenuButton> navigation = new ArrayList<>();
-        if (session.canGoBack(true)) {
-            navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
-        }
-        navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
-
-        return MenuScreen.normal(
-                session.locale().t("event-menu-event-title"),
-                session.locale().t("error-internal"),
-                List.of(navigation)
-        );
-    }
-
-    public static final class EventsState {
-        public int page = 1;
-    }
-
-    public static final class MainState {
-    }
-
-    public static final class CreateStartState {
-    }
-
-    public static final class EventState {
-        public String eventId = "";
     }
 
     public void mapSelection(String uuid, int page) {

--- a/src/main/java/org/xcore/plugin/ui/menu/EventMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/EventMenu.java
@@ -1,14 +1,13 @@
 package org.xcore.plugin.ui.menu;
 
 import arc.struct.Seq;
-import mindustry.Vars;
-import org.xcore.plugin.ui.flow.MenuPrompt;
 import mindustry.maps.Map;
+import io.avaje.inject.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
-import org.xcore.plugin.common.CustomGatherers;
-import org.xcore.plugin.common.SeqStream;
+import org.bson.types.ObjectId;
+import org.xcore.plugin.common.StatusEnum;
 import org.xcore.plugin.config.Config;
 import org.xcore.plugin.config.GlobalConfig;
 import org.xcore.plugin.model.EventData;
@@ -20,9 +19,16 @@ import org.xcore.plugin.service.EventViewService;
 import org.xcore.plugin.service.MapService;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.MenuService;
+import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuRenderContext;
+import org.xcore.plugin.ui.flow.MenuScreen;
+import org.xcore.plugin.ui.route.MenuRoute;
+import org.xcore.plugin.ui.route.RoutedMenuFlow;
 import org.xcore.plugin.vote.VoteEvent;
 import org.xcore.plugin.vote.VoteService;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.ospx.flubundle.Bundle.args;
@@ -30,23 +36,41 @@ import static com.ospx.flubundle.Bundle.args;
 @Singleton
 public class EventMenu extends Menu {
 
+    private static final String ROUTE_MAIN = "event.main";
+    private static final String ROUTE_EVENTS = "event.events";
+    private static final String ROUTE_EVENT = "event.details";
+    private static final String ACTION_CREATE_START = "create-start";
+    private static final String ACTION_EVENTS = "events";
+    private static final String ACTION_THIS_EVENT = "this-event";
+    private static final String ACTION_VOTE_STOP = "vote-stop";
+    private static final String ACTION_STOP = "stop";
+    private static final String ACTION_LIKE = "like";
+    private static final String ACTION_DISLIKE = "dislike";
+    private static final String ACTION_VOTE = "vote";
+    private static final String ACTION_ADMIN_VOTE = "admin-vote";
+    private static final String ACTION_EDIT = "edit";
+    private static final String ACTION_EVENT_MAP = "event-map";
+    private static final String ACTION_PREVIOUS = "previous";
+    private static final String ACTION_NEXT = "next";
+    private static final String ACTION_BACK = "back";
+    private static final String ACTION_CLOSE = "close";
+    private static final String ACTION_MAIN = "main";
+    private static final String ACTION_STATUS_PREFIX = "status:";
+    private static final String ACTION_EVENT_PREFIX = "event:";
+
     private final MapService mapService;
     private final EventService eventService;
     private final EventEditorService eventEditorService;
     private final EventViewService eventViewService;
     private final VoteService voteService;
     private final Provider<MapMenu> mapMenu;
-
-    private static final String PROMPT_CREATE_NAME = "event-create-name";
-    private static final String PROMPT_EDIT_NAME = "event-edit-name";
-    private static final String PROMPT_EDIT_DESCRIPTION = "event-edit-description";
-    private static final String PROMPT_EDIT_PLANNED_START = "event-edit-planned-start";
-    private static final String PROMPT_EDIT_PLANNED_END = "event-edit-planned-end";
+    private final MenuService menuService;
 
     @Inject
     public EventMenu(Config config, GlobalConfig globalConfig, SessionService sessionService,
                      MapService mapService, EventService eventService, EventEditorService eventEditorService,
-                     EventViewService eventViewService, VoteService voteService, Provider<MapMenu> mapMenu) {
+                     EventViewService eventViewService, VoteService voteService, Provider<MapMenu> mapMenu,
+                     MenuService menuService) {
         super(config, globalConfig, sessionService);
         this.mapService = mapService;
         this.eventService = eventService;
@@ -54,297 +78,439 @@ public class EventMenu extends Menu {
         this.eventViewService = eventViewService;
         this.voteService = voteService;
         this.mapMenu = mapMenu;
+        this.menuService = menuService;
+    }
+
+    @PostConstruct
+    public void init() {
+        menuService.registerRoute(new MainFlow());
+        menuService.registerRoute(new EventDraftFlows.CreateStartFlow(this, eventEditorService));
+        menuService.registerRoute(new EventsFlow());
+        menuService.registerRoute(new EventFlow());
+        menuService.registerRoute(new EventDraftFlows.EditFlow(this, eventEditorService));
+        menuService.registerRoute(new EventDraftFlows.MapSelectionFlow(this, eventEditorService, mapService));
     }
 
     public void main(String uuid) {
         Session session = sessionService.get(uuid);
         if (session == null || session.data == null) return;
         session.clear();
-        EventData active = eventViewService.activeEvent();
 
-        var builder = session.builder()
-                .title("event-menu-main-title")
-                .content("event-menu-main-content")
-                .start()
-                    .addLocal(session.locale().t("event-menu-create-start"), () -> {
-                        session.pushHistory(() -> main(uuid));
-                        createStart(uuid, null);
-                    })
-                    .addLocal(session.locale().t("event-menu-events"), () -> {
-                        session.pushHistory(() -> main(uuid));
-                        events(uuid, 1);
-                    })
-                .end();
+        session.menuService.renderRoute(session, MenuRoute.of(ROUTE_MAIN));
+    }
 
-        if (active != null) {
-            builder.addLocalRow("event-menu-this-event", () -> {
-                session.pushHistory(() -> main(uuid));
-                event(uuid, active);
-            });
+    private final class MainFlow implements RoutedMenuFlow<MainState> {
+        @Override
+        public String routeId() {
+            return ROUTE_MAIN;
         }
 
-        if (session.player.admin) {
-            builder.start();
-            if (voteService.getCurrentSession() instanceof VoteEvent) {
-                builder.addLocal(session.locale().t("event-menu-vote-stop"), voteService::endVote);
-            }
-            if (active != null && active.isActive) {
-                builder.addLocal(session.locale().t("event-menu-stop"), eventService::finishActiveEvent);
-            }
-            builder.end();
+        @Override
+        public MainState createState(Session session, MenuRoute route, MainState currentState) {
+            return currentState == null ? new MainState() : currentState;
         }
 
-        builder.addNavigationRow().show();
+        @Override
+        public Class<MainState> stateType() {
+            return MainState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<MainState> context) {
+            Session session = context.session();
+            var local = context.locale();
+            EventData active = eventViewService.activeEvent();
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+            rows.add(List.of(
+                    MenuButton.of(local.t("event-menu-create-start"), ACTION_CREATE_START),
+                    MenuButton.of(local.t("event-menu-events"), ACTION_EVENTS)
+            ));
+
+            if (active != null) {
+                rows.add(List.of(MenuButton.of(local.t("event-menu-this-event"), ACTION_THIS_EVENT)));
+            }
+
+            if (session.player.admin) {
+                List<MenuButton> adminRow = new ArrayList<>();
+                if (voteService.getCurrentSession() instanceof VoteEvent) {
+                    adminRow.add(MenuButton.of(local.t("event-menu-vote-stop"), ACTION_VOTE_STOP));
+                }
+                if (active != null && active.isActive) {
+                    adminRow.add(MenuButton.of(local.t("event-menu-stop"), ACTION_STOP));
+                }
+                if (!adminRow.isEmpty()) {
+                    rows.add(adminRow);
+                }
+            }
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.hasHistory() || session.hasRouteHistory()) {
+                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.normal(
+                    local.t("event-menu-main-title"),
+                    local.t("event-menu-main-content"),
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<MainState> context, String actionId) {
+            Session session = context.session();
+            String uuid = getUuid(session);
+            EventData active = eventViewService.activeEvent();
+
+            switch (actionId) {
+                case ACTION_CREATE_START -> createStart(uuid, null);
+                case ACTION_EVENTS -> context.openRoute(MenuRoute.of(ROUTE_EVENTS).withParam("page", "1"));
+                case ACTION_THIS_EVENT -> {
+                    if (active != null && active.id != null) {
+                        context.openRoute(MenuRoute.of(ROUTE_EVENT).withParam("eventId", active.id.toHexString()));
+                    }
+                }
+                case ACTION_VOTE_STOP -> voteService.endVote();
+                case ACTION_STOP -> eventService.finishActiveEvent();
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                default -> {
+                }
+            }
+        }
     }
 
     public void createStart(String uuid, MapData map) {
         Session session = sessionService.get(uuid);
         if (session == null || session.data == null) return;
         session.clear();
-        EventData draft = eventEditorService.initializeDraft(session, map);
-
-        session.menuService.openPrompt(session,
-                new MenuPrompt(PROMPT_CREATE_NAME,
-                        session.locale().t("event-menu-create-start-title"),
-                        session.locale().t("event-menu-create-start-message"),
-                        20,
-                        session.locale().t("event-menu-create-start-default", args("playerName", session.player.name)),
-                        false),
-                text -> {
-                    eventEditorService.updateName(draft, text);
-                    edit(uuid);
-                },
-                () -> {
-                    eventEditorService.cancelDraft(session);
-                    main(uuid);
-                });
+        eventEditorService.initializeDraft(session, map);
+        session.menuService.renderRoute(session, MenuRoute.of(EventDraftFlows.ROUTE_CREATE_START));
     }
 
     public void edit(String uuid) {
         Session session = sessionService.get(uuid);
         if (session == null || session.data == null) return;
-        session.clear();
         if (!session.hasDraft(EventData.class)) { main(uuid); return; }
+        session.clear();
 
-        EventData draft = session.getDraft(EventData.class);
-        MapData mapData = eventEditorService.findMapForDraft(draft);
-        PlayerData authorData = eventEditorService.findAuthorForDraft(draft);
-
-        String yes = session.locale().t("yes");
-        String no = session.locale().t("no");
-
-        session.builder()
-                .title("event-menu-edit-title")
-                .content("event-menu-edit-content", args(
-                        "name", draft.name, "description", draft.description,
-                        "author", (authorData == null) ? "Unknown" : authorData.nickname,
-                        "mapName", (mapData == null) ? "" : mapData.name,
-                        "isMajor", draft.isMajor ? yes : no,
-                        "isTemporary", draft.isTemporary ? yes : no,
-                        "plannedStartTime", formatTime(draft.plannedStartTime, session),
-                        "plannedEndTime",  formatTime(draft.plannedEndTime, session)
-                ))
-                .start()
-                    .addLocal(session.locale().t("event-menu-edit-name"), () -> {
-                        session.menuService.openPrompt(session,
-                                new MenuPrompt(PROMPT_EDIT_NAME,
-                                        session.locale().t("event-menu-edit-name-title"),
-                                        "",
-                                        24,
-                                        draft.name,
-                                        false),
-                                t -> { eventEditorService.updateName(draft, t); edit(uuid); },
-                                () -> edit(uuid));
-                    })
-                    .addLocal(session.locale().t("event-menu-edit-name-reset"), () -> {
-                        eventEditorService.resetName(draft);
-                        edit(uuid);
-                    })
-                    .addLocal(session.locale().t("event-menu-edit-description"), () -> {
-                        session.menuService.openPrompt(session,
-                                new MenuPrompt(PROMPT_EDIT_DESCRIPTION,
-                                        session.locale().t("event-menu-edit-description-title"),
-                                        "",
-                                        1000,
-                                        draft.description,
-                                        false),
-                                t -> { eventEditorService.updateDescription(draft, t); edit(uuid); },
-                                () -> edit(uuid));
-                    })
-                .end()
-                .start()
-                    .addLocal(session.locale().t("event-menu-edit-map"), () -> {
-                        session.pushHistory(() -> edit(uuid));
-                        mapSelection(uuid, 1);
-                    })
-                    .addLocal(draft.isTemporary ? session.locale().t("event-menu-edit-temporary-active") : session.locale().t("event-menu-edit-temporary-inactive"), () -> {
-                        eventEditorService.toggleTemporary(draft); edit(uuid);
-                    })
-                .end()
-                .start()
-                    .addLocal(session.locale().t("event-menu-edit-planned-start"), () -> {
-                        session.menuService.openPrompt(session,
-                                new MenuPrompt(PROMPT_EDIT_PLANNED_START,
-                                        session.locale().t("event-menu-edit-planned-start-title"),
-                                        "",
-                                        64,
-                                        "",
-                                        false),
-                                t -> { eventEditorService.updatePlannedStartTime(draft, t); edit(uuid); },
-                                () -> edit(uuid));
-                    })
-                    .addLocal(session.locale().t("event-menu-edit-planned-end"), () -> {
-                        session.menuService.openPrompt(session,
-                                new MenuPrompt(PROMPT_EDIT_PLANNED_END,
-                                        session.locale().t("event-menu-edit-planned-end-title"),
-                                        "",
-                                        10,
-                                        "",
-                                        false),
-                                t -> { eventEditorService.updatePlannedEndTime(draft, t); edit(uuid); },
-                                () -> edit(uuid));
-                    })
-                .end()
-                .start()
-                    .addLocal("[green]" + session.locale().t("save"), () -> {
-                        if (eventEditorService.saveDraft(session)) {
-                            events(uuid, 1);
-                        }
-                    })
-                    .addLocal("[red]" + session.locale().t("cancel"), () -> {
-                        eventEditorService.cancelDraft(session);
-                        main(uuid);
-                    })
-                .end()
-                .apply(b -> {
-                    if (session.player.admin) {
-                        b.addRow(draft.isMajor ? session.locale().t("event-menu-edit-major-active") : session.locale().t("event-menu-edit-major-inactive"), () -> {
-                            eventEditorService.toggleMajor(draft); edit(uuid);
-                        });
-                    }
-                })
-                .show();
+        session.menuService.renderRoute(session, MenuRoute.of(EventDraftFlows.ROUTE_EDIT));
     }
 
     public void event(String uuid, EventData event) {
         Session session = sessionService.get(uuid);
         if (session == null || session.data == null) return;
         session.clear();
-        EventViewService.EventDetails details = eventViewService.details(event);
-        MapData mapData = details.map();
-        PlayerData authorData = details.author();
-
-        String yes = session.locale().t("yes");
-        String no = session.locale().t("no");
-
-        var builder = session.builder()
-                .title("event-menu-event-title")
-                .content("event-menu-event-content", args(
-                        "name", event.name, "description", event.description,
-                        "author", (authorData == null) ? "Unknown" : authorData.nickname,
-                        "mapName", (mapData == null) ? "" : mapData.name,
-                        "isMajor", event.isMajor ? yes : no, "isConducted", event.isFinished ? yes : no,
-                        "isActive", event.isActive ? yes : no, "isTemporary", event.isTemporary ? yes : no,
-                        "createdEventTime", formatTime(event.createdModelTime, session),
-                        "plannedStartTime", formatTime(event.plannedStartTime, session),
-                        "plannedEndTime", formatTime(event.plannedEndTime, session),
-                        "like", event.like, "dislike", event.dislike
-                ));
-
-        Boolean currentVote = session.data.eventVotes.get(event.id.toString());
-        String likeTxt = Boolean.TRUE.equals(currentVote) ? session.locale().t("map-vote-like-selected") : session.locale().t("map-vote-like");
-        String dislikeTxt = Boolean.FALSE.equals(currentVote) ? session.locale().t("map-vote-dislike-selected") : session.locale().t("map-vote-dislike");
-
-        builder.addRow(likeTxt, () -> { eventService.handleReputation(session.player, true, event); event(uuid, event); },
-                       dislikeTxt, () -> { eventService.handleReputation(session.player, false, event); event(uuid, event); });
-
-        if (!voteService.isVoting()) {
-            builder.start()
-                .addLocal(session.locale().t("event-vote"), () -> eventService.startVoteSession(session.player, event, false))
-                .ifAdd(session.player.admin, session.locale().t("event-avote"), () -> eventService.startVoteSession(session.player, event, true))
-                .end();
-        }
-
-        boolean isOwner = session.data.id != null && session.data.id.equals(event.author);
-        if (!event.isFinished && !event.isActive && (!event.isMajor || session.player.admin) && (isOwner || session.player.admin)) {
-            builder.addLocalRow("event-menu-edit", () -> {
-                session.pushHistory(() -> event(uuid, event));
-                session.setDraft(event);
-                edit(uuid);
-            });
-        }
-
-        builder.addLocalRow("event-menu-events", () -> { session.pushHistory(() -> event(uuid, event)); events(uuid, 1); });
-
-        if (mapData != null) {
-            builder.addLocalRow("event-menu-event-map", () -> {
-                session.pushHistory(() -> event(uuid, event));
-                mapMenu.get().map(uuid, mapData);
-            });
-        }
-
-        builder.addNavigationRow().show();
+        String eventId = event != null && event.id != null ? event.id.toHexString() : "";
+        session.menuService.renderRoute(session, MenuRoute.of(ROUTE_EVENT).withParam("eventId", eventId));
     }
 
     public void events(String uuid, int page) {
         Session session = sessionService.get(uuid);
         if (session == null || session.data == null) return;
         session.clear();
-        int perPage = globalConfig.eventsPerPage;
-        EventViewService.EventPage eventPage = eventViewService.page(page, perPage, session.sortStatus);
 
-        String menuContent;
-        if (eventPage.isEmpty()) {
-            menuContent = session.locale().t("event-menu-events-empty");
-        } else {
-            menuContent = session.locale().t("event-menu-events-content", args(
-                "page", eventPage.page(),
-                "total", eventPage.totalPages()
-            ));
+        session.menuService.renderRoute(session, MenuRoute.of(ROUTE_EVENTS)
+                .withParam("page", String.valueOf(page)));
+    }
+
+    private final class EventsFlow implements RoutedMenuFlow<EventsState> {
+        @Override
+        public String routeId() {
+            return ROUTE_EVENTS;
         }
 
-        session.builder()
-                .title("event-menu-events-title")
-                .rawContent(menuContent)
-                .start()
-                    .addStatusButton("finished", () -> events(uuid, 1))
-                    .addStatusButton("major", () -> events(uuid, 1))
-                    .addStatusButton("active", () -> events(uuid, 1))
-                .end()
-                .start()
-                    .ifAddLocal(eventPage.hasPrevious(), "previous", () -> events(uuid, eventPage.page() - 1))
-                    .ifAddLocal(eventPage.hasNext(), "next", () -> events(uuid, eventPage.page() + 1))
-                .end()
-                .addForEach(eventPage.events(), (b, e) -> b.addRow(e.isActive ? session.locale().t("event-menu-events-selected", args("name", e.name)) : e.name, () -> {
-                    session.pushHistory(() -> events(uuid, eventPage.page()));
-                    event(uuid, e);
-                }))
-                .addLocalRow("event-menu-main", () -> { session.clearHistory(); main(uuid); })
-                .addNavigationRow()
-                .show();
+        @Override
+        public EventsState createState(Session session, MenuRoute route, EventsState currentState) {
+            EventsState state = currentState == null ? new EventsState() : currentState;
+            state.page = route.intParam("page", 1);
+            return state;
+        }
+
+        @Override
+        public Class<EventsState> stateType() {
+            return EventsState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<EventsState> context) {
+            Session session = context.session();
+            String uuid = getUuid(session);
+            int requestedPage = Math.max(1, context.state().page);
+            int perPage = globalConfig.eventsPerPage;
+            EventViewService.EventPage eventPage = eventViewService.page(requestedPage, perPage, session.sortStatus);
+
+            String menuContent;
+            if (eventPage.isEmpty()) {
+                menuContent = session.locale().t("event-menu-events-empty");
+            } else {
+                menuContent = session.locale().t("event-menu-events-content", args(
+                        "page", eventPage.page(),
+                        "total", eventPage.totalPages()
+                ));
+            }
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+
+            rows.add(List.of(MenuButton.of(
+                    session.locale().t("finished-" + session.sortStatus.getOrDefault("finished", StatusEnum.Neutral).name().toLowerCase()),
+                    ACTION_STATUS_PREFIX + "finished")));
+            rows.add(List.of(MenuButton.of(
+                    session.locale().t("major-" + session.sortStatus.getOrDefault("major", StatusEnum.Neutral).name().toLowerCase()),
+                    ACTION_STATUS_PREFIX + "major")));
+            rows.add(List.of(MenuButton.of(
+                    session.locale().t("active-" + session.sortStatus.getOrDefault("active", StatusEnum.Neutral).name().toLowerCase()),
+                    ACTION_STATUS_PREFIX + "active")));
+
+            List<MenuButton> paginationRow = new ArrayList<>();
+            if (eventPage.hasPrevious()) {
+                paginationRow.add(MenuButton.of(session.locale().t("previous"), ACTION_PREVIOUS));
+            }
+            if (eventPage.hasNext()) {
+                paginationRow.add(MenuButton.of(session.locale().t("next"), ACTION_NEXT));
+            }
+            if (!paginationRow.isEmpty()) {
+                rows.add(paginationRow);
+            }
+
+            for (EventData e : eventPage.events()) {
+                String text = e.isActive ? session.locale().t("event-menu-events-selected", args("name", e.name)) : e.name;
+                rows.add(List.of(MenuButton.of(text, ACTION_EVENT_PREFIX + e.id.toHexString())));
+            }
+
+            rows.add(List.of(MenuButton.of(session.locale().t("event-menu-main"), ACTION_MAIN)));
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.hasHistory() || session.hasRouteHistory()) {
+                navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.normal(
+                    session.locale().t("event-menu-events-title"),
+                    menuContent,
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<EventsState> context, String actionId) {
+            Session session = context.session();
+            String uuid = getUuid(session);
+            int currentPage = Math.max(1, context.state().page);
+
+            switch (actionId) {
+                case ACTION_PREVIOUS -> session.menuService.renderRoute(session,
+                        MenuRoute.of(ROUTE_EVENTS).withParam("page", String.valueOf(currentPage - 1)));
+                case ACTION_NEXT -> session.menuService.renderRoute(session,
+                        MenuRoute.of(ROUTE_EVENTS).withParam("page", String.valueOf(currentPage + 1)));
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                case ACTION_MAIN -> {
+                    session.clearHistory();
+                    main(uuid);
+                }
+                default -> {
+                    if (actionId.startsWith(ACTION_STATUS_PREFIX)) {
+                        String statusKey = actionId.substring(ACTION_STATUS_PREFIX.length());
+                        session.setNextStatus(statusKey);
+                        session.menuService.renderRoute(session, MenuRoute.of(ROUTE_EVENTS).withParam("page", "1"));
+                    } else if (actionId.startsWith(ACTION_EVENT_PREFIX)) {
+                        String eventId = actionId.substring(ACTION_EVENT_PREFIX.length());
+                        EventData event = eventViewService.findById(new ObjectId(eventId));
+                        if (event != null) {
+                            context.openRoute(MenuRoute.of(ROUTE_EVENT).withParam("eventId", eventId));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private final class EventFlow implements RoutedMenuFlow<EventState> {
+        @Override
+        public String routeId() {
+            return ROUTE_EVENT;
+        }
+
+        @Override
+        public EventState createState(Session session, MenuRoute route, EventState currentState) {
+            EventState state = currentState == null ? new EventState() : currentState;
+            String eventId = route.param("eventId");
+            state.eventId = eventId == null ? "" : eventId;
+            return state;
+        }
+
+        @Override
+        public Class<EventState> stateType() {
+            return EventState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<EventState> context) {
+            Session session = context.session();
+            EventViewService.EventDetails details = resolveEventDetails(context.state().eventId);
+            if (details == null || details.event() == null) {
+                return eventNotFoundScreen(session);
+            }
+
+            EventData event = details.event();
+            MapData mapData = details.map();
+            PlayerData authorData = details.author();
+
+            String yes = session.locale().t("yes");
+            String no = session.locale().t("no");
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+            Boolean currentVote = session.data.eventVotes.get(event.id.toString());
+            String likeTxt = Boolean.TRUE.equals(currentVote) ? session.locale().t("map-vote-like-selected") : session.locale().t("map-vote-like");
+            String dislikeTxt = Boolean.FALSE.equals(currentVote) ? session.locale().t("map-vote-dislike-selected") : session.locale().t("map-vote-dislike");
+            rows.add(List.of(
+                    MenuButton.of(likeTxt, ACTION_LIKE),
+                    MenuButton.of(dislikeTxt, ACTION_DISLIKE)
+            ));
+
+            if (!voteService.isVoting()) {
+                List<MenuButton> voteRow = new ArrayList<>();
+                voteRow.add(MenuButton.of(session.locale().t("event-vote"), ACTION_VOTE));
+                if (session.player.admin) {
+                    voteRow.add(MenuButton.of(session.locale().t("event-avote"), ACTION_ADMIN_VOTE));
+                }
+                rows.add(voteRow);
+            }
+
+            boolean isOwner = session.data.id != null && session.data.id.equals(event.author);
+            if (!event.isFinished && !event.isActive && (!event.isMajor || session.player.admin) && (isOwner || session.player.admin)) {
+                rows.add(List.of(MenuButton.of(session.locale().t("event-menu-edit"), ACTION_EDIT)));
+            }
+
+            rows.add(List.of(MenuButton.of(session.locale().t("event-menu-events"), ACTION_EVENTS)));
+
+            if (mapData != null) {
+                rows.add(List.of(MenuButton.of(session.locale().t("event-menu-event-map"), ACTION_EVENT_MAP)));
+            }
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.hasHistory() || session.hasRouteHistory()) {
+                navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.normal(
+                    session.locale().t("event-menu-event-title"),
+                    session.locale().t("event-menu-event-content", args(
+                            "name", event.name,
+                            "description", event.description,
+                            "author", (authorData == null) ? "Unknown" : authorData.nickname,
+                            "mapName", (mapData == null) ? "" : mapData.name,
+                            "isMajor", event.isMajor ? yes : no,
+                            "isConducted", event.isFinished ? yes : no,
+                            "isActive", event.isActive ? yes : no,
+                            "isTemporary", event.isTemporary ? yes : no,
+                            "createdEventTime", formatTime(event.createdModelTime, session),
+                            "plannedStartTime", formatTime(event.plannedStartTime, session),
+                            "plannedEndTime", formatTime(event.plannedEndTime, session),
+                            "like", event.like,
+                            "dislike", event.dislike
+                    )),
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<EventState> context, String actionId) {
+            Session session = context.session();
+            EventViewService.EventDetails details = resolveEventDetails(context.state().eventId);
+            if (details == null || details.event() == null) {
+                switch (actionId) {
+                    case ACTION_BACK -> context.goBack();
+                    case ACTION_CLOSE -> context.close();
+                    default -> {
+                    }
+                }
+                return;
+            }
+
+            EventData event = details.event();
+            MapData mapData = details.map();
+            String uuid = getUuid(session);
+
+            switch (actionId) {
+                case ACTION_LIKE -> {
+                    eventService.handleReputation(session.player, true, event);
+                    context.render();
+                }
+                case ACTION_DISLIKE -> {
+                    eventService.handleReputation(session.player, false, event);
+                    context.render();
+                }
+                case ACTION_VOTE -> eventService.startVoteSession(session.player, event, false);
+                case ACTION_ADMIN_VOTE -> eventService.startVoteSession(session.player, event, true);
+                case ACTION_EDIT -> {
+                    session.setDraft(event);
+                    edit(uuid);
+                }
+                case ACTION_EVENTS -> context.openRoute(MenuRoute.of(ROUTE_EVENTS).withParam("page", "1"));
+                case ACTION_EVENT_MAP -> {
+                    if (mapData != null && mapData.id != null) {
+                        context.openRoute(MenuRoute.of("map.details").withParam("mapId", mapData.id.toHexString()));
+                    }
+                }
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                default -> {
+                }
+            }
+        }
+    }
+
+    private EventViewService.EventDetails resolveEventDetails(String eventId) {
+        try {
+            ObjectId id = new ObjectId(eventId);
+            return eventViewService.details(eventViewService.findById(id));
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+
+    private MenuScreen eventNotFoundScreen(Session session) {
+        List<MenuButton> navigation = new ArrayList<>();
+        if (session.hasHistory() || session.hasRouteHistory()) {
+            navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
+        }
+        navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
+
+        return MenuScreen.normal(
+                session.locale().t("event-menu-event-title"),
+                session.locale().t("error-internal"),
+                List.of(navigation)
+        );
+    }
+
+    public static final class EventsState {
+        public int page = 1;
+    }
+
+    public static final class MainState {
+    }
+
+    public static final class CreateStartState {
+    }
+
+    public static final class EventState {
+        public String eventId = "";
     }
 
     public void mapSelection(String uuid, int page) {
         Session session = sessionService.get(uuid);
         if (session == null || session.data == null) return;
+        if (!session.hasDraft(EventData.class)) { main(uuid); return; }
         session.clear();
-        Seq<Map> maps = mapService.getAvailableMaps();
-        var pagination = CustomGatherers.calculatePagination(maps.size, globalConfig.mapsPerPage);
-
-        int validPage = pagination.clampPage(page);
-        session.builder()
-                .title("event-menu-maps-title")
-                .content("event-menu-maps-content", args("page", validPage, "total", pagination.totalPages()))
-                .start()
-                    .ifAddLocal(validPage > 1, "previous", () -> mapSelection(uuid, validPage - 1))
-                    .ifAddLocal(validPage < pagination.totalPages(), "next", () -> mapSelection(uuid, validPage + 1))
-                .end()
-                .addForEach(SeqStream.of(maps).gather(CustomGatherers.page(globalConfig.mapsPerPage, validPage)).flatMap(List::stream)::iterator, (b, m) -> b.addRow(m.name(), () -> {
-                    eventEditorService.selectMapForDraft(session, m.plainName(), m.file.name(), m.author(), Vars.state.rules.mode().name());
-                    edit(uuid);
-                }))
-                .addNavigationRow()
-                .show();
+        session.menuService.renderRoute(session, MenuRoute.of(EventDraftFlows.ROUTE_MAP_SELECTION)
+                .withParam("page", String.valueOf(page)));
     }
-
 }

--- a/src/main/java/org/xcore/plugin/ui/menu/HelpFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/HelpFlows.java
@@ -99,7 +99,7 @@ final class HelpFlows {
             }
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack(true)) {
+            if (session.canGoBack()) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -190,7 +190,7 @@ final class HelpFlows {
             rows.add(List.of(MenuButton.of(local.t("help-back"), ACTION_BACK)));
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack(true)) {
+            if (session.canGoBack()) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));

--- a/src/main/java/org/xcore/plugin/ui/menu/HelpFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/HelpFlows.java
@@ -99,7 +99,7 @@ final class HelpFlows {
             }
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -190,7 +190,7 @@ final class HelpFlows {
             rows.add(List.of(MenuButton.of(local.t("help-back"), ACTION_BACK)));
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));

--- a/src/main/java/org/xcore/plugin/ui/menu/HelpFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/HelpFlows.java
@@ -1,0 +1,224 @@
+package org.xcore.plugin.ui.menu;
+
+import org.xcore.plugin.cloud.XCoreSender;
+import org.xcore.plugin.common.CustomGatherers;
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuRenderContext;
+import org.xcore.plugin.ui.flow.MenuScreen;
+import org.xcore.plugin.ui.route.MenuRoute;
+import org.xcore.plugin.ui.route.RoutedMenuFlow;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import static com.ospx.flubundle.Bundle.args;
+
+final class HelpFlows {
+
+    static final String ROUTE_LIST = "help.list";
+    static final String ROUTE_DETAILS = "help.details";
+
+    private static final String ACTION_PREVIOUS = "previous";
+    private static final String ACTION_NEXT = "next";
+    private static final String ACTION_BACK = "back";
+    private static final String ACTION_CLOSE = "close";
+    private static final String CMD_PREFIX = "cmd:";
+
+    private static final int MAX_DESC_LEN = 40;
+
+    private HelpFlows() {
+    }
+
+    static final class HelpListFlow implements RoutedMenuFlow<HelpListState> {
+        private final HelpMenu menu;
+
+        HelpListFlow(HelpMenu menu) {
+            this.menu = menu;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_LIST;
+        }
+
+        @Override
+        public HelpListState createState(Session session, MenuRoute route, HelpListState currentState) {
+            return currentState == null ? new HelpListState() : currentState;
+        }
+
+        @Override
+        public Class<HelpListState> stateType() {
+            return HelpListState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<HelpListState> context) {
+            Session session = context.session();
+            XCoreSender sender = session.sender;
+            if (sender == null) {
+                return errorScreen(session);
+            }
+
+            int page = context.route().intParam("page", 1);
+            List<HelpMenu.UnifiedCommand> allCommands = menu.collectAllCommands(sender);
+            allCommands.sort(Comparator.comparing(HelpMenu.UnifiedCommand::name));
+
+            if (allCommands.isEmpty()) {
+                session.locale().send("empty");
+                return errorScreen(session);
+            }
+
+            var pagination = CustomGatherers.calculatePagination(allCommands.size(), menu.globalConfig.commandsPerPage);
+            int currentPage = pagination.clampPage(page);
+            int skip = (currentPage - 1) * menu.globalConfig.commandsPerPage;
+            List<HelpMenu.UnifiedCommand> pageSlice = allCommands.subList(skip, Math.min(skip + menu.globalConfig.commandsPerPage, allCommands.size()));
+
+            var local = context.locale();
+            List<List<MenuButton>> rows = new ArrayList<>();
+
+            List<MenuButton> paginationRow = new ArrayList<>();
+            if (currentPage > 1) {
+                paginationRow.add(MenuButton.of(local.t("previous"), ACTION_PREVIOUS));
+            }
+            if (currentPage < pagination.totalPages()) {
+                paginationRow.add(MenuButton.of(local.t("next"), ACTION_NEXT));
+            }
+            if (!paginationRow.isEmpty()) {
+                rows.add(paginationRow);
+            }
+
+            for (HelpMenu.UnifiedCommand cmd : pageSlice) {
+                String desc = menu.resolveDescription(session, cmd);
+                String btnText = local.t("help-menu-button", args(
+                        "command", menu.formatCommandLabel(session, cmd),
+                        "description", menu.truncate(desc, MAX_DESC_LEN)
+                ));
+                rows.add(List.of(MenuButton.of(btnText, CMD_PREFIX + cmd.name())));
+            }
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.hasHistory() || session.hasRouteHistory()) {
+                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.normal(
+                    local.t("help-menu-title"),
+                    local.t("help-menu-content", args("page", currentPage, "total", pagination.totalPages())),
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<HelpListState> context, String actionId) {
+            Session session = context.session();
+            int currentPage = context.route().intParam("page", 1);
+
+            switch (actionId) {
+                case ACTION_PREVIOUS -> session.menuService.renderRoute(session,
+                        MenuRoute.of(ROUTE_LIST).withParam("page", String.valueOf(currentPage - 1)));
+                case ACTION_NEXT -> session.menuService.renderRoute(session,
+                        MenuRoute.of(ROUTE_LIST).withParam("page", String.valueOf(currentPage + 1)));
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                default -> {
+                    if (actionId.startsWith(CMD_PREFIX)) {
+                        String cmdName = actionId.substring(CMD_PREFIX.length());
+                        context.openRoute(MenuRoute.of(ROUTE_DETAILS)
+                                .withParam("cmd", cmdName)
+                                .withParam("returnPage", String.valueOf(currentPage)));
+                    }
+                }
+            }
+        }
+    }
+
+    static final class HelpDetailsFlow implements RoutedMenuFlow<HelpDetailsState> {
+        private final HelpMenu menu;
+
+        HelpDetailsFlow(HelpMenu menu) {
+            this.menu = menu;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_DETAILS;
+        }
+
+        @Override
+        public HelpDetailsState createState(Session session, MenuRoute route, HelpDetailsState currentState) {
+            return currentState == null ? new HelpDetailsState() : currentState;
+        }
+
+        @Override
+        public Class<HelpDetailsState> stateType() {
+            return HelpDetailsState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<HelpDetailsState> context) {
+            Session session = context.session();
+            XCoreSender sender = session.sender;
+            String cmdName = context.route().param("cmd");
+
+            if (sender == null || cmdName == null) {
+                return errorScreen(session);
+            }
+
+            List<HelpMenu.UnifiedCommand> allCommands = menu.collectAllCommands(sender);
+            HelpMenu.UnifiedCommand cmd = allCommands.stream()
+                    .filter(command -> command.name().equalsIgnoreCase(cmdName))
+                    .findFirst()
+                    .orElse(null);
+
+            if (cmd == null) {
+                return MenuScreen.normal(
+                        session.locale().t("help-menu-title"),
+                        session.locale().t("error-command-not-found"),
+                        List.of(List.of(MenuButton.of(session.locale().t("back"), ACTION_BACK)))
+                );
+            }
+
+            String title = session.locale().t("help-command-title", args("name", cmd.name()));
+            String content = menu.buildCommandContent(session, cmd);
+            var local = context.locale();
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+            rows.add(List.of(MenuButton.of(local.t("help-back"), ACTION_BACK)));
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.hasHistory() || session.hasRouteHistory()) {
+                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.normal(title, content, rows);
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<HelpDetailsState> context, String actionId) {
+            switch (actionId) {
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+            }
+        }
+    }
+
+    static final class HelpListState {
+    }
+
+    static final class HelpDetailsState {
+    }
+
+    private static MenuScreen errorScreen(Session session) {
+        return MenuScreen.normal(
+                session.locale().t("help-menu-title"),
+                "",
+                List.of(List.of(MenuButton.of(session.locale().t("close"), ACTION_CLOSE)))
+        );
+    }
+}

--- a/src/main/java/org/xcore/plugin/ui/menu/HelpMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/HelpMenu.java
@@ -1,6 +1,7 @@
 package org.xcore.plugin.ui.menu;
 
 import arc.util.CommandHandler;
+import io.avaje.inject.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
@@ -11,13 +12,22 @@ import org.incendo.cloud.help.result.CommandEntry;
 import org.xcore.cloud.mindustry.MindustryCloudCommand;
 import org.xcore.plugin.cloud.CloudService;
 import org.xcore.plugin.cloud.XCoreSender;
-import org.xcore.plugin.common.CustomGatherers;
 import org.xcore.plugin.config.Config;
 import org.xcore.plugin.config.GlobalConfig;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.MenuService;
+import org.xcore.plugin.ui.route.MenuRoute;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
 import static com.ospx.flubundle.Bundle.args;
 
@@ -25,12 +35,19 @@ import static com.ospx.flubundle.Bundle.args;
 public class HelpMenu extends Menu {
 
     private final Provider<CloudService> cloud;
-    private static final int MAX_DESC_LEN = 40;
+    private final MenuService menuService;
 
     @Inject
-    public HelpMenu(Config config, GlobalConfig globalConfig, SessionService sessionService, Provider<CloudService> cloud) {
+    public HelpMenu(Config config, GlobalConfig globalConfig, SessionService sessionService, Provider<CloudService> cloud, MenuService menuService) {
         super(config, globalConfig, sessionService);
         this.cloud = cloud;
+        this.menuService = menuService;
+    }
+
+    @PostConstruct
+    public void init() {
+        menuService.registerRoute(new HelpFlows.HelpListFlow(this));
+        menuService.registerRoute(new HelpFlows.HelpDetailsFlow(this));
     }
 
     public void help(String uuid, int page) {
@@ -45,57 +62,17 @@ public class HelpMenu extends Menu {
         }
 
         List<UnifiedCommand> allCommands = collectAllCommands(sender);
-        allCommands.sort(Comparator.comparing(UnifiedCommand::name));
+        allCommands.sort(java.util.Comparator.comparing(UnifiedCommand::name));
 
         if (allCommands.isEmpty()) {
             session.locale().send("empty");
             return;
         }
 
-        var pagination = CustomGatherers.calculatePagination(allCommands.size(), globalConfig.commandsPerPage);
-        int currentPage = pagination.clampPage(page);
-        int skip = (currentPage - 1) * globalConfig.commandsPerPage;
-        List<UnifiedCommand> pageSlice = allCommands.subList(skip, Math.min(skip + globalConfig.commandsPerPage, allCommands.size()));
-
-        session.builder()
-                .title("help-menu-title")
-                .content("help-menu-content", args("page", currentPage, "total", pagination.totalPages()))
-                .start()
-                    .ifAdd(currentPage > 1, session.locale().t("previous"), () -> help(uuid, currentPage - 1))
-                    .ifAdd(currentPage < pagination.totalPages(), session.locale().t("next"), () -> help(uuid, currentPage + 1))
-                .end()
-                .addForEach(pageSlice, (builder, cmd) -> {
-                    String desc = resolveDescription(session, cmd);
-                    String btnText = session.locale().t("help-menu-button", args(
-                            "command", formatCommandLabel(session, cmd),
-                            "description", truncate(desc, MAX_DESC_LEN)
-                    ));
-                    builder.addRow(btnText, () -> {
-                        session.pushHistory(() -> help(uuid, currentPage));
-                        details(uuid, cmd, currentPage);
-                    });
-                })
-                .addNavigationRow()
-                .show();
+        session.menuService.renderRoute(session, MenuRoute.of(HelpFlows.ROUTE_LIST).withParam("page", String.valueOf(page)));
     }
 
-    private void details(String uuid, UnifiedCommand cmd, int returnPage) {
-        Session session = sessionService.get(uuid);
-        if (session == null || session.data == null) return;
-        session.clear();
-
-        String title = session.locale().t("help-command-title", args("name", cmd.name()));
-        String content = buildCommandContent(session, cmd);
-
-        session.builder()
-                .title(title, true)
-                .rawContent(content)
-                .addRow(session.locale().t("help-back"), () -> help(uuid, returnPage))
-                .addNavigationRow()
-                .show();
-    }
-
-    private String buildCommandContent(Session session, UnifiedCommand cmd) {
+    String buildCommandContent(Session session, UnifiedCommand cmd) {
         boolean hasCloud = cmd.isCloudCommand();
         boolean hasLegacy = !cmd.legacyVariants().isEmpty();
 
@@ -155,7 +132,7 @@ public class HelpMenu extends Menu {
         ));
     }
 
-    private List<UnifiedCommand> collectAllCommands(XCoreSender sender) {
+    List<UnifiedCommand> collectAllCommands(XCoreSender sender) {
         Map<String, UnifiedCommandBuilder> commandMap = new LinkedHashMap<>();
         var handler = Vars.netServer.clientCommands;
         CloudService cloudService = cloud.get();
@@ -193,7 +170,7 @@ public class HelpMenu extends Menu {
         return new ArrayList<>(commandMap.values().stream().map(UnifiedCommandBuilder::build).toList());
     }
 
-    private String resolveDescription(Session session, UnifiedCommand cmd) {
+    String resolveDescription(Session session, UnifiedCommand cmd) {
         String key = "commands-" + cmd.name() + "-description";
         String res = session.locale().t(key);
         if (!res.equals(key)) return res;
@@ -231,7 +208,7 @@ public class HelpMenu extends Menu {
         return new ArrayList<>(uniqueAliases);
     }
 
-    private String formatCommandLabel(Session session, UnifiedCommand cmd) {
+    String formatCommandLabel(Session session, UnifiedCommand cmd) {
         int overloads = cmd.syntaxes().size();
         if (overloads <= 1) return cmd.name();
         return session.locale().t("help-command-with-overload-count", args(
@@ -279,12 +256,12 @@ public class HelpMenu extends Menu {
         }
     }
 
-    private String truncate(String text, int max) {
+    String truncate(String text, int max) {
         if (text == null) return "";
         return text.length() <= max ? text : text.substring(0, max - 3) + "...";
     }
 
-    private record UnifiedCommand(String name, List<CommandVariant> variants) {
+    record UnifiedCommand(String name, List<CommandVariant> variants) {
         List<String> syntaxes() {
             return variants.stream().map(CommandVariant::syntax).toList();
         }

--- a/src/main/java/org/xcore/plugin/ui/menu/InformationMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/InformationMenu.java
@@ -120,7 +120,7 @@ public class InformationMenu extends Menu {
             }
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (context.session().canGoBack(true)) {
+            if (context.session().canGoBack()) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -192,7 +192,7 @@ public class InformationMenu extends Menu {
             rows.add(List.of(MenuButton.of(local.t("discord-red-vs-blue"), ACTION_DISCORD_RED_VS_BLUE)));
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack(true)) {
+            if (session.canGoBack()) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));

--- a/src/main/java/org/xcore/plugin/ui/menu/InformationMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/InformationMenu.java
@@ -120,7 +120,7 @@ public class InformationMenu extends Menu {
             }
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (context.session().hasHistory() || context.session().hasRouteHistory()) {
+            if (context.session().canGoBack(true)) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -192,7 +192,7 @@ public class InformationMenu extends Menu {
             rows.add(List.of(MenuButton.of(local.t("discord-red-vs-blue"), ACTION_DISCORD_RED_VS_BLUE)));
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));

--- a/src/main/java/org/xcore/plugin/ui/menu/InformationMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/InformationMenu.java
@@ -1,5 +1,6 @@
 package org.xcore.plugin.ui.menu;
 
+import io.avaje.inject.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
@@ -9,9 +10,11 @@ import org.xcore.plugin.config.GlobalConfig;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
 import org.xcore.plugin.ui.flow.MenuButton;
-import org.xcore.plugin.ui.flow.MenuFlow;
 import org.xcore.plugin.ui.flow.MenuRenderContext;
 import org.xcore.plugin.ui.flow.MenuScreen;
+import org.xcore.plugin.ui.MenuService;
+import org.xcore.plugin.ui.route.MenuRoute;
+import org.xcore.plugin.ui.route.RoutedMenuFlow;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,6 +23,14 @@ import static com.ospx.flubundle.Bundle.args;
 
 @Singleton
 public class InformationMenu extends Menu {
+    private static final String ROUTE_MAIN = "information.main";
+    private static final String ROUTE_INFORMATION = "information.info";
+    private static final String ACTION_INFORMATION = "information";
+    private static final String ACTION_HELP = "help";
+    private static final String ACTION_MAPS = "maps";
+    private static final String ACTION_PLAYERS = "players";
+    private static final String ACTION_EVENT_MAIN = "event-main";
+    private static final String ACTION_EVENT_LIST = "event-list";
     private static final String ACTION_DISCORD = "discord";
     private static final String ACTION_GITHUB = "github";
     private static final String ACTION_DONATELLO = "donatello";
@@ -29,6 +40,7 @@ public class InformationMenu extends Menu {
     private static final String ACTION_CLOSE = "close";
 
     private final BuildInfo buildInfo;
+    private final MenuService menuService;
 
     private final Provider<MapMenu> map;
     private final Provider<EventMenu> event;
@@ -38,14 +50,21 @@ public class InformationMenu extends Menu {
 
     @Inject
     public InformationMenu(Config config, GlobalConfig globalConfig, SessionService sessionService,
-                           BuildInfo buildInfo, Provider<MapMenu> map, Provider<EventMenu> event,
+                           BuildInfo buildInfo, MenuService menuService, Provider<MapMenu> map, Provider<EventMenu> event,
                            Provider<HelpMenu> help, Provider<PlayerMenu> player) {
         super(config, globalConfig, sessionService);
         this.buildInfo = buildInfo;
+        this.menuService = menuService;
         this.map = map;
         this.event = event;
         this.help = help;
         this.player = player;
+    }
+
+    @PostConstruct
+    public void init() {
+        menuService.registerRoute(new MainFlow());
+        menuService.registerRoute(new InformationFlow());
     }
 
     public void main(String uuid) {
@@ -53,19 +72,7 @@ public class InformationMenu extends Menu {
         if (session == null || session.data == null) return;
         session.clear();
 
-        Runnable lambda = () -> {session.pushHistory(() -> {main(uuid); }); };
-        session.builder().title("menu-main-title").content("menu-main-content")
-                .addLocal("commands-info", () -> {lambda.run(); information(uuid); })
-                .addLocal("help-menu", () -> {lambda.run(); help.get().help(uuid, 1); })
-                .end()
-                .addLocal("map-maps", () -> {lambda.run(); map.get().maps(uuid, 1); })
-                .addLocal("player-menu-players", () -> {lambda.run(); player.get().players(uuid, 1); })
-                .end()
-                .ifAddLocal(config.isEvent(),"event-menu-main", () -> {lambda.run(); event.get().main(uuid); })
-                .ifAddLocal(config.isEvent(),"event-events", () -> {lambda.run(); event.get().events(uuid, 1); })
-                .end()
-                .addNavigationRow()
-                .show();
+        session.menuService.renderRoute(session, MenuRoute.of(ROUTE_MAIN));
     }
 
     public void information(String uuid) {
@@ -73,10 +80,97 @@ public class InformationMenu extends Menu {
         if (session == null || session.data == null) return;
         session.clear();
 
-        session.menuService.renderFlow(session, new InformationFlow());
+        session.menuService.renderRoute(session, MenuRoute.of(ROUTE_INFORMATION));
     }
 
-    private final class InformationFlow implements MenuFlow<InformationState> {
+    private final class MainFlow implements RoutedMenuFlow<MainState> {
+        @Override
+        public String routeId() {
+            return ROUTE_MAIN;
+        }
+
+        @Override
+        public MainState createState(Session session, MenuRoute route, MainState currentState) {
+            return currentState == null ? new MainState() : currentState;
+        }
+
+        @Override
+        public Class<MainState> stateType() {
+            return MainState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<MainState> context) {
+            var local = context.locale();
+            List<List<MenuButton>> rows = new ArrayList<>();
+            rows.add(List.of(
+                    MenuButton.of(local.t("commands-info"), ACTION_INFORMATION),
+                    MenuButton.of(local.t("help-menu"), ACTION_HELP)
+            ));
+            rows.add(List.of(
+                    MenuButton.of(local.t("map-maps"), ACTION_MAPS),
+                    MenuButton.of(local.t("player-menu-players"), ACTION_PLAYERS)
+            ));
+
+            if (config.isEvent()) {
+                rows.add(List.of(
+                        MenuButton.of(local.t("event-menu-main"), ACTION_EVENT_MAIN),
+                        MenuButton.of(local.t("event-events"), ACTION_EVENT_LIST)
+                ));
+            }
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (context.session().hasHistory() || context.session().hasRouteHistory()) {
+                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.normal(
+                    local.t("menu-main-title"),
+                    local.t("menu-main-content"),
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<MainState> context, String actionId) {
+            Session session = context.session();
+            String uuid = getUuid(session);
+            switch (actionId) {
+                case ACTION_INFORMATION -> context.openRoute(MenuRoute.of(ROUTE_INFORMATION));
+                case ACTION_HELP -> openRoutedFromMain(context, () -> help.get().help(uuid, 1));
+                case ACTION_MAPS -> openRoutedFromMain(context, () -> map.get().maps(uuid, 1));
+                case ACTION_PLAYERS -> openRoutedFromMain(context, () -> player.get().players(uuid, 1));
+                case ACTION_EVENT_MAIN -> openRoutedFromMain(context, () -> event.get().main(uuid));
+                case ACTION_EVENT_LIST -> openRoutedFromMain(context, () -> event.get().events(uuid, 1));
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                default -> {
+                }
+            }
+        }
+
+        private void openRoutedFromMain(MenuRenderContext<MainState> context, Runnable action) {
+            Session session = context.session();
+            if (context.route() != null) {
+                session.pushRouteHistory(context.route());
+            }
+            action.run();
+        }
+    }
+
+    private final class InformationFlow implements RoutedMenuFlow<InformationState> {
+        @Override
+        public String routeId() {
+            return ROUTE_INFORMATION;
+        }
+
+        @Override
+        public InformationState createState(Session session, MenuRoute route, InformationState currentState) {
+            return currentState == null ? new InformationState() : currentState;
+        }
+
         @Override
         public Class<InformationState> stateType() {
             return InformationState.class;
@@ -98,7 +192,7 @@ public class InformationMenu extends Menu {
             rows.add(List.of(MenuButton.of(local.t("discord-red-vs-blue"), ACTION_DISCORD_RED_VS_BLUE)));
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.hasHistory()) {
+            if (session.hasHistory() || session.hasRouteHistory()) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -120,13 +214,7 @@ public class InformationMenu extends Menu {
                 case ACTION_DONATELLO -> openUrl(session, globalConfig.donatelloUrl);
                 case ACTION_WEBLATE -> openUrl(session, globalConfig.weblateUrl);
                 case ACTION_DISCORD_RED_VS_BLUE -> openUrl(session, globalConfig.discordRedVSBlueUrl);
-                case ACTION_BACK -> {
-                    Runnable previousMenu = session.popHistory();
-                    if (previousMenu != null) {
-                        session.menuService.close(session);
-                        previousMenu.run();
-                    }
-                }
+                case ACTION_BACK -> context.goBack();
                 case ACTION_CLOSE -> context.close();
                 default -> {
                 }
@@ -139,5 +227,8 @@ public class InformationMenu extends Menu {
     }
 
     public static final class InformationState {
+    }
+
+    public static final class MainState {
     }
 }

--- a/src/main/java/org/xcore/plugin/ui/menu/MapFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/MapFlows.java
@@ -112,7 +112,7 @@ final class MapFlows {
             }
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack(true)) {
+            if (session.canGoBack()) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -235,7 +235,7 @@ final class MapFlows {
             }
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack(true)) {
+            if (session.canGoBack()) {
                 navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));

--- a/src/main/java/org/xcore/plugin/ui/menu/MapFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/MapFlows.java
@@ -112,7 +112,7 @@ final class MapFlows {
             }
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -235,7 +235,7 @@ final class MapFlows {
             }
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));

--- a/src/main/java/org/xcore/plugin/ui/menu/MapFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/MapFlows.java
@@ -1,0 +1,303 @@
+package org.xcore.plugin.ui.menu;
+
+import arc.struct.Seq;
+import mindustry.maps.Map;
+import org.xcore.plugin.common.CustomGatherers;
+import org.xcore.plugin.common.SeqStream;
+import org.xcore.plugin.config.Config;
+import org.xcore.plugin.database.repository.EventDataRepository;
+import org.xcore.plugin.database.repository.MapDataRepository;
+import org.xcore.plugin.model.EventData;
+import org.xcore.plugin.model.MapData;
+import org.xcore.plugin.model.enums.Feature;
+import org.xcore.plugin.service.MapService;
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuRenderContext;
+import org.xcore.plugin.ui.flow.MenuScreen;
+import org.xcore.plugin.ui.route.MenuRoute;
+import org.xcore.plugin.ui.route.RoutedMenuFlow;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.ospx.flubundle.Bundle.args;
+import static mindustry.Vars.state;
+
+final class MapFlows {
+
+    static final String ROUTE_MAP = "map.details";
+    static final String ROUTE_MAPS = "map.maps";
+
+    private static final String ACTION_LIKE = "like";
+    private static final String ACTION_DISLIKE = "dislike";
+    private static final String ACTION_RTV = "rtv";
+    private static final String ACTION_ADMIN_RTV = "admin-rtv";
+    private static final String ACTION_MAPS = "maps";
+    private static final String ACTION_CREATE_START = "create-start";
+    private static final String ACTION_PREVIOUS = "previous";
+    private static final String ACTION_NEXT = "next";
+    private static final String ACTION_BACK = "back";
+    private static final String ACTION_CLOSE = "close";
+    private static final String ACTION_MAP_PREFIX = "map-";
+
+    private MapFlows() {
+    }
+
+    static final class MapsFlow implements RoutedMenuFlow<MapsState> {
+        private final MapMenu menu;
+        private final MapDataRepository mapDataRepository;
+        private final MapService mapService;
+
+        MapsFlow(MapMenu menu, MapDataRepository mapDataRepository, MapService mapService) {
+            this.menu = menu;
+            this.mapDataRepository = mapDataRepository;
+            this.mapService = mapService;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_MAPS;
+        }
+
+        @Override
+        public MapsState createState(Session session, MenuRoute route, MapsState currentState) {
+            return currentState == null ? new MapsState() : currentState;
+        }
+
+        @Override
+        public Class<MapsState> stateType() {
+            return MapsState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<MapsState> context) {
+            Session session = context.session();
+            int page = context.route().intParam("page", 1);
+            Seq<Map> availableMaps = mapService.getAvailableMaps();
+            var pagination = CustomGatherers.calculatePagination(availableMaps.size, menu.globalConfig.mapsPerPage);
+
+            if (availableMaps.isEmpty()) {
+                session.locale().send("empty");
+                return MenuScreen.normal(
+                        session.locale().t("commands-maps-title"),
+                        "",
+                        List.of(List.of(MenuButton.of(session.locale().t("close"), ACTION_CLOSE)))
+                );
+            }
+
+            int validPage = pagination.clampPage(page);
+            List<Map> pageMaps = SeqStream.of(availableMaps)
+                    .gather(CustomGatherers.page(menu.globalConfig.mapsPerPage, validPage))
+                    .flatMap(List::stream)
+                    .toList();
+
+            var local = context.locale();
+            List<List<MenuButton>> rows = new ArrayList<>();
+
+            List<MenuButton> paginationRow = new ArrayList<>();
+            if (validPage > 1) {
+                paginationRow.add(MenuButton.of(local.t("previous"), ACTION_PREVIOUS));
+            }
+            if (validPage < pagination.totalPages()) {
+                paginationRow.add(MenuButton.of(local.t("next"), ACTION_NEXT));
+            }
+            if (!paginationRow.isEmpty()) {
+                rows.add(paginationRow);
+            }
+
+            for (int i = 0; i < pageMaps.size(); i++) {
+                Map map = pageMaps.get(i);
+                rows.add(List.of(MenuButton.of(map.name(), ACTION_MAP_PREFIX + i)));
+            }
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.hasHistory() || session.hasRouteHistory()) {
+                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.normal(
+                    local.t("commands-maps-title"),
+                    local.t("commands-maps-content", args("page", validPage, "total", pagination.totalPages())),
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<MapsState> context, String actionId) {
+            Session session = context.session();
+            int page = context.route().intParam("page", 1);
+
+            switch (actionId) {
+                case ACTION_PREVIOUS -> session.menuService.renderRoute(session,
+                        MenuRoute.of(ROUTE_MAPS).withParam("page", String.valueOf(page - 1)));
+                case ACTION_NEXT -> session.menuService.renderRoute(session,
+                        MenuRoute.of(ROUTE_MAPS).withParam("page", String.valueOf(page + 1)));
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                default -> {
+                    if (actionId.startsWith(ACTION_MAP_PREFIX)) {
+                        int index = Integer.parseInt(actionId.substring(ACTION_MAP_PREFIX.length()));
+                        Seq<Map> availableMaps = mapService.getAvailableMaps();
+                        var pagination = CustomGatherers.calculatePagination(availableMaps.size, menu.globalConfig.mapsPerPage);
+                        int validPage = pagination.clampPage(page);
+                        String gameMode = state.rules.mode().name();
+                        List<Map> pageMaps = SeqStream.of(availableMaps)
+                                .gather(CustomGatherers.page(menu.globalConfig.mapsPerPage, validPage))
+                                .flatMap(List::stream)
+                                .toList();
+                        if (index >= 0 && index < pageMaps.size()) {
+                            Map map = pageMaps.get(index);
+                            MapData data = mapDataRepository.findOrCreate(map.plainName(), map.file.name(), map.author(), gameMode);
+                            if (data != null && data.id != null) {
+                                context.openRoute(MenuRoute.of(ROUTE_MAP).withParam("mapId", data.id.toHexString()));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    static final class MapFlow implements RoutedMenuFlow<MapState> {
+        private final MapMenu menu;
+        private final Config config;
+        private final EventDataRepository eventDataRepository;
+        private final MapService mapService;
+
+        MapFlow(MapMenu menu, Config config, EventDataRepository eventDataRepository, MapService mapService) {
+            this.menu = menu;
+            this.config = config;
+            this.eventDataRepository = eventDataRepository;
+            this.mapService = mapService;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_MAP;
+        }
+
+        @Override
+        public MapState createState(Session session, MenuRoute route, MapState currentState) {
+            MapState state = currentState == null ? new MapState() : currentState;
+            String mapId = route.param("mapId");
+            state.mapId = mapId == null ? "" : mapId;
+            return state;
+        }
+
+        @Override
+        public Class<MapState> stateType() {
+            return MapState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<MapState> context) {
+            Session session = context.session();
+            MapData mapData = menu.resolveMap(context.state().mapId);
+            if (mapData == null) {
+                return menu.mapNotFoundScreen(session);
+            }
+
+            Map mindustryMap = mapService.findPersistedMap(mapData);
+            String last = mapData.playedTimes == 0
+                    ? session.locale().t("never")
+                    : (System.currentTimeMillis() - mapData.lastPlayedTime) / 60000 + "m";
+            String desc = (mindustryMap == null || mindustryMap.description().isEmpty())
+                    ? session.locale().t("no-description")
+                    : mindustryMap.description();
+            Boolean currentVote = session.data.mapVotes.get(mapData.id.toString());
+            String likeTxt = Boolean.TRUE.equals(currentVote) ? session.locale().t("map-vote-like-selected") : session.locale().t("map-vote-like");
+            String dislikeTxt = Boolean.FALSE.equals(currentVote) ? session.locale().t("map-vote-dislike-selected") : session.locale().t("map-vote-dislike");
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+            rows.add(List.of(
+                    MenuButton.of(likeTxt, ACTION_LIKE),
+                    MenuButton.of(dislikeTxt, ACTION_DISLIKE)
+            ));
+
+            EventData activeEvent = eventDataRepository.findActive().orElse(null);
+            boolean rtvEnabled = !config.isFeatureDisabled(Feature.RTV);
+            if (rtvEnabled && (!config.isEvent() || (activeEvent == null || !activeEvent.isActive) || activeEvent.map.equals(mapData.id))) {
+                List<MenuButton> rtvRow = new ArrayList<>();
+                rtvRow.add(MenuButton.of(session.locale().t("map-rtv"), ACTION_RTV));
+                if (session.player.admin) {
+                    rtvRow.add(MenuButton.of(session.locale().t("map-artv"), ACTION_ADMIN_RTV));
+                }
+                rows.add(rtvRow);
+            }
+
+            rows.add(List.of(MenuButton.of(session.locale().t("map-maps"), ACTION_MAPS)));
+
+            if (config.isEvent()) {
+                rows.add(List.of(MenuButton.of(session.locale().t("event-menu-create-start-map"), ACTION_CREATE_START)));
+            }
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.hasHistory() || session.hasRouteHistory()) {
+                navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.normal(
+                    session.locale().t("commands-map-title"),
+                    session.locale().t("commands-map-content", args(
+                            "name", mapData.name, "author", mapData.author, "description", desc,
+                            "width", (mindustryMap == null) ? "?" : mindustryMap.width,
+                            "height", (mindustryMap == null) ? "?" : mindustryMap.height,
+                            "reputation", mapData.reputation, "popularity", String.format("%.1f", mapData.popularity),
+                            "interest", String.format("%.1f", mapData.interest), "played", mapData.playedTimes,
+                            "playedYear", mapData.playedTimesYear, "lastPlayed", last,
+                            "like", mapData.like, "dislike", mapData.dislike,
+                            "min", mapData.minimumGameTime / 60000, "avg", mapData.averageGameTime / 60000, "max", mapData.maximumGameTime / 60000
+                    )),
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<MapState> context, String actionId) {
+            Session session = context.session();
+            MapData mapData = menu.resolveMap(context.state().mapId);
+            if (mapData == null) {
+                switch (actionId) {
+                    case ACTION_BACK -> context.goBack();
+                    case ACTION_CLOSE -> context.close();
+                    default -> {
+                    }
+                }
+                return;
+            }
+
+            Map mindustryMap = mapService.findPersistedMap(mapData);
+            String uuid = menu.getUuid(session);
+            switch (actionId) {
+                case ACTION_LIKE -> {
+                    mapService.handleReputation(session.player, true, mapData);
+                    context.render();
+                }
+                case ACTION_DISLIKE -> {
+                    mapService.handleReputation(session.player, false, mapData);
+                    context.render();
+                }
+                case ACTION_RTV -> mapService.startRtvSession(session.player, mindustryMap, true, false);
+                case ACTION_ADMIN_RTV -> mapService.startRtvSession(session.player, mindustryMap, true, true);
+                case ACTION_MAPS -> context.openRoute(MenuRoute.of(ROUTE_MAPS).withParam("page", "1"));
+                case ACTION_CREATE_START -> menu.eventMenu.get().createStart(uuid, mapData);
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                default -> {
+                }
+            }
+        }
+    }
+
+    static final class MapsState {
+    }
+
+    static final class MapState {
+        String mapId = "";
+    }
+}

--- a/src/main/java/org/xcore/plugin/ui/menu/MapMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/MapMenu.java
@@ -1,136 +1,103 @@
 package org.xcore.plugin.ui.menu;
 
-import arc.struct.Seq;
+import io.avaje.inject.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 import mindustry.game.Team;
 import mindustry.gen.Groups;
-import mindustry.maps.Map;
-import org.xcore.plugin.common.CustomGatherers;
-import org.xcore.plugin.common.SeqStream;
 import org.xcore.plugin.config.Config;
 import org.xcore.plugin.config.GlobalConfig;
 import org.xcore.plugin.database.repository.EventDataRepository;
 import org.xcore.plugin.database.repository.MapDataRepository;
-import org.xcore.plugin.model.EventData;
 import org.xcore.plugin.model.MapData;
-import org.xcore.plugin.model.enums.Feature;
 import org.xcore.plugin.service.MapService;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.MenuService;
+import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuScreen;
+import org.xcore.plugin.ui.route.MenuRoute;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.ospx.flubundle.Bundle.args;
-import static mindustry.Vars.state;
 
 @Singleton
 public class MapMenu extends Menu {
 
+    private static final String ACTION_BACK = "back";
+    private static final String ACTION_CLOSE = "close";
+
     private final MapDataRepository mapDataRepository;
-    private final EventDataRepository eventDataRepository;
     private final MapService mapService;
-    private final Provider<EventMenu> eventMenu;
+    final Provider<EventMenu> eventMenu;
+    private final MenuService menuService;
+    private final Config config;
+    private final EventDataRepository eventDataRepository;
 
     @Inject
     public MapMenu(Config config, GlobalConfig globalConfig, SessionService sessionService,
                    MapDataRepository mapDataRepository, EventDataRepository eventDataRepository,
-                   MapService mapService, Provider<EventMenu> eventMenu) {
+                   MapService mapService, Provider<EventMenu> eventMenu, MenuService menuService) {
         super(config, globalConfig, sessionService);
+        this.config = config;
         this.mapDataRepository = mapDataRepository;
         this.eventDataRepository = eventDataRepository;
         this.mapService = mapService;
         this.eventMenu = eventMenu;
+        this.menuService = menuService;
+    }
+
+    @PostConstruct
+    public void init() {
+        menuService.registerRoute(new MapFlows.MapFlow(this, config, eventDataRepository, mapService));
+        menuService.registerRoute(new MapFlows.MapsFlow(this, mapDataRepository, mapService));
     }
 
     public void map(String uuid, MapData m) {
         Session session = sessionService.get(uuid);
         if (session == null || session.data == null) return;
         session.clear();
-        Map mindustryMap = mapService.findPersistedMap(m);
-
-        String last = m.playedTimes == 0
-                ? session.locale().t("never")
-                : (System.currentTimeMillis() - m.lastPlayedTime) / 60000 + "m";
-
-        String desc = (mindustryMap == null || mindustryMap.description().isEmpty())
-                ? session.locale().t("no-description")
-                : mindustryMap.description();
-
-        var builder = session.builder()
-                .title("commands-map-title")
-                .content("commands-map-content", args(
-                        "name", m.name, "author", m.author, "description", desc,
-                        "width", (mindustryMap == null) ? "?" : mindustryMap.width,
-                        "height", (mindustryMap == null) ? "?" : mindustryMap.height,
-                        "reputation", m.reputation, "popularity", String.format("%.1f", m.popularity),
-                        "interest", String.format("%.1f", m.interest), "played", m.playedTimes,
-                        "playedYear", m.playedTimesYear, "lastPlayed", last,
-                        "like", m.like, "dislike", m.dislike,
-                        "min", m.minimumGameTime / 60000, "avg", m.averageGameTime / 60000, "max", m.maximumGameTime / 60000
-                ));
-
-        Boolean currentVote = session.data.mapVotes.get(m.id.toString());
-        String likeTxt = Boolean.TRUE.equals(currentVote) ? session.locale().t("map-vote-like-selected") : session.locale().t("map-vote-like");
-        String dislikeTxt = Boolean.FALSE.equals(currentVote) ? session.locale().t("map-vote-dislike-selected") : session.locale().t("map-vote-dislike");
-
-        builder.addRow(likeTxt, () -> { mapService.handleReputation(session.player, true, m); map(uuid, m); },
-                       dislikeTxt, () -> { mapService.handleReputation(session.player, false, m); map(uuid, m); });
-
-        EventData activeEvent = eventDataRepository.findActive().orElse(null);
-        boolean rtvEnabled = !config.isFeatureDisabled(Feature.RTV);
-        if (rtvEnabled && (!config.isEvent() || (activeEvent == null || !activeEvent.isActive) || activeEvent.map.equals(m.id))) {
-            builder.start()
-                .addLocal(session.locale().t("map-rtv"), () -> mapService.startRtvSession(session.player, mindustryMap, true, false))
-                .ifAdd(session.player.admin, session.locale().t("map-artv"), () -> mapService.startRtvSession(session.player, mindustryMap, true, true))
-                .end();
-        }
-
-        builder.addLocalRow("map-maps", () -> { session.pushHistory(() -> map(uuid, m)); maps(uuid, 1); });
-
-        if (config.isEvent()) {
-            builder.addLocalRow("event-menu-create-start-map", () -> {
-                session.pushHistory(() -> map(uuid, m));
-                eventMenu.get().createStart(uuid, m);
-            });
-        }
-
-        builder.addNavigationRow().show();
+        String mapId = m != null && m.id != null ? m.id.toHexString() : "";
+        session.menuService.renderRoute(session, MenuRoute.of(MapFlows.ROUTE_MAP).withParam("mapId", mapId));
     }
 
     public void maps(String uuid, int page) {
         Session session = sessionService.get(uuid);
         if (session == null || session.data == null) return;
         session.clear();
-        Seq<Map> availableMaps = mapService.getAvailableMaps();
-        var pagination = CustomGatherers.calculatePagination(availableMaps.size, globalConfig.mapsPerPage);
-
+        var availableMaps = mapService.getAvailableMaps();
         if (availableMaps.isEmpty()) {
             session.locale().send("empty");
             return;
         }
+        session.menuService.renderRoute(session, MenuRoute.of(MapFlows.ROUTE_MAPS).withParam("page", String.valueOf(page)));
+    }
 
-        int validPage = pagination.clampPage(page);
-        String gameMode = state.rules.mode().name();
+    MapData resolveMap(String mapId) {
+        if (mapId == null || mapId.isBlank()) {
+            return null;
+        }
+        try {
+            return mapDataRepository.findById(new org.bson.types.ObjectId(mapId));
+        } catch (IllegalArgumentException exception) {
+            return null;
+        }
+    }
 
-        var builder = session.builder()
-                .title("commands-maps-title")
-                .content("commands-maps-content", args("page", validPage, "total", pagination.totalPages()))
-
-                .start()
-                    .ifAddLocal(validPage > 1, "previous", () -> maps(uuid, validPage - 1))
-                    .ifAddLocal(validPage < pagination.totalPages(), "next", () -> maps(uuid, validPage + 1))
-                .end()
-
-                .addForEach(SeqStream.of(availableMaps).gather(CustomGatherers.page(globalConfig.mapsPerPage, validPage)).flatMap(List::stream)::iterator,
-                (b, map) -> b.addRow(map.name(), () -> {
-                    session.pushHistory(() -> maps(uuid, validPage));
-                    MapData data = mapDataRepository.findOrCreate(map.plainName(), map.file.name(), map.author(), gameMode);
-                    map(uuid, data);
-                }));
-
-        builder.addNavigationRow().show();
+    MenuScreen mapNotFoundScreen(Session session) {
+        List<MenuButton> navigation = new ArrayList<>();
+        if (session.hasHistory() || session.hasRouteHistory()) {
+            navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
+        }
+        navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
+        return MenuScreen.normal(
+                session.locale().t("commands-map-title"),
+                session.locale().t("error-internal"),
+                List.of(navigation)
+        );
     }
 
     public void showGameOverMenu(MapData current, MapData next, Team winner) {

--- a/src/main/java/org/xcore/plugin/ui/menu/MapMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/MapMenu.java
@@ -89,7 +89,7 @@ public class MapMenu extends Menu {
 
     MenuScreen mapNotFoundScreen(Session session) {
         List<MenuButton> navigation = new ArrayList<>();
-        if (session.canGoBack(true)) {
+        if (session.canGoBack()) {
             navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
         }
         navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
@@ -123,15 +123,13 @@ public class MapMenu extends Menu {
                             "author", nextAuthor,
                             "seconds", 10
                     ))
-                    .addLocal(likeButtonText, () -> mapService.handleReputation(player, true, current))
-                    .addLocal(dislikeButtonText, () -> mapService.handleReputation(player, false, current))
+                    .addButtonText(likeButtonText, () -> mapService.handleReputation(player, true, current))
+                    .addButtonText(dislikeButtonText, () -> mapService.handleReputation(player, false, current))
                     .end()
-                    .addLocal("current-map", () -> {
-                        session.clearHistory();
+                    .addButtonKey("current-map", () -> {
                         map(player.uuid(), current);
                     })
-                    .addLocal("next-map", () -> {
-                        session.clearHistory();
+                    .addButtonKey("next-map", () -> {
                         map(player.uuid(), next);
                     })
                     .addNavigationRow().show();

--- a/src/main/java/org/xcore/plugin/ui/menu/MapMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/MapMenu.java
@@ -89,7 +89,7 @@ public class MapMenu extends Menu {
 
     MenuScreen mapNotFoundScreen(Session session) {
         List<MenuButton> navigation = new ArrayList<>();
-        if (session.hasHistory() || session.hasRouteHistory()) {
+        if (session.canGoBack(true)) {
             navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
         }
         navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));

--- a/src/main/java/org/xcore/plugin/ui/menu/MessageFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/MessageFlows.java
@@ -1,0 +1,500 @@
+package org.xcore.plugin.ui.menu;
+
+import org.bson.types.ObjectId;
+import org.xcore.plugin.common.CustomGatherers;
+import org.xcore.plugin.model.PlayerData;
+import org.xcore.plugin.model.PrivateMessage;
+import org.xcore.plugin.service.PrivateMessageService;
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuPrompt;
+import org.xcore.plugin.ui.flow.MenuRenderContext;
+import org.xcore.plugin.ui.flow.MenuScreen;
+import org.xcore.plugin.ui.route.MenuRoute;
+import org.xcore.plugin.ui.route.RoutedMenuFlow;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.ospx.flubundle.Bundle.args;
+
+final class MessageFlows {
+
+    static final String ROUTE_INBOX = "message.inbox";
+    static final String ROUTE_BLOCKED = "message.blocked";
+    static final String ROUTE_DETAILS = "message.details";
+
+    private static final String ACTION_PREVIOUS = "previous";
+    private static final String ACTION_NEXT = "next";
+    private static final String ACTION_COMPOSE = "compose";
+    private static final String ACTION_BLOCKED = "blocked";
+    private static final String ACTION_BACK = "back";
+    private static final String ACTION_CLOSE = "close";
+    private static final String ACTION_MESSAGE_PREFIX = "message:";
+    private static final String ACTION_UNBLOCK_PREFIX = "unblock:";
+    private static final String ACTION_REPLY = "reply";
+    private static final String ACTION_DELETE = "delete";
+    private static final String ACTION_TOGGLE_BLOCK = "toggle-block";
+
+    private static final String PROMPT_REPLY = "private-message-reply";
+    private static final String PROMPT_COMPOSE_TARGET = "private-message-compose-target";
+    private static final String PROMPT_COMPOSE_BODY = "private-message-compose-body";
+
+    private MessageFlows() {
+    }
+
+    static final class InboxFlow implements RoutedMenuFlow<InboxState> {
+        private final MessageMenu menu;
+        private final PrivateMessageService privateMessageService;
+
+        InboxFlow(MessageMenu menu, PrivateMessageService privateMessageService) {
+            this.menu = menu;
+            this.privateMessageService = privateMessageService;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_INBOX;
+        }
+
+        @Override
+        public InboxState createState(Session session, MenuRoute route, InboxState currentState) {
+            InboxState state = currentState == null ? new InboxState() : currentState;
+            state.page = route.intParam("page", 1);
+            return state;
+        }
+
+        @Override
+        public Class<InboxState> stateType() {
+            return InboxState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<InboxState> context) {
+            Session session = context.session();
+            String uuid = menu.getUuid(session);
+            int requestedPage = Math.max(1, context.state().page);
+
+            long total = privateMessageService.countInbox(session.data.uuid);
+            var pagination = CustomGatherers.calculatePagination(total, menu.globalConfig.privateMessagesPerPage);
+            int validPage = pagination.totalPages() <= 0 ? 1 : pagination.clampPage(requestedPage);
+            context.state().page = validPage;
+            List<PrivateMessage> messages = privateMessageService.inbox(session.data.uuid, validPage);
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+
+            List<MenuButton> pagingRow = new ArrayList<>();
+            if (validPage > 1) {
+                pagingRow.add(MenuButton.of(session.locale().t("previous"), ACTION_PREVIOUS));
+            }
+            if (validPage < Math.max(1, pagination.totalPages())) {
+                pagingRow.add(MenuButton.of(session.locale().t("next"), ACTION_NEXT));
+            }
+            if (!pagingRow.isEmpty()) {
+                rows.add(pagingRow);
+            }
+
+            for (PrivateMessage message : messages) {
+                String text = session.locale().t(
+                        message.readAt > 0 ? "private-message-menu-entry-read" : "private-message-menu-entry-unread",
+                        args(
+                                "author", message.fromName,
+                                "pid", message.fromPid,
+                                "message", preview(message.message),
+                                "time", menu.formatTime(message.createdModelTime, session)
+                        )
+                );
+                rows.add(List.of(MenuButton.of(text, ACTION_MESSAGE_PREFIX + message.id.toHexString())));
+            }
+
+            rows.add(List.of(
+                    MenuButton.of(session.locale().t("private-message-compose"), ACTION_COMPOSE),
+                    MenuButton.of(session.locale().t("private-message-blocked"), ACTION_BLOCKED)
+            ));
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.hasHistory() || session.hasRouteHistory()) {
+                navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.normal(
+                    session.locale().t("private-message-menu-title"),
+                    session.locale().t(total == 0 ? "private-message-menu-empty" : "private-message-menu-content", args(
+                            "page", validPage,
+                            "total", Math.max(1, pagination.totalPages()),
+                            "unread", privateMessageService.countUnread(session.data.uuid)
+                    )),
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<InboxState> context, String actionId) {
+            Session session = context.session();
+            String uuid = menu.getUuid(session);
+            int currentPage = Math.max(1, context.state().page);
+
+            switch (actionId) {
+                case ACTION_PREVIOUS -> session.menuService.renderRoute(session,
+                        MenuRoute.of(ROUTE_INBOX).withParam("page", String.valueOf(currentPage - 1)));
+                case ACTION_NEXT -> session.menuService.renderRoute(session,
+                        MenuRoute.of(ROUTE_INBOX).withParam("page", String.valueOf(currentPage + 1)));
+                case ACTION_COMPOSE -> promptCompose(menu, privateMessageService, uuid, context::render);
+                case ACTION_BLOCKED -> context.openRoute(MenuRoute.of(ROUTE_BLOCKED).withParam("page", "1"));
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                default -> {
+                    if (actionId.startsWith(ACTION_MESSAGE_PREFIX)) {
+                        ObjectId messageId = new ObjectId(actionId.substring(ACTION_MESSAGE_PREFIX.length()));
+                        context.openRoute(MenuRoute.of(ROUTE_DETAILS)
+                                .withParam("messageId", messageId.toHexString())
+                                .withParam("returnPage", String.valueOf(currentPage)));
+                    }
+                }
+            }
+        }
+    }
+
+    static final class DetailsFlow implements RoutedMenuFlow<DetailsState> {
+        private final MessageMenu menu;
+        private final PrivateMessageService privateMessageService;
+
+        DetailsFlow(MessageMenu menu, PrivateMessageService privateMessageService) {
+            this.menu = menu;
+            this.privateMessageService = privateMessageService;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_DETAILS;
+        }
+
+        @Override
+        public DetailsState createState(Session session, MenuRoute route, DetailsState currentState) {
+            DetailsState state = currentState == null ? new DetailsState() : currentState;
+            state.messageId = route.param("messageId");
+            state.returnPage = route.intParam("returnPage", 1);
+            return state;
+        }
+
+        @Override
+        public Class<DetailsState> stateType() {
+            return DetailsState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<DetailsState> context) {
+            Session session = context.session();
+            DetailsView view = resolveDetailsView(session, context.state(), privateMessageService);
+            if (view == null) {
+                return notFoundScreen(session);
+            }
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+            rows.add(List.of(
+                    MenuButton.of(session.locale().t("reply"), ACTION_REPLY),
+                    MenuButton.of(session.locale().t("delete"), ACTION_DELETE)
+            ));
+            rows.add(List.of(MenuButton.of(
+                    session.locale().t(view.blocked ? "private-message-unblock" : "private-message-block"),
+                    ACTION_TOGGLE_BLOCK
+            )));
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.hasHistory() || session.hasRouteHistory()) {
+                navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.normal(
+                    session.locale().t("private-message-details-title"),
+                    session.locale().t("private-message-details-content", args(
+                            "author", view.message.fromName,
+                            "pid", view.message.fromPid,
+                            "time", menu.formatTime(view.message.createdModelTime, session),
+                            "message", view.message.message,
+                            "status", session.locale().t(view.markedRead || view.message.readAt > 0 ? "private-message-status-read" : "private-message-status-unread")
+                    )),
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<DetailsState> context, String actionId) {
+            Session session = context.session();
+            DetailsView view = resolveDetailsView(session, context.state(), privateMessageService);
+            if (view == null) {
+                if (ACTION_BACK.equals(actionId)) {
+                    context.goBack();
+                } else if (ACTION_CLOSE.equals(actionId)) {
+                    context.close();
+                }
+                return;
+            }
+
+            switch (actionId) {
+                case ACTION_REPLY -> context.openPrompt(new MenuPrompt(
+                        PROMPT_REPLY,
+                        session.locale().t("private-message-reply-title"),
+                        session.locale().t("private-message-reply-message", args("pid", view.message.fromPid)),
+                        menu.globalConfig.privateMessageMaxLength,
+                        "",
+                        false
+                ));
+                case ACTION_DELETE -> {
+                    privateMessageService.softDelete(view.message.id, session.data.uuid);
+                    if (session.hasRouteHistory()) {
+                        context.goBack();
+                    } else {
+                        menu.inbox(menu.getUuid(session), context.state().returnPage);
+                    }
+                }
+                case ACTION_TOGGLE_BLOCK -> {
+                    if (view.blocked) {
+                        privateMessageService.unblock(session, view.message.fromPid);
+                    } else {
+                        privateMessageService.block(session, view.message.fromPid);
+                    }
+                    context.render();
+                }
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                default -> {
+                }
+            }
+        }
+
+        @Override
+        public void onPromptSubmit(MenuRenderContext<DetailsState> context, String promptId, String text) {
+            if (!PROMPT_REPLY.equals(promptId)) {
+                return;
+            }
+
+            Session session = context.session();
+            DetailsView view = resolveDetailsView(session, context.state(), privateMessageService);
+            if (view == null) {
+                context.render();
+                return;
+            }
+
+            privateMessageService.send(session, view.message.fromPid, text);
+            context.render();
+        }
+
+        @Override
+        public void onPromptCancel(MenuRenderContext<DetailsState> context, String promptId) {
+            if (PROMPT_REPLY.equals(promptId)) {
+                context.render();
+            }
+        }
+    }
+
+    static final class BlockedFlow implements RoutedMenuFlow<BlockedState> {
+        private final MessageMenu menu;
+        private final PrivateMessageService privateMessageService;
+
+        BlockedFlow(MessageMenu menu, PrivateMessageService privateMessageService) {
+            this.menu = menu;
+            this.privateMessageService = privateMessageService;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_BLOCKED;
+        }
+
+        @Override
+        public BlockedState createState(Session session, MenuRoute route, BlockedState currentState) {
+            BlockedState state = currentState == null ? new BlockedState() : currentState;
+            state.page = route.intParam("page", 1);
+            return state;
+        }
+
+        @Override
+        public Class<BlockedState> stateType() {
+            return BlockedState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<BlockedState> context) {
+            Session session = context.session();
+            int requestedPage = Math.max(1, context.state().page);
+
+            List<PlayerData> blockedPlayers = privateMessageService.listBlocked(session);
+            var pagination = CustomGatherers.calculatePagination(blockedPlayers.size(), menu.globalConfig.privateMessagesPerPage);
+            int validPage = pagination.totalPages() <= 0 ? 1 : pagination.clampPage(requestedPage);
+            context.state().page = validPage;
+            int start = (validPage - 1) * menu.globalConfig.privateMessagesPerPage;
+            int end = Math.min(start + menu.globalConfig.privateMessagesPerPage, blockedPlayers.size());
+            List<PlayerData> pageItems = start >= blockedPlayers.size() ? List.of() : blockedPlayers.subList(start, end);
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+
+            List<MenuButton> pagingRow = new ArrayList<>();
+            if (validPage > 1) {
+                pagingRow.add(MenuButton.of(session.locale().t("previous"), ACTION_PREVIOUS));
+            }
+            if (validPage < Math.max(1, pagination.totalPages())) {
+                pagingRow.add(MenuButton.of(session.locale().t("next"), ACTION_NEXT));
+            }
+            if (!pagingRow.isEmpty()) {
+                rows.add(pagingRow);
+            }
+
+            for (PlayerData playerData : pageItems) {
+                rows.add(List.of(MenuButton.of(
+                        session.locale().t("private-message-blocked-entry", args("target", playerData.nickname, "pid", playerData.pid)),
+                        ACTION_UNBLOCK_PREFIX + playerData.pid
+                )));
+            }
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.hasHistory() || session.hasRouteHistory()) {
+                navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.normal(
+                    session.locale().t("private-message-blocked-title"),
+                    session.locale().t(blockedPlayers.isEmpty() ? "private-message-blocked-empty" : "private-message-blocked-content", args(
+                            "page", validPage,
+                            "total", Math.max(1, pagination.totalPages()),
+                            "count", blockedPlayers.size()
+                    )),
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<BlockedState> context, String actionId) {
+            Session session = context.session();
+            int currentPage = Math.max(1, context.state().page);
+
+            switch (actionId) {
+                case ACTION_PREVIOUS -> session.menuService.renderRoute(session,
+                        MenuRoute.of(ROUTE_BLOCKED).withParam("page", String.valueOf(currentPage - 1)));
+                case ACTION_NEXT -> session.menuService.renderRoute(session,
+                        MenuRoute.of(ROUTE_BLOCKED).withParam("page", String.valueOf(currentPage + 1)));
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                default -> {
+                    if (actionId.startsWith(ACTION_UNBLOCK_PREFIX)) {
+                        int pid = Integer.parseInt(actionId.substring(ACTION_UNBLOCK_PREFIX.length()));
+                        privateMessageService.unblock(session, pid);
+                        context.render();
+                    }
+                }
+            }
+        }
+    }
+
+    static final class InboxState {
+        public int page = 1;
+    }
+
+    static final class BlockedState {
+        public int page = 1;
+    }
+
+    static final class DetailsState {
+        public String messageId;
+        public int returnPage = 1;
+    }
+
+    private static void promptCompose(MessageMenu menu, PrivateMessageService privateMessageService, String uuid, Runnable onBack) {
+        Session session = menu.sessionService.get(uuid);
+        if (session == null || session.data == null) return;
+
+        session.menuService.openPrompt(session,
+                new MenuPrompt(
+                        PROMPT_COMPOSE_TARGET,
+                        session.locale().t("private-message-compose-target-title"),
+                        session.locale().t("private-message-compose-target-message"),
+                        32,
+                        session.lastPrivateTargetPid == null ? "" : "#" + session.lastPrivateTargetPid,
+                        false),
+                pidText -> handleComposeTarget(menu, privateMessageService, uuid, onBack, pidText),
+                onBack);
+    }
+
+    private static void handleComposeTarget(MessageMenu menu,
+                                            PrivateMessageService privateMessageService,
+                                            String uuid,
+                                            Runnable onBack,
+                                            String pidText) {
+        Session session = menu.sessionService.get(uuid);
+        if (session == null || session.data == null) return;
+
+        Integer targetPid = privateMessageService.parseMenuPid(pidText);
+        if (targetPid == null) {
+            session.locale().send("error-private-message-invalid-pid", args());
+            onBack.run();
+            return;
+        }
+
+        session.menuService.openPrompt(session,
+                new MenuPrompt(
+                        PROMPT_COMPOSE_BODY,
+                        session.locale().t("private-message-compose-body-title"),
+                        session.locale().t("private-message-compose-body-message", args("pid", "#" + targetPid)),
+                        menu.globalConfig.privateMessageMaxLength,
+                        "",
+                        false),
+                message -> {
+                    privateMessageService.send(session, targetPid, message);
+                    onBack.run();
+                },
+                onBack);
+    }
+
+    private static String preview(String message) {
+        if (message == null) {
+            return "";
+        }
+
+        return message.length() <= 40 ? message : message.substring(0, 37) + "...";
+    }
+
+    private static DetailsView resolveDetailsView(Session session,
+                                                  DetailsState state,
+                                                  PrivateMessageService privateMessageService) {
+        if (session == null || session.data == null || state == null || state.messageId == null) {
+            return null;
+        }
+
+        ObjectId messageId;
+        try {
+            messageId = new ObjectId(state.messageId);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+
+        PrivateMessage message = privateMessageService.getMessage(messageId, session.data.uuid);
+        if (message == null) {
+            return null;
+        }
+
+        boolean markedRead = privateMessageService.markRead(messageId, session.data.uuid);
+        boolean blocked = session.data.blockedPrivateUuids != null && session.data.blockedPrivateUuids.contains(message.fromUuid);
+        return new DetailsView(message, markedRead, blocked);
+    }
+
+    private static MenuScreen notFoundScreen(Session session) {
+        return MenuScreen.normal(
+                session.locale().t("private-message-details-title"),
+                session.locale().t("error-private-message-not-found"),
+                List.of(List.of(
+                        MenuButton.of(session.locale().t("back"), ACTION_BACK),
+                        MenuButton.of(session.locale().t("close"), ACTION_CLOSE)
+                ))
+        );
+    }
+
+    private record DetailsView(PrivateMessage message, boolean markedRead, boolean blocked) {
+    }
+}

--- a/src/main/java/org/xcore/plugin/ui/menu/MessageFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/MessageFlows.java
@@ -114,7 +114,7 @@ final class MessageFlows {
             ));
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack(true)) {
+            if (session.canGoBack()) {
                 navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
@@ -204,7 +204,7 @@ final class MessageFlows {
             )));
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack(true)) {
+            if (session.canGoBack()) {
                 navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
@@ -353,7 +353,7 @@ final class MessageFlows {
             }
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack(true)) {
+            if (session.canGoBack()) {
                 navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));

--- a/src/main/java/org/xcore/plugin/ui/menu/MessageFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/MessageFlows.java
@@ -114,7 +114,7 @@ final class MessageFlows {
             ));
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
@@ -204,7 +204,7 @@ final class MessageFlows {
             )));
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
@@ -353,7 +353,7 @@ final class MessageFlows {
             }
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));

--- a/src/main/java/org/xcore/plugin/ui/menu/MessageMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/MessageMenu.java
@@ -1,38 +1,39 @@
 package org.xcore.plugin.ui.menu;
 
+import io.avaje.inject.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.bson.types.ObjectId;
-import org.xcore.plugin.common.CustomGatherers;
 import org.xcore.plugin.config.Config;
 import org.xcore.plugin.config.GlobalConfig;
-import org.xcore.plugin.model.PlayerData;
-import org.xcore.plugin.model.PrivateMessage;
 import org.xcore.plugin.service.PrivateMessageService;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
-import org.xcore.plugin.ui.flow.MenuPrompt;
-
-import java.util.List;
-
-import static com.ospx.flubundle.Bundle.args;
+import org.xcore.plugin.ui.MenuService;
+import org.xcore.plugin.ui.route.MenuRoute;
 
 @Singleton
 public class MessageMenu extends Menu {
 
-    private static final String PROMPT_REPLY = "private-message-reply";
-    private static final String PROMPT_COMPOSE_TARGET = "private-message-compose-target";
-    private static final String PROMPT_COMPOSE_BODY = "private-message-compose-body";
-
     private final PrivateMessageService privateMessageService;
+    private final MenuService menuService;
 
     @Inject
     public MessageMenu(Config config,
                        GlobalConfig globalConfig,
                        SessionService sessionService,
-                       PrivateMessageService privateMessageService) {
+                       PrivateMessageService privateMessageService,
+                       MenuService menuService) {
         super(config, globalConfig, sessionService);
         this.privateMessageService = privateMessageService;
+        this.menuService = menuService;
+    }
+
+    @PostConstruct
+    public void init() {
+        menuService.registerRoute(new MessageFlows.InboxFlow(this, privateMessageService));
+        menuService.registerRoute(new MessageFlows.BlockedFlow(this, privateMessageService));
+        menuService.registerRoute(new MessageFlows.DetailsFlow(this, privateMessageService));
     }
 
     public void inbox(String uuid, int page) {
@@ -40,100 +41,8 @@ public class MessageMenu extends Menu {
         if (session == null || session.data == null) return;
         session.clear();
 
-        long total = privateMessageService.countInbox(session.data.uuid);
-        var pagination = CustomGatherers.calculatePagination(total, globalConfig.privateMessagesPerPage);
-        int validPage = pagination.totalPages() <= 0 ? 1 : pagination.clampPage(page);
-        List<PrivateMessage> messages = privateMessageService.inbox(session.data.uuid, validPage);
-
-        var builder = session.builder()
-                .title("private-message-menu-title")
-                .content(total == 0
-                                ? "private-message-menu-empty"
-                                : "private-message-menu-content",
-                        args(
-                                "page", validPage,
-                                "total", Math.max(1, pagination.totalPages()),
-                                "unread", privateMessageService.countUnread(session.data.uuid)
-                        ))
-                .start()
-                .ifAddLocal(validPage > 1, "previous", () -> inbox(uuid, validPage - 1))
-                .ifAddLocal(validPage < Math.max(1, pagination.totalPages()), "next", () -> inbox(uuid, validPage + 1))
-                .end();
-
-        if (!messages.isEmpty()) {
-            builder.addForEach(messages, (b, message) -> {
-                String text = session.locale().t(
-                        message.readAt > 0 ? "private-message-menu-entry-read" : "private-message-menu-entry-unread",
-                        args(
-                                "author", message.fromName,
-                                "pid", message.fromPid,
-                                "message", preview(message.message),
-                                "time", formatTime(message.createdModelTime, session)
-                        )
-                );
-
-                b.addRow(text, () -> {
-                    session.pushHistory(() -> inbox(uuid, validPage));
-                    details(uuid, message.id, validPage);
-                });
-            });
-        }
-
-        builder.start()
-                .addLocal("private-message-compose", () -> promptCompose(uuid, () -> inbox(uuid, validPage)))
-                .addLocal("private-message-blocked", () -> {
-                    session.pushHistory(() -> inbox(uuid, validPage));
-                    blocked(uuid, 1);
-                })
-                .end()
-                .addNavigationRow()
-                .show();
-    }
-
-    public void details(String uuid, ObjectId messageId, int returnPage) {
-        Session session = sessionService.get(uuid);
-        if (session == null || session.data == null) return;
-        session.clear();
-
-        PrivateMessage message = privateMessageService.getMessage(messageId, session.data.uuid);
-        if (message == null) {
-            session.locale().send("error-private-message-not-found", args());
-            Runnable previous = session.popHistory();
-            if (previous != null) {
-                previous.run();
-            }
-            return;
-        }
-
-        boolean markedRead = privateMessageService.markRead(messageId, session.data.uuid);
-        boolean blocked = session.data.blockedPrivateUuids != null && session.data.blockedPrivateUuids.contains(message.fromUuid);
-
-        session.builder()
-                .title("private-message-details-title")
-                .content("private-message-details-content", args(
-                        "author", message.fromName,
-                        "pid", message.fromPid,
-                        "time", formatTime(message.createdModelTime, session),
-                        "message", message.message,
-                        "status", session.locale().t(markedRead || message.readAt > 0 ? "private-message-status-read" : "private-message-status-unread")
-                ))
-                .start()
-                .addLocal("reply", () -> promptReply(uuid, message, returnPage))
-                .addLocal("delete", () -> {
-                    privateMessageService.softDelete(messageId, session.data.uuid);
-                    inbox(uuid, returnPage);
-                })
-                .end()
-                .addLocalRow(blocked ? "private-message-unblock" : "private-message-block", () -> {
-                    if (blocked) {
-                        privateMessageService.unblock(session, message.fromPid);
-                    } else {
-                        privateMessageService.block(session, message.fromPid);
-                    }
-                    details(uuid, messageId, returnPage);
-                })
-                .addNavigationRow()
-                .show();
+        session.menuService.renderRoute(session, MenuRoute.of(MessageFlows.ROUTE_INBOX)
+                .withParam("page", String.valueOf(page)));
     }
 
     public void blocked(String uuid, int page) {
@@ -141,105 +50,17 @@ public class MessageMenu extends Menu {
         if (session == null || session.data == null) return;
         session.clear();
 
-        List<PlayerData> blockedPlayers = privateMessageService.listBlocked(session);
-        var pagination = CustomGatherers.calculatePagination(blockedPlayers.size(), globalConfig.privateMessagesPerPage);
-        int validPage = pagination.totalPages() <= 0 ? 1 : pagination.clampPage(page);
-        int start = (validPage - 1) * globalConfig.privateMessagesPerPage;
-        int end = Math.min(start + globalConfig.privateMessagesPerPage, blockedPlayers.size());
-        List<PlayerData> pageItems = start >= blockedPlayers.size() ? List.of() : blockedPlayers.subList(start, end);
-
-        var builder = session.builder()
-                .title("private-message-blocked-title")
-                .content(blockedPlayers.isEmpty()
-                                ? "private-message-blocked-empty"
-                                : "private-message-blocked-content",
-                        args(
-                                "page", validPage,
-                                "total", Math.max(1, pagination.totalPages()),
-                                "count", blockedPlayers.size()
-                        ))
-                .start()
-                .ifAddLocal(validPage > 1, "previous", () -> blocked(uuid, validPage - 1))
-                .ifAddLocal(validPage < Math.max(1, pagination.totalPages()), "next", () -> blocked(uuid, validPage + 1))
-                .end();
-
-        builder.addForEach(pageItems, (b, playerData) -> b.addRow(
-                session.locale().t("private-message-blocked-entry", args("target", playerData.nickname, "pid", playerData.pid)),
-                () -> {
-                    privateMessageService.unblock(session, playerData.pid);
-                    blocked(uuid, validPage);
-                }
-        ));
-
-        builder.addNavigationRow().show();
+        session.menuService.renderRoute(session, MenuRoute.of(MessageFlows.ROUTE_BLOCKED)
+                .withParam("page", String.valueOf(page)));
     }
 
-    private void promptReply(String uuid, PrivateMessage message, int returnPage) {
+    public void details(String uuid, ObjectId messageId, int returnPage) {
         Session session = sessionService.get(uuid);
         if (session == null || session.data == null) return;
+        session.clear();
 
-        session.menuService.openPrompt(session,
-                new MenuPrompt(
-                        PROMPT_REPLY,
-                        session.locale().t("private-message-reply-title"),
-                        session.locale().t("private-message-reply-message", args("pid", message.fromPid)),
-                        globalConfig.privateMessageMaxLength,
-                        "",
-                        false),
-                text -> {
-                    privateMessageService.send(session, message.fromPid, text);
-                    details(uuid, message.id, returnPage);
-                },
-                () -> details(uuid, message.id, returnPage));
-    }
-
-    private void promptCompose(String uuid, Runnable onBack) {
-        Session session = sessionService.get(uuid);
-        if (session == null || session.data == null) return;
-
-        session.menuService.openPrompt(session,
-                new MenuPrompt(
-                        PROMPT_COMPOSE_TARGET,
-                        session.locale().t("private-message-compose-target-title"),
-                        session.locale().t("private-message-compose-target-message"),
-                        32,
-                        session.lastPrivateTargetPid == null ? "" : "#" + session.lastPrivateTargetPid,
-                        false),
-                pidText -> handleComposeTarget(uuid, onBack, pidText),
-                onBack);
-    }
-
-    private void handleComposeTarget(String uuid, Runnable onBack, String pidText) {
-        Session session = sessionService.get(uuid);
-        if (session == null || session.data == null) return;
-
-        Integer targetPid = privateMessageService.parseMenuPid(pidText);
-        if (targetPid == null) {
-            session.locale().send("error-private-message-invalid-pid", args());
-            onBack.run();
-            return;
-        }
-
-        session.menuService.openPrompt(session,
-                new MenuPrompt(
-                        PROMPT_COMPOSE_BODY,
-                        session.locale().t("private-message-compose-body-title"),
-                        session.locale().t("private-message-compose-body-message", args("pid", "#" + targetPid)),
-                        globalConfig.privateMessageMaxLength,
-                        "",
-                        false),
-                message -> {
-                    privateMessageService.send(session, targetPid, message);
-                    onBack.run();
-                },
-                onBack);
-    }
-
-    private String preview(String message) {
-        if (message == null) {
-            return "";
-        }
-
-        return message.length() <= 40 ? message : message.substring(0, 37) + "...";
+        session.menuService.renderRoute(session, MenuRoute.of(MessageFlows.ROUTE_DETAILS)
+                .withParam("messageId", messageId.toHexString())
+                .withParam("returnPage", String.valueOf(returnPage)));
     }
 }

--- a/src/main/java/org/xcore/plugin/ui/menu/PlayerMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/PlayerMenu.java
@@ -1,41 +1,26 @@
 package org.xcore.plugin.ui.menu;
 
-import arc.struct.Seq;
-import arc.util.Strings;
 import com.ospx.flubundle.Bundle;
+import io.avaje.inject.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
-import org.xcore.plugin.common.CustomGatherers;
 import org.xcore.plugin.config.Config;
 import org.xcore.plugin.config.GlobalConfig;
 import org.xcore.plugin.database.repository.GameDataRepository;
-import org.xcore.plugin.localization.Localization;
-import org.xcore.plugin.model.ModeStatsSummary;
 import org.xcore.plugin.model.PlayerData;
-import org.xcore.plugin.model.PlayerStatsOverview;
-import org.xcore.plugin.player.Badge;
 import org.xcore.plugin.service.PlayerDisplayService;
 import org.xcore.plugin.service.PlayerProfileSettingsService;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
-import org.xcore.plugin.ui.flow.MenuPrompt;
+import org.xcore.plugin.ui.MenuService;
+import org.xcore.plugin.ui.route.MenuRoute;
 
-import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Locale;
-import java.util.Objects;
-
-import static com.ospx.flubundle.Bundle.args;
 @Singleton
 public class PlayerMenu extends Menu {
 
-    private final GameDataRepository gameDataRepository;
     private final Bundle bundle;
-    private final PlayerDisplayService playerDisplayService;
     private final PlayerProfileSettingsService profileSettings;
-    private final AuditHistoryMenu auditHistoryMenu;
+    private final MenuService menuService;
 
     @Inject
     public PlayerMenu(Config config,
@@ -45,13 +30,25 @@ public class PlayerMenu extends Menu {
                       Bundle bundle,
                       PlayerDisplayService playerDisplayService,
                       PlayerProfileSettingsService profileSettings,
-                      AuditHistoryMenu auditHistoryMenu) {
+                      AuditHistoryMenu auditHistoryMenu,
+                      MenuService menuService) {
         super(config, globalConfig, sessionService);
-        this.gameDataRepository = gameDataRepository;
         this.bundle = bundle;
-        this.playerDisplayService = playerDisplayService;
         this.profileSettings = profileSettings;
-        this.auditHistoryMenu = auditHistoryMenu;
+        this.menuService = menuService;
+
+        menuService.registerRoute(new PlayerProfileFlows.PlayerFlow(this, gameDataRepository, auditHistoryMenu));
+        menuService.registerRoute(new PlayerProfileFlows.PlayersFlow(this, sessionService, playerDisplayService));
+    }
+
+    @PostConstruct
+    public void init() {
+        menuService.registerRoute(new PlayerSettingsFlows.SettingsFlow(profileSettings));
+        menuService.registerRoute(new PlayerSettingsFlows.ChatSettingsFlow(profileSettings));
+        menuService.registerRoute(new PlayerSettingsFlows.LanguageSelectionFlow(bundle, profileSettings));
+        menuService.registerRoute(new PlayerSettingsFlows.BadgeSymbolColorModeFlow(profileSettings));
+        menuService.registerRoute(new PlayerSettingsFlows.BadgesFlow(profileSettings));
+        menuService.registerRoute(new PlayerSettingsFlows.AllBadgesFlow(profileSettings));
     }
 
     public void player(String uuid, PlayerData targetData) {
@@ -64,201 +61,14 @@ public class PlayerMenu extends Menu {
             return;
         }
 
-        Localization local = session.locale();
-        boolean isOwner = session.data.uuid.equals(targetData.uuid);
-
-        String customNickname = targetData.customNickname == null || Objects.equals(targetData.customNickname, "")
-                ? targetData.nickname : targetData.customNickname;
-        String description = targetData.description == null || Objects.equals(targetData.description, "")
-                ? local.t("no-description") : targetData.description;
-        String activeBadge = activeBadgeName(local, targetData);
-        String systemBadge = systemBadgeName(local, targetData);
-        String accountCreated = formatTime(targetData.createdModelTime, session);
-        String playTime = formatPlayTime(targetData.totalPlayTime, local);
-        String rankName = local.t("hexed-ranks-" + targetData.hexedRank().name());
-        String hexedProgress = formatHexedProgress(local, targetData);
-        PlayerStatsOverview statsOverview = gameDataRepository.aggregatePlayerStatsOverview(targetData.uuid);
-        var overallStats = statsOverview.overall();
-        NumberFormat numberFormat = NumberFormat.getIntegerInstance(local.getLocale());
-
-        session.builder()
-                .title("player-menu-player-title")
-                .content("player-menu-player-content", args(
-                        "nickname", targetData.nickname,
-                        "customNickname", customNickname,
-                        "activeBadge", activeBadge,
-                        "systemBadge", systemBadge,
-                        "description", description,
-                        "pid", targetData.pid,
-                        "accountCreated", accountCreated,
-                        "totalPlayTime", playTime,
-                        "hexedRankTag", targetData.hexedRank().tag,
-                        "hexedRankName", rankName,
-                        "hexedProgress", hexedProgress,
-                        "pvpRating", numberFormat.format(targetData.pvpRating),
-                        "gamesPlayed", numberFormat.format(overallStats.gamesPlayed()),
-                        "gamesWon", numberFormat.format(overallStats.gamesWon()),
-                        "winRate", numberFormat.format(overallStats.winRatePercent()),
-                        "blocksBuilt", numberFormat.format(overallStats.blocksBuilt()),
-                        "blocksDeconstructed", numberFormat.format(overallStats.blocksDeconstructed()),
-                        "blocksDestroyed", numberFormat.format(overallStats.blocksDestroyed()),
-                        "unitsProduced", numberFormat.format(overallStats.unitsProduced()),
-                        "unitsDestroyed", numberFormat.format(overallStats.unitsDestroyed()),
-                        "pvpSummary", formatPvpSummary(local, statsOverview.pvp(), numberFormat),
-                        "survivalSummary", formatSurvivalSummary(local, statsOverview.survival(), numberFormat),
-                        "hexedSummary", formatHexedSummary(local, statsOverview.hexed(), numberFormat),
-                        "admin", targetData.admin ? local.t("yes") : local.t("no"),
-                        "hexedPoints", numberFormat.format(targetData.hexedPoints)
-                ))
-                .ifAddLocal((isOwner || session.player.admin), "player-menu-settings", () -> {
-                    session.pushHistory(() -> player(uuid, targetData));
-                    settings(uuid, targetData);
-                })
-                .ifAddLocal(session.player.admin, "audit-menu-open", () -> {
-                    session.pushHistory(() -> player(uuid, targetData));
-                    auditHistoryMenu.history(uuid, targetData);
-                })
-                .ifAddLocal(session.player.admin, "audit-menu-actions-open", () -> {
-                    session.pushHistory(() -> player(uuid, targetData));
-                    auditHistoryMenu.actions(uuid, targetData);
-                })
-                .end()
-                .addLocalRow("player-menu-players", () -> {
-                    session.pushHistory(() -> player(uuid, targetData));
-                    players(uuid, 1);
-                })
-                .addNavigationRow()
-                .show();
-    }
-
-    private String formatPvpSummary(Localization local, ModeStatsSummary stats, NumberFormat numberFormat) {
-        if (!stats.hasData()) {
-            return local.t("player-menu-player-no-mode-stats");
-        }
-        return local.t("player-menu-player-pvp-summary", args(
-                "gamesPlayed", numberFormat.format(stats.gamesPlayed()),
-                "gamesWon", numberFormat.format(stats.gamesWon()),
-                "winRate", numberFormat.format(stats.winRatePercent())
-        ));
-    }
-
-    private String formatSurvivalSummary(Localization local, ModeStatsSummary stats, NumberFormat numberFormat) {
-        if (!stats.hasData()) {
-            return local.t("player-menu-player-no-mode-stats");
-        }
-        return local.t("player-menu-player-survival-summary", args(
-                "gamesPlayed", numberFormat.format(stats.gamesPlayed()),
-                "bestWave", numberFormat.format(stats.bestWave()),
-                "averageWave", numberFormat.format(stats.averageWave())
-        ));
-    }
-
-    private String formatHexedSummary(Localization local, ModeStatsSummary stats, NumberFormat numberFormat) {
-        if (!stats.hasData()) {
-            return local.t("player-menu-player-no-mode-stats");
-        }
-        return local.t("player-menu-player-hexed-summary", args(
-                "gamesPlayed", numberFormat.format(stats.gamesPlayed()),
-                "gamesWon", numberFormat.format(stats.gamesWon()),
-                "bestPlacement", numberFormat.format(stats.bestPlacement()),
-                "top3Finishes", numberFormat.format(stats.top3Finishes())
-        ));
-    }
-
-    private String formatHexedProgress(Localization local, PlayerData targetData) {
-        var rank = targetData.hexedRank();
-        if (!rank.hasNext()) {
-            return local.t("player-menu-player-max-rank");
-        }
-
-        int currentPoints = targetData.hexedPoints;
-        int requiredPoints = rank.next.requirements.wins();
-        String nextRankName = local.t("hexed-ranks-" + rank.next.name());
-        return local.t("player-menu-player-hexed-progress", args(
-                "currentPoints", currentPoints,
-                "requiredPoints", requiredPoints,
-                "nextRankName", nextRankName
-        ));
+        session.menuService.renderRoute(session, MenuRoute.of(PlayerProfileFlows.ROUTE_PLAYER).withParam("targetUuid", targetData.uuid));
     }
 
     public void players(String uuid, int page) {
         Session session = sessionService.get(uuid);
         if (session == null || session.data == null) return;
         session.clear();
-
-        List<Session> onlinePlayers = getFilteredOnlinePlayers(session);
-        int totalPlayers = onlinePlayers.size();
-        int perPage = globalConfig.eventsPerPage;
-        var pagination = CustomGatherers.calculatePagination(totalPlayers, perPage);
-        int totalPages = Math.max(1, pagination.totalPages());
-
-        int validPage = pagination.totalPages() <= 0 ? 1 : pagination.clampPage(page);
-        int skip = (validPage - 1) * perPage;
-        List<Session> players = onlinePlayers.stream()
-                .skip(skip)
-                .limit(perPage)
-                .toList();
-
-        String menuContent;
-        if (totalPlayers == 0) {
-            menuContent = session.locale().t("player-menu-players-empty");
-        } else {
-            menuContent = session.locale().t("player-menu-players-content", args(
-                "page", validPage,
-                "total", totalPages
-            ));
-        }
-
-        session.builder()
-                .title("player-menu-players-title")
-                .rawContent(menuContent)
-
-                .addStatusButton("admin", () -> players(uuid, 1))
-
-                .start()
-                    .ifAddLocal(validPage > 1, "previous", () -> players(uuid, validPage - 1))
-                    .ifAddLocal(validPage < totalPages, "next", () -> players(uuid, validPage + 1))
-                .end()
-
-                .addForEach(players, (b, onlinePlayer) -> b.addRow(session.locale().t("player-menu-players-row", args(
-                        "nickname", playerDisplayService.resolveBaseName(onlinePlayer.data, onlinePlayer.player),
-                        "pid", onlinePlayer.data.pid
-                )), () -> {
-                    session.pushHistory(() -> players(uuid, validPage));
-                    player(uuid, onlinePlayer.data);
-                }))
-
-                .addNavigationRow()
-                .show();
-    }
-
-    private List<Session> getFilteredOnlinePlayers(Session viewerSession) {
-        return streamCachedPlayers()
-                .filter(onlineSession -> onlineSession != null && onlineSession.data != null && onlineSession.player != null)
-                .filter(onlineSession -> matchesAdminFilter(viewerSession, onlineSession))
-                .sorted(Comparator
-                        .comparing((Session onlineSession) -> playerDisplayService.resolveBaseName(onlineSession.data, onlineSession.player), String.CASE_INSENSITIVE_ORDER)
-                        .thenComparingInt(onlineSession -> onlineSession.data.pid))
-                .toList();
-    }
-
-    private java.util.stream.Stream<Session> streamCachedPlayers() {
-        return sessionService.streamCached();
-    }
-
-    private boolean matchesAdminFilter(Session viewerSession, Session onlineSession) {
-        var adminFilter = viewerSession.sortStatus.get("admin");
-        boolean isAdmin = onlineSession.player.admin || onlineSession.data.admin;
-
-        if (adminFilter == null) {
-            return true;
-        }
-
-        return switch (adminFilter) {
-            case Active -> isAdmin;
-            case Inactive -> !isAdmin;
-            case Neutral -> true;
-        };
+        session.menuService.renderRoute(session, MenuRoute.of(PlayerProfileFlows.ROUTE_PLAYERS).withParam("page", String.valueOf(page)));
     }
 
     public void settings(String uuid, PlayerData targetData) {
@@ -275,91 +85,7 @@ public class PlayerMenu extends Menu {
             return;
         }
 
-        Localization local = session.locale();
-
-        String customNickDisplay = (targetData.customNickname == null || targetData.customNickname.isEmpty())
-                ? local.t("none") : targetData.customNickname;
-        String descDisplay = (targetData.description == null || targetData.description.isEmpty())
-                ? local.t("no-description") : targetData.description;
-        String activeBadge = activeBadgeName(local, targetData);
-        String systemBadge = systemBadgeName(local, targetData);
-        String globalChat = targetData.globalChatVisible ? local.t("yes") : local.t("no");
-        String discordRelay = targetData.discordRelayVisible ? local.t("yes") : local.t("no");
-
-        session.builder().title("player-menu-settings-title")
-                .content("player-menu-settings-content", args(
-                        "nickname", targetData.nickname,
-                        "customNickname", customNickDisplay,
-                        "activeBadge", activeBadge,
-                        "systemBadge", systemBadge,
-                        "description", descDisplay,
-                        "leaderboard", targetData.leaderboard ? local.t("yes") : local.t("no"),
-                        "language", local.getLanguageName(targetData.language, "auto"),
-                        "translatorLanguage", local.getLanguageName(targetData.translatorLanguage, "off"),
-                        "globalChat", globalChat,
-                        "discordRelay", discordRelay
-                ))
-                .start()
-                    .addLocal("player-menu-settings-customNickname", () -> {
-                        var prompt = new MenuPrompt(
-                                "custom-nickname",
-                                local.t("player-menu-settings-customNickname-title"),
-                                local.t("player-menu-settings-customNickname-message"),
-                                256, targetData.customNickname, false);
-                        session.menuService.openPrompt(session, prompt,
-                                text -> {
-                                    String newNick = text == null || text.trim().isEmpty() ? "" : text;
-                                    if (!newNick.isEmpty()) {
-                                        var result = profileSettings.validateCustomNickname(newNick);
-                                        if (!result.valid()) {
-                                            local.send(result.errorKey(), args("max", result.maxBytes()));
-                                            settings(uuid, targetData);
-                                            return;
-                                        }
-                                    }
-                                    profileSettings.updateCustomNickname(targetData, newNick, true, true);
-                                    settings(uuid, targetData);
-                                },
-                                () -> settings(uuid, targetData));
-                    })
-                    .addLocal("player-menu-settings-customNickname-reset", () -> {
-                        profileSettings.updateCustomNickname(targetData, "", true, true);
-                        settings(uuid, targetData);
-                    })
-                    .addLocal("player-menu-settings-description", () -> {
-                        var prompt = new MenuPrompt(
-                                "description",
-                                local.t("player-menu-settings-description-title"),
-                                "",
-                                1000, targetData.description, false);
-                        session.menuService.openPrompt(session, prompt,
-                                text -> {
-                                    profileSettings.updateDescription(targetData, text);
-                                    settings(uuid, targetData);
-                                },
-                                () -> settings(uuid, targetData));
-                    })
-                .end()
-                .addLocalRow("player-menu-settings-chat", () -> {
-                    session.pushHistory(() -> settings(uuid, targetData));
-                    chatSettings(uuid, targetData);
-                })
-                .addLocalRow("player-menu-settings-badges", () -> {
-                    session.pushHistory(() -> settings(uuid, targetData));
-                    badges(uuid, targetData);
-                })
-                .addLocalRow(targetData.leaderboard ? "player-leaderboard-active" : "player-leaderboard-inactive", () -> {
-                    profileSettings.updateLeaderboard(targetData, !targetData.leaderboard);
-                    settings(uuid, targetData);
-                })
-                .start()
-                    .add(local.t("settings-language-label", args("lang", local.getLanguageName(targetData.language, "auto"))), () -> {
-                        session.pushHistory(() -> settings(uuid, targetData));
-                        languageSelectionMenu(uuid, targetData, false);
-                    })
-                .end()
-                .addNavigationRow()
-                .show();
+        session.menuService.renderRoute(session, MenuRoute.of(PlayerSettingsFlows.ROUTE_SETTINGS).withParam("targetUuid", targetData.uuid));
     }
 
     public void chatSettings(String uuid, PlayerData targetData) {
@@ -376,66 +102,17 @@ public class PlayerMenu extends Menu {
             return;
         }
 
-        Localization local = session.locale();
-
-        session.builder()
-                .title("player-menu-settings-chat-title")
-                .content("player-menu-settings-chat-content", args(
-                        "globalChat", targetData.globalChatVisible ? local.t("yes") : local.t("no"),
-                        "discordRelay", targetData.discordRelayVisible ? local.t("yes") : local.t("no"),
-                        "translatorLanguage", local.getLanguageName(targetData.translatorLanguage, "off")
-                ))
-                .addLocalRow(targetData.globalChatVisible ? "player-menu-settings-global-chat-on" : "player-menu-settings-global-chat-off", () -> {
-                    profileSettings.updateGlobalChatVisible(targetData, !targetData.globalChatVisible);
-                    chatSettings(uuid, targetData);
-                })
-                .addLocalRow(targetData.discordRelayVisible ? "player-menu-settings-discord-relay-on" : "player-menu-settings-discord-relay-off", () -> {
-                    profileSettings.updateDiscordRelayVisible(targetData, !targetData.discordRelayVisible);
-                    chatSettings(uuid, targetData);
-                })
-                .addRow(local.t("settings-translator-label", args("lang", local.getLanguageName(targetData.translatorLanguage, "off"))), () -> {
-                    session.pushHistory(() -> chatSettings(uuid, targetData));
-                    languageSelectionMenu(uuid, targetData, true);
-                })
-                .addNavigationRow()
-                .show();
+        session.menuService.renderRoute(session, MenuRoute.of(PlayerSettingsFlows.ROUTE_CHAT_SETTINGS).withParam("targetUuid", targetData.uuid));
     }
 
     public void languageSelectionMenu(String uuid, PlayerData targetData, boolean isTranslator) {
         Session session = sessionService.get(uuid);
         if (session == null || session.data == null) return;
         session.clear();
-        Seq<Locale> locales = bundle.getAvailableLocales();
-        Localization local = session.locale();
 
-        var builder = session.builder()
-                .title(isTranslator ? "player-menu-settings-translator-title" : "player-menu-settings-language-title")
-                .start()
-                    .addLocal(isTranslator ? "default" : "auto", () -> {
-                        if (isTranslator) {
-                            profileSettings.updateTranslatorLanguage(targetData, "off");
-                        } else {
-                            profileSettings.updateLanguage(targetData, "auto");
-                        }
-                        session.popHistory().run();
-                    })
-                .end();
-
-        builder.addForEach(locales, (b, loc) -> {
-            String code = "uk".equals(loc.getLanguage()) ? "uk_UA" : loc.getLanguage();
-            String langName = Strings.capitalize(loc.getDisplayLanguage(loc));
-
-            b.addRow(langName, () -> {
-                        if (isTranslator) {
-                            profileSettings.updateTranslatorLanguage(targetData, code);
-                        } else {
-                            profileSettings.updateLanguage(targetData, code);
-                        }
-                        session.popHistory().run();
-                    });
-        });
-
-        builder.addNavigationRow().show();
+        session.menuService.renderRoute(session, MenuRoute.of(PlayerSettingsFlows.ROUTE_LANGUAGE_SELECTION)
+                .withParam("targetUuid", targetData.uuid)
+                .withParam("isTranslator", String.valueOf(isTranslator)));
     }
 
     public void badges(String uuid, PlayerData targetData) {
@@ -452,46 +129,7 @@ public class PlayerMenu extends Menu {
             return;
         }
 
-        Localization local = session.locale();
-        List<Badge> badges = unlockedSelectableBadges(targetData);
-        String header = local.t("badge-menu-content", args(
-                "systemBadge", systemBadgeName(local, targetData),
-                "activeBadge", activeBadgeName(local, targetData),
-                "symbolColorMode", badgeSymbolColorModeLabel(local, targetData)
-        ));
-
-        var builder = session.builder()
-                .title("badge-menu-title")
-                .rawContent(badges.isEmpty() ? header + "\n" + local.t("badge-menu-empty") : header);
-
-        if (!badges.isEmpty()) {
-            builder.addForEach(badges, (b, badge) -> b.addRow(local.t("badge-menu-row", args(
-                    "badge", badgeLabel(local, badge),
-                    "description", local.t(badge.descriptionKey())
-            )), () -> {
-                profileSettings.updateActiveBadge(targetData, badge.id(), true, true);
-                badges(uuid, targetData);
-            }));
-        }
-
-        builder.start()
-                .addLocal("badge-menu-symbol-color-button", () -> {
-                    session.pushHistory(() -> badges(uuid, targetData));
-                    badgeSymbolColorMode(uuid, targetData);
-                }, args("mode", badgeSymbolColorModeLabel(local, targetData)))
-                .end()
-                .start()
-                .addLocal("badge-menu-view-all", () -> {
-                    session.pushHistory(() -> badges(uuid, targetData));
-                    allBadges(uuid, targetData);
-                })
-                .addLocal("badge-clear-button", () -> {
-                    profileSettings.updateActiveBadge(targetData, "", true, true);
-                    badges(uuid, targetData);
-                })
-                .end()
-                .addNavigationRow()
-                .show();
+        session.menuService.renderRoute(session, MenuRoute.of(PlayerSettingsFlows.ROUTE_BADGES).withParam("targetUuid", targetData.uuid));
     }
 
     public void badgeSymbolColorMode(String uuid, PlayerData targetData) {
@@ -508,23 +146,7 @@ public class PlayerMenu extends Menu {
             return;
         }
 
-        Localization local = session.locale();
-
-        session.builder()
-                .title("badge-menu-symbol-color-title")
-                .content("badge-menu-symbol-color-content", args(
-                        "mode", badgeSymbolColorModeLabel(local, targetData)
-                ))
-                .addLocalRow("badge-menu-symbol-color-default", () -> {
-                    profileSettings.updateBadgeSymbolColorMode(targetData, "default", true, true);
-                    badgeSymbolColorMode(uuid, targetData);
-                })
-                .addLocalRow("badge-menu-symbol-color-player-color", () -> {
-                    profileSettings.updateBadgeSymbolColorMode(targetData, "player-color", true, true);
-                    badgeSymbolColorMode(uuid, targetData);
-                })
-                .addNavigationRow()
-                .show();
+        session.menuService.renderRoute(session, MenuRoute.of(PlayerSettingsFlows.ROUTE_BADGE_SYMBOL_COLOR).withParam("targetUuid", targetData.uuid));
     }
 
     public void allBadges(String uuid, PlayerData targetData) {
@@ -541,77 +163,6 @@ public class PlayerMenu extends Menu {
             return;
         }
 
-        Localization local = session.locale();
-        var builder = session.builder()
-                .title("badge-menu-all-title")
-                .content("badge-menu-all-content");
-
-        builder.addForEach(List.of(Badge.values()), (b, badge) -> b.addRow(local.t("badge-menu-all-row", args(
-                "badge", badgeLabel(local, badge),
-                "state", badgeState(local, targetData, badge),
-                "description", local.t(badge.descriptionKey())
-        )), () -> {
-            if (badge.selectable() && !badge.system() && ownsBadge(targetData, badge)) {
-                profileSettings.updateActiveBadge(targetData, badge.id(), true, true);
-            }
-            allBadges(uuid, targetData);
-        }));
-
-        builder.addNavigationRow().show();
+        session.menuService.renderRoute(session, MenuRoute.of(PlayerSettingsFlows.ROUTE_ALL_BADGES).withParam("targetUuid", targetData.uuid));
     }
-
-    private String activeBadgeName(Localization local, PlayerData targetData) {
-        Badge badge = Badge.byId(targetData.activeBadge);
-        if (badge == null || targetData.unlockedBadges == null || !targetData.unlockedBadges.contains(badge.id())) {
-            return local.t("none");
-        }
-        return badgeLabel(local, badge);
-    }
-
-    private String systemBadgeName(Localization local, PlayerData targetData) {
-        return targetData.admin ? badgeLabel(local, Badge.ADMIN) : local.t("none");
-    }
-
-    private String badgeSymbolColorModeLabel(Localization local, PlayerData targetData) {
-        return usesPlayerBadgeSymbolColor(targetData)
-                ? local.t("badge-menu-symbol-color-player-color")
-                : local.t("badge-menu-symbol-color-default");
-    }
-
-    private List<Badge> unlockedSelectableBadges(PlayerData targetData) {
-        List<Badge> result = new ArrayList<>();
-        for (Badge badge : Badge.selectableManualBadges()) {
-            if (targetData.unlockedBadges != null && targetData.unlockedBadges.contains(badge.id())) {
-                result.add(badge);
-            }
-        }
-        return result;
-    }
-
-    private String badgeLabel(Localization local, Badge badge) {
-        return badge.tag() + " " + local.t(badge.nameKey());
-    }
-
-    private String badgeState(Localization local, PlayerData targetData, Badge badge) {
-        if (badge.system()) {
-            return targetData.admin ? local.t("badge-state-system-active") : local.t("badge-state-system");
-        }
-
-        if (badge.id().equals(targetData.activeBadge) && ownsBadge(targetData, badge)) {
-            return local.t("badge-state-active");
-        }
-
-        return ownsBadge(targetData, badge) ? local.t("badge-state-unlocked") : local.t("badge-state-locked");
-    }
-
-    private boolean ownsBadge(PlayerData targetData, Badge badge) {
-        return targetData.unlockedBadges != null && targetData.unlockedBadges.contains(badge.id());
-    }
-
-    private boolean usesPlayerBadgeSymbolColor(PlayerData targetData) {
-        return targetData != null
-                && targetData.badgeSymbolColorMode != null
-                && targetData.badgeSymbolColorMode.equalsIgnoreCase("player-color");
-    }
-
 }

--- a/src/main/java/org/xcore/plugin/ui/menu/PlayerProfileFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/PlayerProfileFlows.java
@@ -116,7 +116,7 @@ final class PlayerProfileFlows {
             rows.add(List.of(MenuButton.of(local.t("player-menu-players"), ACTION_PLAYERS)));
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -267,7 +267,7 @@ final class PlayerProfileFlows {
             }
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));

--- a/src/main/java/org/xcore/plugin/ui/menu/PlayerProfileFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/PlayerProfileFlows.java
@@ -1,0 +1,433 @@
+package org.xcore.plugin.ui.menu;
+
+import org.xcore.plugin.common.CustomGatherers;
+import org.xcore.plugin.common.StatusEnum;
+import org.xcore.plugin.database.repository.GameDataRepository;
+import org.xcore.plugin.localization.Localization;
+import org.xcore.plugin.model.ModeStatsSummary;
+import org.xcore.plugin.model.PlayerData;
+import org.xcore.plugin.model.PlayerStatsOverview;
+import org.xcore.plugin.service.PlayerDisplayService;
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuRenderContext;
+import org.xcore.plugin.ui.flow.MenuScreen;
+import org.xcore.plugin.ui.route.MenuRoute;
+import org.xcore.plugin.ui.route.RoutedMenuFlow;
+
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+import static com.ospx.flubundle.Bundle.args;
+
+final class PlayerProfileFlows {
+
+    static final String ROUTE_PLAYER = "player.profile";
+    static final String ROUTE_PLAYERS = "player.players";
+
+    private static final String ACTION_BACK = "back";
+    private static final String ACTION_CLOSE = "close";
+    private static final String ACTION_SETTINGS = "settings";
+    private static final String ACTION_AUDIT_HISTORY = "audit-history";
+    private static final String ACTION_AUDIT_ACTIONS = "audit-actions";
+    private static final String ACTION_PLAYERS = "players";
+    private static final String ACTION_ADMIN_FILTER = "admin-filter";
+    private static final String ACTION_PREV = "prev";
+    private static final String ACTION_NEXT = "next";
+    private static final String ACTION_SELECT_PREFIX = "select-";
+
+    private PlayerProfileFlows() {
+    }
+
+    static final class PlayerFlow implements RoutedMenuFlow<PlayerState> {
+        private final PlayerMenu menu;
+        private final GameDataRepository gameDataRepository;
+        private final AuditHistoryMenu auditHistoryMenu;
+
+        PlayerFlow(PlayerMenu menu, GameDataRepository gameDataRepository, AuditHistoryMenu auditHistoryMenu) {
+            this.menu = menu;
+            this.gameDataRepository = gameDataRepository;
+            this.auditHistoryMenu = auditHistoryMenu;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_PLAYER;
+        }
+
+        @Override
+        public PlayerState createState(Session session, MenuRoute route, PlayerState currentState) {
+            String targetUuid = route.param("targetUuid");
+            if (currentState != null && Objects.equals(currentState.targetUuid, targetUuid)) {
+                return currentState;
+            }
+            return new PlayerState(targetUuid);
+        }
+
+        @Override
+        public Class<PlayerState> stateType() {
+            return PlayerState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<PlayerState> context) {
+            Session session = context.session();
+            PlayerState state = context.state();
+            PlayerData targetData = session.playerDataRepository.findByUuid(state.targetUuid);
+
+            if (targetData == null) {
+                session.locale().send("error-player-not-found");
+                return errorScreen(session, "player-menu-player-title", "error-player-not-found");
+            }
+
+            Localization local = context.locale();
+            boolean isOwner = session.data.uuid.equals(targetData.uuid);
+
+            String customNickname = targetData.customNickname == null || Objects.equals(targetData.customNickname, "")
+                    ? targetData.nickname : targetData.customNickname;
+            String description = targetData.description == null || Objects.equals(targetData.description, "")
+                    ? local.t("no-description") : targetData.description;
+            String activeBadge = PlayerSettingsFlows.activeBadgeName(local, targetData);
+            String systemBadge = PlayerSettingsFlows.systemBadgeName(local, targetData);
+            String accountCreated = menu.formatTime(targetData.createdModelTime, session);
+            String playTime = menu.formatPlayTime(targetData.totalPlayTime, local);
+            String rankName = local.t("hexed-ranks-" + targetData.hexedRank().name());
+            String hexedProgress = formatHexedProgress(local, targetData);
+            PlayerStatsOverview statsOverview = gameDataRepository.aggregatePlayerStatsOverview(targetData.uuid);
+            var overallStats = statsOverview.overall();
+            NumberFormat numberFormat = NumberFormat.getIntegerInstance(local.getLocale());
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+            List<MenuButton> actions = new ArrayList<>();
+            if (isOwner || session.player.admin) {
+                actions.add(MenuButton.of(local.t("player-menu-settings"), ACTION_SETTINGS));
+            }
+            if (session.player.admin) {
+                actions.add(MenuButton.of(local.t("audit-menu-open"), ACTION_AUDIT_HISTORY));
+                actions.add(MenuButton.of(local.t("audit-menu-actions-open"), ACTION_AUDIT_ACTIONS));
+            }
+            if (!actions.isEmpty()) {
+                rows.add(actions);
+            }
+            rows.add(List.of(MenuButton.of(local.t("player-menu-players"), ACTION_PLAYERS)));
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.hasHistory() || session.hasRouteHistory()) {
+                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.normal(
+                    local.t("player-menu-player-title"),
+                    local.t("player-menu-player-content", args(
+                            "nickname", targetData.nickname,
+                            "customNickname", customNickname,
+                            "activeBadge", activeBadge,
+                            "systemBadge", systemBadge,
+                            "description", description,
+                            "pid", targetData.pid,
+                            "accountCreated", accountCreated,
+                            "totalPlayTime", playTime,
+                            "hexedRankTag", targetData.hexedRank().tag,
+                            "hexedRankName", rankName,
+                            "hexedProgress", hexedProgress,
+                            "pvpRating", numberFormat.format(targetData.pvpRating),
+                            "gamesPlayed", numberFormat.format(overallStats.gamesPlayed()),
+                            "gamesWon", numberFormat.format(overallStats.gamesWon()),
+                            "winRate", numberFormat.format(overallStats.winRatePercent()),
+                            "blocksBuilt", numberFormat.format(overallStats.blocksBuilt()),
+                            "blocksDeconstructed", numberFormat.format(overallStats.blocksDeconstructed()),
+                            "blocksDestroyed", numberFormat.format(overallStats.blocksDestroyed()),
+                            "unitsProduced", numberFormat.format(overallStats.unitsProduced()),
+                            "unitsDestroyed", numberFormat.format(overallStats.unitsDestroyed()),
+                            "pvpSummary", formatPvpSummary(local, statsOverview.pvp(), numberFormat),
+                            "survivalSummary", formatSurvivalSummary(local, statsOverview.survival(), numberFormat),
+                            "hexedSummary", formatHexedSummary(local, statsOverview.hexed(), numberFormat),
+                            "admin", targetData.admin ? local.t("yes") : local.t("no"),
+                            "hexedPoints", numberFormat.format(targetData.hexedPoints)
+                    )),
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<PlayerState> context, String actionId) {
+            Session session = context.session();
+            PlayerState state = context.state();
+            PlayerData targetData = session.playerDataRepository.findByUuid(state.targetUuid);
+            if (targetData == null) {
+                return;
+            }
+
+            switch (actionId) {
+                case ACTION_SETTINGS -> context.openRoute(MenuRoute.of(PlayerSettingsFlows.ROUTE_SETTINGS).withParam("targetUuid", state.targetUuid));
+                case ACTION_AUDIT_HISTORY -> auditHistoryMenu.history(session.data.uuid, targetData);
+                case ACTION_AUDIT_ACTIONS -> auditHistoryMenu.actions(session.data.uuid, targetData);
+                case ACTION_PLAYERS -> context.openRoute(MenuRoute.of(ROUTE_PLAYERS).withParam("page", "1"));
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+            }
+        }
+    }
+
+    static final class PlayersFlow implements RoutedMenuFlow<PlayersState> {
+        private final PlayerMenu menu;
+        private final SessionService sessionService;
+        private final PlayerDisplayService playerDisplayService;
+
+        PlayersFlow(PlayerMenu menu, SessionService sessionService, PlayerDisplayService playerDisplayService) {
+            this.menu = menu;
+            this.sessionService = sessionService;
+            this.playerDisplayService = playerDisplayService;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_PLAYERS;
+        }
+
+        @Override
+        public PlayersState createState(Session session, MenuRoute route, PlayersState currentState) {
+            int page = route.intParam("page", 1);
+            if (currentState != null && currentState.page == page) {
+                return currentState;
+            }
+            return new PlayersState(page);
+        }
+
+        @Override
+        public Class<PlayersState> stateType() {
+            return PlayersState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<PlayersState> context) {
+            Session session = context.session();
+            PlayersState state = context.state();
+            Localization local = context.locale();
+
+            List<Session> onlinePlayers = getFilteredOnlinePlayers(session, sessionService, playerDisplayService);
+            int totalPlayers = onlinePlayers.size();
+            int perPage = menu.globalConfig.eventsPerPage;
+            var pagination = CustomGatherers.calculatePagination(totalPlayers, perPage);
+            int totalPages = Math.max(1, pagination.totalPages());
+            int validPage = pagination.totalPages() <= 0 ? 1 : pagination.clampPage(state.page);
+            int skip = (validPage - 1) * perPage;
+            List<Session> players = onlinePlayers.stream()
+                    .skip(skip)
+                    .limit(perPage)
+                    .toList();
+
+            String menuContent;
+            if (totalPlayers == 0) {
+                menuContent = local.t("player-menu-players-empty");
+            } else {
+                menuContent = local.t("player-menu-players-content", args(
+                        "page", validPage,
+                        "total", totalPages
+                ));
+            }
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+
+            StatusEnum adminStatus = session.sortStatus.getOrDefault("admin", StatusEnum.Neutral);
+            String adminLabel;
+            if (adminStatus == StatusEnum.Active) {
+                adminLabel = local.t("admin-active");
+            } else if (adminStatus == StatusEnum.Inactive) {
+                adminLabel = local.t("admin-inactive");
+            } else {
+                adminLabel = local.t("admin-neutral");
+            }
+            rows.add(List.of(MenuButton.of(adminLabel, ACTION_ADMIN_FILTER)));
+
+            List<MenuButton> paginationRow = new ArrayList<>();
+            if (validPage > 1) {
+                paginationRow.add(MenuButton.of(local.t("previous"), ACTION_PREV));
+            }
+            if (validPage < totalPages) {
+                paginationRow.add(MenuButton.of(local.t("next"), ACTION_NEXT));
+            }
+            if (!paginationRow.isEmpty()) {
+                rows.add(paginationRow);
+            }
+
+            for (int i = 0; i < players.size(); i++) {
+                Session onlinePlayer = players.get(i);
+                String label = local.t("player-menu-players-row", args(
+                        "nickname", playerDisplayService.resolveBaseName(onlinePlayer.data, onlinePlayer.player),
+                        "pid", onlinePlayer.data.pid
+                ));
+                rows.add(List.of(MenuButton.of(label, ACTION_SELECT_PREFIX + i)));
+            }
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.hasHistory() || session.hasRouteHistory()) {
+                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.normal(
+                    local.t("player-menu-players-title"),
+                    menuContent,
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<PlayersState> context, String actionId) {
+            Session session = context.session();
+            PlayersState state = context.state();
+
+            switch (actionId) {
+                case ACTION_ADMIN_FILTER -> {
+                    session.setNextStatus("admin");
+                    state.page = 1;
+                    context.render();
+                }
+                case ACTION_PREV -> {
+                    state.page = Math.max(1, state.page - 1);
+                    context.render();
+                }
+                case ACTION_NEXT -> {
+                    state.page = state.page + 1;
+                    context.render();
+                }
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                default -> {
+                    if (actionId.startsWith(ACTION_SELECT_PREFIX)) {
+                        int index = Integer.parseInt(actionId.substring(ACTION_SELECT_PREFIX.length()));
+                        List<Session> onlinePlayers = getFilteredOnlinePlayers(session, sessionService, playerDisplayService);
+                        int perPage = menu.globalConfig.eventsPerPage;
+                        var pagination = CustomGatherers.calculatePagination(onlinePlayers.size(), perPage);
+                        int validPage = pagination.totalPages() <= 0 ? 1 : pagination.clampPage(state.page);
+                        int skip = (validPage - 1) * perPage;
+                        List<Session> players = onlinePlayers.stream()
+                                .skip(skip)
+                                .limit(perPage)
+                                .toList();
+                        if (index >= 0 && index < players.size()) {
+                            Session onlinePlayer = players.get(index);
+                            context.openRoute(MenuRoute.of(ROUTE_PLAYER).withParam("targetUuid", onlinePlayer.data.uuid));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    static final class PlayerState {
+        public String targetUuid;
+
+        public PlayerState() {
+        }
+
+        public PlayerState(String targetUuid) {
+            this.targetUuid = targetUuid;
+        }
+    }
+
+    static final class PlayersState {
+        public int page;
+
+        public PlayersState() {
+        }
+
+        public PlayersState(int page) {
+            this.page = page;
+        }
+    }
+
+    private static MenuScreen errorScreen(Session session, String titleKey, String messageKey) {
+        Localization local = session.locale();
+        return MenuScreen.normal(
+                local.t(titleKey),
+                local.t(messageKey),
+                List.of(List.of(MenuButton.of(local.t("close"), ACTION_CLOSE)))
+        );
+    }
+
+    private static String formatPvpSummary(Localization local, ModeStatsSummary stats, NumberFormat numberFormat) {
+        if (!stats.hasData()) {
+            return local.t("player-menu-player-no-mode-stats");
+        }
+        return local.t("player-menu-player-pvp-summary", args(
+                "gamesPlayed", numberFormat.format(stats.gamesPlayed()),
+                "gamesWon", numberFormat.format(stats.gamesWon()),
+                "winRate", numberFormat.format(stats.winRatePercent())
+        ));
+    }
+
+    private static String formatSurvivalSummary(Localization local, ModeStatsSummary stats, NumberFormat numberFormat) {
+        if (!stats.hasData()) {
+            return local.t("player-menu-player-no-mode-stats");
+        }
+        return local.t("player-menu-player-survival-summary", args(
+                "gamesPlayed", numberFormat.format(stats.gamesPlayed()),
+                "bestWave", numberFormat.format(stats.bestWave()),
+                "averageWave", numberFormat.format(stats.averageWave())
+        ));
+    }
+
+    private static String formatHexedSummary(Localization local, ModeStatsSummary stats, NumberFormat numberFormat) {
+        if (!stats.hasData()) {
+            return local.t("player-menu-player-no-mode-stats");
+        }
+        return local.t("player-menu-player-hexed-summary", args(
+                "gamesPlayed", numberFormat.format(stats.gamesPlayed()),
+                "gamesWon", numberFormat.format(stats.gamesWon()),
+                "bestPlacement", numberFormat.format(stats.bestPlacement()),
+                "top3Finishes", numberFormat.format(stats.top3Finishes())
+        ));
+    }
+
+    private static String formatHexedProgress(Localization local, PlayerData targetData) {
+        var rank = targetData.hexedRank();
+        if (!rank.hasNext()) {
+            return local.t("player-menu-player-max-rank");
+        }
+
+        int currentPoints = targetData.hexedPoints;
+        int requiredPoints = rank.next.requirements.wins();
+        String nextRankName = local.t("hexed-ranks-" + rank.next.name());
+        return local.t("player-menu-player-hexed-progress", args(
+                "currentPoints", currentPoints,
+                "requiredPoints", requiredPoints,
+                "nextRankName", nextRankName
+        ));
+    }
+
+    private static List<Session> getFilteredOnlinePlayers(Session viewerSession,
+                                                          SessionService sessionService,
+                                                          PlayerDisplayService playerDisplayService) {
+        return sessionService.streamCached()
+                .filter(onlineSession -> onlineSession != null && onlineSession.data != null && onlineSession.player != null)
+                .filter(onlineSession -> matchesAdminFilter(viewerSession, onlineSession))
+                .sorted(Comparator
+                        .comparing((Session onlineSession) -> playerDisplayService.resolveBaseName(onlineSession.data, onlineSession.player), String.CASE_INSENSITIVE_ORDER)
+                        .thenComparingInt(onlineSession -> onlineSession.data.pid))
+                .toList();
+    }
+
+    private static boolean matchesAdminFilter(Session viewerSession, Session onlineSession) {
+        var adminFilter = viewerSession.sortStatus.get("admin");
+        boolean isAdmin = onlineSession.player.admin || onlineSession.data.admin;
+
+        if (adminFilter == null) {
+            return true;
+        }
+
+        return switch (adminFilter) {
+            case Active -> isAdmin;
+            case Inactive -> !isAdmin;
+            case Neutral -> true;
+        };
+    }
+}

--- a/src/main/java/org/xcore/plugin/ui/menu/PlayerProfileFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/PlayerProfileFlows.java
@@ -116,7 +116,7 @@ final class PlayerProfileFlows {
             rows.add(List.of(MenuButton.of(local.t("player-menu-players"), ACTION_PLAYERS)));
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack(true)) {
+            if (session.canGoBack()) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -267,7 +267,7 @@ final class PlayerProfileFlows {
             }
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack(true)) {
+            if (session.canGoBack()) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));

--- a/src/main/java/org/xcore/plugin/ui/menu/PlayerSettingsFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/PlayerSettingsFlows.java
@@ -129,7 +129,7 @@ final class PlayerSettingsFlows {
                     ACTION_LANGUAGE)));
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -291,7 +291,7 @@ final class PlayerSettingsFlows {
                     ACTION_TRANSLATOR_LANGUAGE)));
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -398,7 +398,7 @@ final class PlayerSettingsFlows {
             }
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -486,7 +486,7 @@ final class PlayerSettingsFlows {
             rows.add(List.of(MenuButton.of(local.t("badge-menu-symbol-color-player-color"), ACTION_SET_PLAYER_COLOR_MODE)));
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -594,7 +594,7 @@ final class PlayerSettingsFlows {
             rows.add(bottomRow);
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -690,7 +690,7 @@ final class PlayerSettingsFlows {
             }
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));

--- a/src/main/java/org/xcore/plugin/ui/menu/PlayerSettingsFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/PlayerSettingsFlows.java
@@ -129,7 +129,7 @@ final class PlayerSettingsFlows {
                     ACTION_LANGUAGE)));
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack(true)) {
+            if (session.canGoBack()) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -291,7 +291,7 @@ final class PlayerSettingsFlows {
                     ACTION_TRANSLATOR_LANGUAGE)));
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack(true)) {
+            if (session.canGoBack()) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -398,7 +398,7 @@ final class PlayerSettingsFlows {
             }
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack(true)) {
+            if (session.canGoBack()) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -486,7 +486,7 @@ final class PlayerSettingsFlows {
             rows.add(List.of(MenuButton.of(local.t("badge-menu-symbol-color-player-color"), ACTION_SET_PLAYER_COLOR_MODE)));
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack(true)) {
+            if (session.canGoBack()) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -594,7 +594,7 @@ final class PlayerSettingsFlows {
             rows.add(bottomRow);
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack(true)) {
+            if (session.canGoBack()) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -690,7 +690,7 @@ final class PlayerSettingsFlows {
             }
 
             List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack(true)) {
+            if (session.canGoBack()) {
                 navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));

--- a/src/main/java/org/xcore/plugin/ui/menu/PlayerSettingsFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/PlayerSettingsFlows.java
@@ -1,0 +1,863 @@
+package org.xcore.plugin.ui.menu;
+
+import arc.struct.Seq;
+import arc.util.Strings;
+import com.ospx.flubundle.Bundle;
+import org.xcore.plugin.localization.Localization;
+import org.xcore.plugin.model.PlayerData;
+import org.xcore.plugin.player.Badge;
+import org.xcore.plugin.service.PlayerProfileSettingsService;
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuPrompt;
+import org.xcore.plugin.ui.flow.MenuRenderContext;
+import org.xcore.plugin.ui.flow.MenuScreen;
+import org.xcore.plugin.ui.route.MenuRoute;
+import org.xcore.plugin.ui.route.RoutedMenuFlow;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import static com.ospx.flubundle.Bundle.args;
+
+final class PlayerSettingsFlows {
+
+    static final String ROUTE_CHAT_SETTINGS = "player.chat-settings";
+    static final String ROUTE_BADGES = "player.badges";
+    static final String ROUTE_ALL_BADGES = "player.all-badges";
+    static final String ROUTE_SETTINGS = "player.settings";
+    static final String ROUTE_LANGUAGE_SELECTION = "player.language-selection";
+    static final String ROUTE_BADGE_SYMBOL_COLOR = "player.badge-symbol-color";
+
+    private static final String ACTION_TOGGLE_GLOBAL_CHAT = "toggle-global-chat";
+    private static final String ACTION_TOGGLE_DISCORD_RELAY = "toggle-discord-relay";
+    private static final String ACTION_TRANSLATOR_LANGUAGE = "translator-language";
+    private static final String ACTION_BACK = "back";
+    private static final String ACTION_CLOSE = "close";
+    private static final String ACTION_SET_DEFAULT_MODE = "set-default-mode";
+    private static final String ACTION_SET_PLAYER_COLOR_MODE = "set-player-color-mode";
+    private static final String ACTION_SYMBOL_COLOR_MODE = "symbol-color-mode";
+    private static final String ACTION_VIEW_ALL = "view-all";
+    private static final String ACTION_CLEAR = "clear";
+    private static final String ACTION_CUSTOM_NICKNAME = "custom-nickname";
+    private static final String ACTION_CUSTOM_NICKNAME_RESET = "custom-nickname-reset";
+    private static final String ACTION_DESCRIPTION = "description";
+    private static final String ACTION_CHAT_SETTINGS = "chat-settings";
+    private static final String ACTION_BADGES = "badges";
+    private static final String ACTION_LEADERBOARD = "leaderboard";
+    private static final String ACTION_LANGUAGE = "language";
+    private static final String ACTION_SELECT_AUTO = "auto";
+    private static final String ACTION_SELECT_DEFAULT = "default";
+
+    private PlayerSettingsFlows() {
+    }
+
+    static final class SettingsFlow implements RoutedMenuFlow<SettingsState> {
+        private final PlayerProfileSettingsService profileSettings;
+
+        SettingsFlow(PlayerProfileSettingsService profileSettings) {
+            this.profileSettings = profileSettings;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_SETTINGS;
+        }
+
+        @Override
+        public SettingsState createState(Session session, MenuRoute route, SettingsState currentState) {
+            String targetUuid = route.param("targetUuid");
+            if (currentState != null && Objects.equals(currentState.targetUuid, targetUuid)) {
+                return currentState;
+            }
+            return new SettingsState(targetUuid);
+        }
+
+        @Override
+        public Class<SettingsState> stateType() {
+            return SettingsState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<SettingsState> context) {
+            Session session = context.session();
+            SettingsState state = context.state();
+            PlayerData targetData = session.playerDataRepository.findByUuid(state.targetUuid);
+
+            if (targetData == null) {
+                session.locale().send("error-player-not-found");
+                return errorScreen(session, "player-menu-settings-title", "error-player-not-found");
+            }
+
+            if (!hasAccess(session, targetData)) {
+                session.locale().send("error-no-access");
+                return errorScreen(session, "player-menu-settings-title", "error-no-access");
+            }
+
+            Localization local = context.locale();
+
+            String customNickDisplay = (targetData.customNickname == null || targetData.customNickname.isEmpty())
+                    ? local.t("none") : targetData.customNickname;
+            String descDisplay = (targetData.description == null || targetData.description.isEmpty())
+                    ? local.t("no-description") : targetData.description;
+            String activeBadge = activeBadgeName(local, targetData);
+            String systemBadge = systemBadgeName(local, targetData);
+            String globalChat = targetData.globalChatVisible ? local.t("yes") : local.t("no");
+            String discordRelay = targetData.discordRelayVisible ? local.t("yes") : local.t("no");
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+
+            rows.add(List.of(
+                    MenuButton.of(local.t("player-menu-settings-customNickname"), ACTION_CUSTOM_NICKNAME),
+                    MenuButton.of(local.t("player-menu-settings-customNickname-reset"), ACTION_CUSTOM_NICKNAME_RESET),
+                    MenuButton.of(local.t("player-menu-settings-description"), ACTION_DESCRIPTION)));
+
+            rows.add(List.of(MenuButton.of(
+                    local.t("player-menu-settings-chat"),
+                    ACTION_CHAT_SETTINGS)));
+            rows.add(List.of(MenuButton.of(
+                    local.t("player-menu-settings-badges"),
+                    ACTION_BADGES)));
+            rows.add(List.of(MenuButton.of(
+                    local.t(targetData.leaderboard ? "player-leaderboard-active" : "player-leaderboard-inactive"),
+                    ACTION_LEADERBOARD)));
+
+            rows.add(List.of(MenuButton.of(
+                    local.t("settings-language-label", args("lang", local.getLanguageName(targetData.language, "auto"))),
+                    ACTION_LANGUAGE)));
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.hasHistory() || session.hasRouteHistory()) {
+                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.normal(
+                    local.t("player-menu-settings-title"),
+                    local.t("player-menu-settings-content", args(
+                            "nickname", targetData.nickname,
+                            "customNickname", customNickDisplay,
+                            "activeBadge", activeBadge,
+                            "systemBadge", systemBadge,
+                            "description", descDisplay,
+                            "leaderboard", targetData.leaderboard ? local.t("yes") : local.t("no"),
+                            "language", local.getLanguageName(targetData.language, "auto"),
+                            "translatorLanguage", local.getLanguageName(targetData.translatorLanguage, "off"),
+                            "globalChat", globalChat,
+                            "discordRelay", discordRelay
+                    )),
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<SettingsState> context, String actionId) {
+            Session session = context.session();
+            SettingsState state = context.state();
+            PlayerData targetData = session.playerDataRepository.findByUuid(state.targetUuid);
+            if (targetData == null) return;
+
+            Localization local = context.locale();
+
+            switch (actionId) {
+                case ACTION_CUSTOM_NICKNAME -> context.openPrompt(new MenuPrompt(
+                        ACTION_CUSTOM_NICKNAME,
+                        local.t("player-menu-settings-customNickname-title"),
+                        local.t("player-menu-settings-customNickname-message"),
+                        256,
+                        targetData.customNickname,
+                        false
+                ));
+                case ACTION_CUSTOM_NICKNAME_RESET -> {
+                    profileSettings.updateCustomNickname(targetData, "", true, true);
+                    context.render();
+                }
+                case ACTION_DESCRIPTION -> context.openPrompt(new MenuPrompt(
+                        ACTION_DESCRIPTION,
+                        local.t("player-menu-settings-description-title"),
+                        "",
+                        1000,
+                        targetData.description,
+                        false
+                ));
+                case ACTION_CHAT_SETTINGS -> context.openRoute(MenuRoute.of(ROUTE_CHAT_SETTINGS).withParam("targetUuid", state.targetUuid));
+                case ACTION_BADGES -> context.openRoute(MenuRoute.of(ROUTE_BADGES).withParam("targetUuid", state.targetUuid));
+                case ACTION_LEADERBOARD -> {
+                    profileSettings.updateLeaderboard(targetData, !targetData.leaderboard);
+                    context.render();
+                }
+                case ACTION_LANGUAGE -> context.openRoute(MenuRoute.of(ROUTE_LANGUAGE_SELECTION)
+                        .withParam("targetUuid", state.targetUuid)
+                        .withParam("isTranslator", "false"));
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                default -> {
+                }
+            }
+        }
+
+        @Override
+        public void onPromptSubmit(MenuRenderContext<SettingsState> context, String promptId, String text) {
+            Session session = context.session();
+            SettingsState state = context.state();
+            PlayerData targetData = session.playerDataRepository.findByUuid(state.targetUuid);
+            if (targetData == null) return;
+
+            switch (promptId) {
+                case ACTION_CUSTOM_NICKNAME -> {
+                    String newNick = text == null || text.trim().isEmpty() ? "" : text;
+                    if (!newNick.isEmpty()) {
+                        var result = profileSettings.validateCustomNickname(newNick);
+                        if (!result.valid()) {
+                            context.locale().send(result.errorKey(), args("max", result.maxBytes()));
+                            context.render();
+                            return;
+                        }
+                    }
+                    profileSettings.updateCustomNickname(targetData, newNick, true, true);
+                    context.render();
+                }
+                case ACTION_DESCRIPTION -> {
+                    profileSettings.updateDescription(targetData, text);
+                    context.render();
+                }
+                default -> {
+                }
+            }
+        }
+
+        @Override
+        public void onPromptCancel(MenuRenderContext<SettingsState> context, String promptId) {
+            context.render();
+        }
+    }
+
+    static final class ChatSettingsFlow implements RoutedMenuFlow<ChatSettingsState> {
+        private final PlayerProfileSettingsService profileSettings;
+
+        ChatSettingsFlow(PlayerProfileSettingsService profileSettings) {
+            this.profileSettings = profileSettings;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_CHAT_SETTINGS;
+        }
+
+        @Override
+        public ChatSettingsState createState(Session session, MenuRoute route, ChatSettingsState currentState) {
+            String targetUuid = route.param("targetUuid");
+            if (currentState != null && Objects.equals(currentState.targetUuid, targetUuid)) {
+                return currentState;
+            }
+            return new ChatSettingsState(targetUuid);
+        }
+
+        @Override
+        public Class<ChatSettingsState> stateType() {
+            return ChatSettingsState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<ChatSettingsState> context) {
+            Session session = context.session();
+            ChatSettingsState state = context.state();
+            PlayerData targetData = session.playerDataRepository.findByUuid(state.targetUuid);
+
+            if (targetData == null) {
+                session.locale().send("error-player-not-found");
+                return errorScreen(session, "player-menu-settings-chat-title", "error-player-not-found");
+            }
+
+            if (!hasAccess(session, targetData)) {
+                session.locale().send("error-no-access");
+                return errorScreen(session, "player-menu-settings-chat-title", "error-no-access");
+            }
+
+            Localization local = context.locale();
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+            rows.add(List.of(MenuButton.of(
+                    local.t(targetData.globalChatVisible ? "player-menu-settings-global-chat-on" : "player-menu-settings-global-chat-off"),
+                    ACTION_TOGGLE_GLOBAL_CHAT)));
+            rows.add(List.of(MenuButton.of(
+                    local.t(targetData.discordRelayVisible ? "player-menu-settings-discord-relay-on" : "player-menu-settings-discord-relay-off"),
+                    ACTION_TOGGLE_DISCORD_RELAY)));
+            rows.add(List.of(MenuButton.of(
+                    local.t("settings-translator-label", args("lang", local.getLanguageName(targetData.translatorLanguage, "off"))),
+                    ACTION_TRANSLATOR_LANGUAGE)));
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.hasHistory() || session.hasRouteHistory()) {
+                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.normal(
+                    local.t("player-menu-settings-chat-title"),
+                    local.t("player-menu-settings-chat-content", args(
+                            "globalChat", targetData.globalChatVisible ? local.t("yes") : local.t("no"),
+                            "discordRelay", targetData.discordRelayVisible ? local.t("yes") : local.t("no"),
+                            "translatorLanguage", local.getLanguageName(targetData.translatorLanguage, "off")
+                    )),
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<ChatSettingsState> context, String actionId) {
+            Session session = context.session();
+            ChatSettingsState state = context.state();
+            PlayerData targetData = session.playerDataRepository.findByUuid(state.targetUuid);
+            if (targetData == null) return;
+
+            switch (actionId) {
+                case ACTION_TOGGLE_GLOBAL_CHAT -> {
+                    profileSettings.updateGlobalChatVisible(targetData, !targetData.globalChatVisible);
+                    context.render();
+                }
+                case ACTION_TOGGLE_DISCORD_RELAY -> {
+                    profileSettings.updateDiscordRelayVisible(targetData, !targetData.discordRelayVisible);
+                    context.render();
+                }
+                case ACTION_TRANSLATOR_LANGUAGE -> context.openRoute(MenuRoute.of(ROUTE_LANGUAGE_SELECTION)
+                        .withParam("targetUuid", state.targetUuid)
+                        .withParam("isTranslator", "true"));
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                default -> {
+                }
+            }
+        }
+    }
+
+    static final class LanguageSelectionFlow implements RoutedMenuFlow<LanguageSelectionState> {
+        private final Bundle bundle;
+        private final PlayerProfileSettingsService profileSettings;
+
+        LanguageSelectionFlow(Bundle bundle, PlayerProfileSettingsService profileSettings) {
+            this.bundle = bundle;
+            this.profileSettings = profileSettings;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_LANGUAGE_SELECTION;
+        }
+
+        @Override
+        public LanguageSelectionState createState(Session session, MenuRoute route, LanguageSelectionState currentState) {
+            String targetUuid = route.param("targetUuid");
+            boolean isTranslator = Boolean.parseBoolean(route.param("isTranslator"));
+            if (currentState != null && Objects.equals(currentState.targetUuid, targetUuid) && currentState.isTranslator == isTranslator) {
+                return currentState;
+            }
+            return new LanguageSelectionState(targetUuid, isTranslator);
+        }
+
+        @Override
+        public Class<LanguageSelectionState> stateType() {
+            return LanguageSelectionState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<LanguageSelectionState> context) {
+            Session session = context.session();
+            LanguageSelectionState state = context.state();
+            PlayerData targetData = session.playerDataRepository.findByUuid(state.targetUuid);
+
+            String titleKey = state.isTranslator ? "player-menu-settings-translator-title" : "player-menu-settings-language-title";
+
+            if (targetData == null) {
+                session.locale().send("error-player-not-found");
+                return errorScreen(session, titleKey, "error-player-not-found");
+            }
+
+            if (!hasAccess(session, targetData)) {
+                session.locale().send("error-no-access");
+                return errorScreen(session, titleKey, "error-no-access");
+            }
+
+            Localization local = context.locale();
+            Seq<Locale> locales = bundle.getAvailableLocales();
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+
+            String firstActionId = state.isTranslator ? ACTION_SELECT_DEFAULT : ACTION_SELECT_AUTO;
+            String firstLabelKey = state.isTranslator ? "default" : "auto";
+            rows.add(List.of(MenuButton.of(local.t(firstLabelKey), firstActionId)));
+
+            for (Locale loc : locales) {
+                String code = "uk".equals(loc.getLanguage()) ? "uk_UA" : loc.getLanguage();
+                String langName = Strings.capitalize(loc.getDisplayLanguage(loc));
+                rows.add(List.of(MenuButton.of(langName, code)));
+            }
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.hasHistory() || session.hasRouteHistory()) {
+                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.normal(local.t(titleKey), "", rows);
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<LanguageSelectionState> context, String actionId) {
+            Session session = context.session();
+            LanguageSelectionState state = context.state();
+            PlayerData targetData = session.playerDataRepository.findByUuid(state.targetUuid);
+            if (targetData == null) return;
+
+            switch (actionId) {
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                case ACTION_SELECT_AUTO -> {
+                    profileSettings.updateLanguage(targetData, "auto");
+                    context.goBack();
+                }
+                case ACTION_SELECT_DEFAULT -> {
+                    profileSettings.updateTranslatorLanguage(targetData, "off");
+                    context.goBack();
+                }
+                default -> {
+                    if (state.isTranslator) {
+                        profileSettings.updateTranslatorLanguage(targetData, actionId);
+                    } else {
+                        profileSettings.updateLanguage(targetData, actionId);
+                    }
+                    context.goBack();
+                }
+            }
+        }
+    }
+
+    static final class BadgeSymbolColorModeFlow implements RoutedMenuFlow<BadgeSymbolColorModeState> {
+        private final PlayerProfileSettingsService profileSettings;
+
+        BadgeSymbolColorModeFlow(PlayerProfileSettingsService profileSettings) {
+            this.profileSettings = profileSettings;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_BADGE_SYMBOL_COLOR;
+        }
+
+        @Override
+        public BadgeSymbolColorModeState createState(Session session, MenuRoute route, BadgeSymbolColorModeState currentState) {
+            String targetUuid = route.param("targetUuid");
+            if (currentState != null && Objects.equals(currentState.targetUuid, targetUuid)) {
+                return currentState;
+            }
+            return new BadgeSymbolColorModeState(targetUuid);
+        }
+
+        @Override
+        public Class<BadgeSymbolColorModeState> stateType() {
+            return BadgeSymbolColorModeState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<BadgeSymbolColorModeState> context) {
+            Session session = context.session();
+            BadgeSymbolColorModeState state = context.state();
+            PlayerData targetData = session.playerDataRepository.findByUuid(state.targetUuid);
+
+            if (targetData == null) {
+                session.locale().send("error-player-not-found");
+                return errorScreen(session, "badge-menu-symbol-color-title", "error-player-not-found");
+            }
+
+            if (!hasAccess(session, targetData)) {
+                session.locale().send("error-no-access");
+                return errorScreen(session, "badge-menu-symbol-color-title", "error-no-access");
+            }
+
+            Localization local = context.locale();
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+            rows.add(List.of(MenuButton.of(local.t("badge-menu-symbol-color-default"), ACTION_SET_DEFAULT_MODE)));
+            rows.add(List.of(MenuButton.of(local.t("badge-menu-symbol-color-player-color"), ACTION_SET_PLAYER_COLOR_MODE)));
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.hasHistory() || session.hasRouteHistory()) {
+                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.normal(
+                    local.t("badge-menu-symbol-color-title"),
+                    local.t("badge-menu-symbol-color-content", args("mode", badgeSymbolColorModeLabel(local, targetData))),
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<BadgeSymbolColorModeState> context, String actionId) {
+            Session session = context.session();
+            BadgeSymbolColorModeState state = context.state();
+            PlayerData targetData = session.playerDataRepository.findByUuid(state.targetUuid);
+            if (targetData == null) return;
+
+            switch (actionId) {
+                case ACTION_SET_DEFAULT_MODE -> {
+                    profileSettings.updateBadgeSymbolColorMode(targetData, "default", true, true);
+                    context.render();
+                }
+                case ACTION_SET_PLAYER_COLOR_MODE -> {
+                    profileSettings.updateBadgeSymbolColorMode(targetData, "player-color", true, true);
+                    context.render();
+                }
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                default -> {
+                }
+            }
+        }
+    }
+
+    static final class BadgesFlow implements RoutedMenuFlow<BadgesState> {
+        private final PlayerProfileSettingsService profileSettings;
+
+        BadgesFlow(PlayerProfileSettingsService profileSettings) {
+            this.profileSettings = profileSettings;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_BADGES;
+        }
+
+        @Override
+        public BadgesState createState(Session session, MenuRoute route, BadgesState currentState) {
+            String targetUuid = route.param("targetUuid");
+            if (currentState != null && Objects.equals(currentState.targetUuid, targetUuid)) {
+                return currentState;
+            }
+            return new BadgesState(targetUuid);
+        }
+
+        @Override
+        public Class<BadgesState> stateType() {
+            return BadgesState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<BadgesState> context) {
+            Session session = context.session();
+            BadgesState state = context.state();
+            PlayerData targetData = session.playerDataRepository.findByUuid(state.targetUuid);
+
+            if (targetData == null) {
+                session.locale().send("error-player-not-found");
+                return errorScreen(session, "badge-menu-title", "error-player-not-found");
+            }
+
+            if (!hasAccess(session, targetData)) {
+                session.locale().send("error-no-access");
+                return errorScreen(session, "badge-menu-title", "error-no-access");
+            }
+
+            Localization local = context.locale();
+            List<Badge> badges = unlockedSelectableBadges(targetData);
+            String header = local.t("badge-menu-content", args(
+                    "systemBadge", systemBadgeName(local, targetData),
+                    "activeBadge", activeBadgeName(local, targetData),
+                    "symbolColorMode", badgeSymbolColorModeLabel(local, targetData)
+            ));
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+
+            for (Badge badge : badges) {
+                rows.add(List.of(MenuButton.of(
+                        local.t("badge-menu-row", args(
+                                "badge", badgeLabel(local, badge),
+                                "description", local.t(badge.descriptionKey())
+                        )),
+                        badge.id())));
+            }
+
+            rows.add(List.of(MenuButton.of(
+                    local.t("badge-menu-symbol-color-button", args("mode", badgeSymbolColorModeLabel(local, targetData))),
+                    ACTION_SYMBOL_COLOR_MODE)));
+
+            List<MenuButton> bottomRow = new ArrayList<>();
+            bottomRow.add(MenuButton.of(local.t("badge-menu-view-all"), ACTION_VIEW_ALL));
+            bottomRow.add(MenuButton.of(local.t("badge-clear-button"), ACTION_CLEAR));
+            rows.add(bottomRow);
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.hasHistory() || session.hasRouteHistory()) {
+                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.normal(
+                    local.t("badge-menu-title"),
+                    badges.isEmpty() ? header + "\n" + local.t("badge-menu-empty") : header,
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<BadgesState> context, String actionId) {
+            Session session = context.session();
+            BadgesState state = context.state();
+            PlayerData targetData = session.playerDataRepository.findByUuid(state.targetUuid);
+            if (targetData == null) return;
+
+            switch (actionId) {
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                case ACTION_SYMBOL_COLOR_MODE -> context.openRoute(MenuRoute.of(ROUTE_BADGE_SYMBOL_COLOR).withParam("targetUuid", state.targetUuid));
+                case ACTION_VIEW_ALL -> context.openRoute(MenuRoute.of(ROUTE_ALL_BADGES).withParam("targetUuid", state.targetUuid));
+                case ACTION_CLEAR -> {
+                    profileSettings.updateActiveBadge(targetData, "", true, true);
+                    context.render();
+                }
+                default -> {
+                    Badge badge = Badge.byId(actionId);
+                    if (badge != null) {
+                        profileSettings.updateActiveBadge(targetData, badge.id(), true, true);
+                        context.render();
+                    }
+                }
+            }
+        }
+    }
+
+    static final class AllBadgesFlow implements RoutedMenuFlow<AllBadgesState> {
+        private final PlayerProfileSettingsService profileSettings;
+
+        AllBadgesFlow(PlayerProfileSettingsService profileSettings) {
+            this.profileSettings = profileSettings;
+        }
+
+        @Override
+        public String routeId() {
+            return ROUTE_ALL_BADGES;
+        }
+
+        @Override
+        public AllBadgesState createState(Session session, MenuRoute route, AllBadgesState currentState) {
+            String targetUuid = route.param("targetUuid");
+            if (currentState != null && Objects.equals(currentState.targetUuid, targetUuid)) {
+                return currentState;
+            }
+            return new AllBadgesState(targetUuid);
+        }
+
+        @Override
+        public Class<AllBadgesState> stateType() {
+            return AllBadgesState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<AllBadgesState> context) {
+            Session session = context.session();
+            AllBadgesState state = context.state();
+            PlayerData targetData = session.playerDataRepository.findByUuid(state.targetUuid);
+
+            if (targetData == null) {
+                session.locale().send("error-player-not-found");
+                return errorScreen(session, "badge-menu-all-title", "error-player-not-found");
+            }
+
+            if (!hasAccess(session, targetData)) {
+                session.locale().send("error-no-access");
+                return errorScreen(session, "badge-menu-all-title", "error-no-access");
+            }
+
+            Localization local = context.locale();
+            List<List<MenuButton>> rows = new ArrayList<>();
+
+            for (Badge badge : Badge.values()) {
+                rows.add(List.of(MenuButton.of(
+                        local.t("badge-menu-all-row", args(
+                                "badge", badgeLabel(local, badge),
+                                "state", badgeState(local, targetData, badge),
+                                "description", local.t(badge.descriptionKey())
+                        )),
+                        badge.id())));
+            }
+
+            List<MenuButton> navigation = new ArrayList<>();
+            if (session.hasHistory() || session.hasRouteHistory()) {
+                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
+            }
+            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
+            rows.add(navigation);
+
+            return MenuScreen.normal(
+                    local.t("badge-menu-all-title"),
+                    local.t("badge-menu-all-content"),
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<AllBadgesState> context, String actionId) {
+            Session session = context.session();
+            AllBadgesState state = context.state();
+            PlayerData targetData = session.playerDataRepository.findByUuid(state.targetUuid);
+            if (targetData == null) return;
+
+            switch (actionId) {
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                default -> {
+                    Badge badge = Badge.byId(actionId);
+                    if (badge != null) {
+                        if (badge.selectable() && !badge.system() && ownsBadge(targetData, badge)) {
+                            profileSettings.updateActiveBadge(targetData, badge.id(), true, true);
+                        }
+                        context.render();
+                    }
+                }
+            }
+        }
+    }
+
+    static final class ChatSettingsState {
+        public String targetUuid;
+
+        ChatSettingsState() {
+        }
+
+        ChatSettingsState(String targetUuid) {
+            this.targetUuid = targetUuid;
+        }
+    }
+
+    static final class BadgeSymbolColorModeState {
+        public String targetUuid;
+
+        BadgeSymbolColorModeState() {
+        }
+
+        BadgeSymbolColorModeState(String targetUuid) {
+            this.targetUuid = targetUuid;
+        }
+    }
+
+    static final class BadgesState {
+        public String targetUuid;
+
+        BadgesState() {
+        }
+
+        BadgesState(String targetUuid) {
+            this.targetUuid = targetUuid;
+        }
+    }
+
+    static final class AllBadgesState {
+        public String targetUuid;
+
+        AllBadgesState() {
+        }
+
+        AllBadgesState(String targetUuid) {
+            this.targetUuid = targetUuid;
+        }
+    }
+
+    static final class LanguageSelectionState {
+        public String targetUuid;
+        public boolean isTranslator;
+
+        LanguageSelectionState() {
+        }
+
+        LanguageSelectionState(String targetUuid, boolean isTranslator) {
+            this.targetUuid = targetUuid;
+            this.isTranslator = isTranslator;
+        }
+    }
+
+    static final class SettingsState {
+        public String targetUuid;
+
+        SettingsState() {
+        }
+
+        SettingsState(String targetUuid) {
+            this.targetUuid = targetUuid;
+        }
+    }
+
+    private static MenuScreen errorScreen(Session session, String titleKey, String messageKey) {
+        Localization local = session.locale();
+        return MenuScreen.normal(
+                local.t(titleKey),
+                local.t(messageKey),
+                List.of(List.of(MenuButton.of(local.t("close"), ACTION_CLOSE)))
+        );
+    }
+
+    private static boolean hasAccess(Session session, PlayerData targetData) {
+        return session.data.uuid.equals(targetData.uuid) || session.player.admin;
+    }
+
+    static String activeBadgeName(Localization local, PlayerData targetData) {
+        Badge badge = Badge.byId(targetData.activeBadge);
+        if (badge == null || targetData.unlockedBadges == null || !targetData.unlockedBadges.contains(badge.id())) {
+            return local.t("none");
+        }
+        return badgeLabel(local, badge);
+    }
+
+    static String systemBadgeName(Localization local, PlayerData targetData) {
+        return targetData.admin ? badgeLabel(local, Badge.ADMIN) : local.t("none");
+    }
+
+    static String badgeSymbolColorModeLabel(Localization local, PlayerData targetData) {
+        return usesPlayerBadgeSymbolColor(targetData)
+                ? local.t("badge-menu-symbol-color-player-color")
+                : local.t("badge-menu-symbol-color-default");
+    }
+
+    static List<Badge> unlockedSelectableBadges(PlayerData targetData) {
+        List<Badge> result = new ArrayList<>();
+        for (Badge badge : Badge.selectableManualBadges()) {
+            if (targetData.unlockedBadges != null && targetData.unlockedBadges.contains(badge.id())) {
+                result.add(badge);
+            }
+        }
+        return result;
+    }
+
+    static String badgeLabel(Localization local, Badge badge) {
+        return badge.tag() + " " + local.t(badge.nameKey());
+    }
+
+    static String badgeState(Localization local, PlayerData targetData, Badge badge) {
+        if (badge.system()) {
+            return targetData.admin ? local.t("badge-state-system-active") : local.t("badge-state-system");
+        }
+
+        if (badge.id().equals(targetData.activeBadge) && ownsBadge(targetData, badge)) {
+            return local.t("badge-state-active");
+        }
+
+        return ownsBadge(targetData, badge) ? local.t("badge-state-unlocked") : local.t("badge-state-locked");
+    }
+
+    static boolean ownsBadge(PlayerData targetData, Badge badge) {
+        return targetData.unlockedBadges != null && targetData.unlockedBadges.contains(badge.id());
+    }
+
+    private static boolean usesPlayerBadgeSymbolColor(PlayerData targetData) {
+        return targetData != null
+                && targetData.badgeSymbolColorMode != null
+                && targetData.badgeSymbolColorMode.equalsIgnoreCase("player-color");
+    }
+}

--- a/src/main/java/org/xcore/plugin/ui/menu/TopMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/TopMenu.java
@@ -175,7 +175,7 @@ public class TopMenu extends Menu {
             }
 
             List<MenuButton> bottomNav = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 bottomNav.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             bottomNav.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -296,7 +296,7 @@ public class TopMenu extends Menu {
             ));
 
             List<MenuButton> navRow = new ArrayList<>();
-            if (session.hasHistory() || session.hasRouteHistory()) {
+            if (session.canGoBack(true)) {
                 navRow.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navRow.add(MenuButton.of(local.t("close"), ACTION_CLOSE));

--- a/src/main/java/org/xcore/plugin/ui/menu/TopMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/TopMenu.java
@@ -1,5 +1,6 @@
 package org.xcore.plugin.ui.menu;
 
+import io.avaje.inject.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.xcore.plugin.config.Config;
@@ -11,10 +12,12 @@ import org.xcore.plugin.model.enums.TopCategory;
 import org.xcore.plugin.service.TopMenuService;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.MenuService;
 import org.xcore.plugin.ui.flow.MenuButton;
-import org.xcore.plugin.ui.flow.MenuFlow;
 import org.xcore.plugin.ui.flow.MenuRenderContext;
 import org.xcore.plugin.ui.flow.MenuScreen;
+import org.xcore.plugin.ui.route.MenuRoute;
+import org.xcore.plugin.ui.route.RoutedMenuFlow;
 
 import java.text.NumberFormat;
 import java.util.ArrayDeque;
@@ -30,6 +33,9 @@ public class TopMenu extends Menu {
     private static final int PLAYERS_PER_PAGE = 10;
     private static final LeaderboardCursor FIRST_PAGE_MARKER = new LeaderboardCursor(0, 0, -2);
 
+    private static final String ROUTE_TOP_LIST = "top.list";
+    private static final String ROUTE_TOP_CATEGORIES = "top.categories";
+
     private static final String ACTION_PREVIOUS = "previous";
     private static final String ACTION_NEXT = "next";
     private static final String ACTION_CATEGORY = "category";
@@ -39,54 +45,47 @@ public class TopMenu extends Menu {
 
     private final TopMenuService topMenuService;
     private final PlayerMenu playerMenu;
+    private final MenuService menuService;
 
     @Inject
     public TopMenu(Config config,
                    GlobalConfig globalConfig,
                    SessionService sessionService,
+                   MenuService menuService,
                    TopMenuService topMenuService,
                    PlayerMenu playerMenu) {
         super(config, globalConfig, sessionService);
+        this.menuService = menuService;
         this.topMenuService = topMenuService;
         this.playerMenu = playerMenu;
     }
 
+    @PostConstruct
+    public void init() {
+        menuService.registerRoute(new TopListFlow());
+        menuService.registerRoute(new CategoriesFlow());
+    }
+
     public void top(String uuid) {
-        top(uuid, null, null, 1, true);
+        top(uuid, null, 1);
     }
 
     public void top(String uuid, TopCategory category, int page) {
-        top(uuid, category, null, page, true);
-    }
-
-    private void top(String uuid,
-                     TopCategory category,
-                     LeaderboardCursor cursor,
-                     int page,
-                     boolean resetState) {
         Session session = sessionService.get(uuid);
         if (session == null || session.data == null) return;
         session.clear();
 
-        TopMenuState state = session.getDraft(TopMenuState.class);
-        if (state == null) {
-            session.locale().send("error-internal", args());
-            return;
-        }
-
         TopCategory resolvedCategory = category == null ? topMenuService.resolveDefaultCategory() : category;
-        if (resetState || state.category != resolvedCategory) {
-            state.category = resolvedCategory;
-            state.currentPage = page;
-            state.currentCursor = cursor;
-            state.nextCursor = null;
-            state.backStack.clear();
-        } else {
-            state.currentCursor = cursor;
-            state.currentPage = page;
-        }
+        TopMenuState state = session.getDraft(TopMenuState.class);
+        state.category = resolvedCategory;
+        state.currentPage = page;
+        state.currentCursor = null;
+        state.nextCursor = null;
+        state.backStack.clear();
 
-        session.menuService.renderFlow(session, new TopMenuFlow());
+        session.menuService.renderRoute(session, MenuRoute.of(ROUTE_TOP_LIST)
+                .withParam("category", resolvedCategory.name())
+                .withParam("page", String.valueOf(page)));
     }
 
     public void categories(String uuid, TopCategory currentCategory) {
@@ -96,23 +95,44 @@ public class TopMenu extends Menu {
 
         TopCategory resolvedCategory = currentCategory == null ? topMenuService.resolveDefaultCategory() : currentCategory;
 
-        session.builder()
-                .title("top-menu-categories-title")
-                .content("top-menu-categories-content", args(
-                        "category", session.locale().t(resolvedCategory.bundleKey())
-                ))
-                .addRow(
-                        categoryButton(session, TopCategory.MINI_PVP, resolvedCategory),
-                        () -> top(uuid, TopCategory.MINI_PVP, null, 1, true),
-                        categoryButton(session, TopCategory.PLAYTIME, resolvedCategory),
-                        () -> top(uuid, TopCategory.PLAYTIME, null, 1, true)
-                )
-                .addRow(categoryButton(session, TopCategory.HEXED, resolvedCategory), () -> top(uuid, TopCategory.HEXED, null, 1, true))
-                .addNavigationRow()
-                .show();
+        session.menuService.renderRoute(session, MenuRoute.of(ROUTE_TOP_CATEGORIES)
+                .withParam("category", resolvedCategory.name()));
     }
 
-    private final class TopMenuFlow implements MenuFlow<TopMenuState> {
+    private TopCategory parseCategory(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return TopCategory.valueOf(value);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private final class TopListFlow implements RoutedMenuFlow<TopMenuState> {
+        @Override
+        public String routeId() {
+            return ROUTE_TOP_LIST;
+        }
+
+        @Override
+        public TopMenuState createState(Session session, MenuRoute route, TopMenuState currentState) {
+            TopCategory routeCategory = parseCategory(route.param("category"));
+            TopCategory resolvedCategory = routeCategory == null ? topMenuService.resolveDefaultCategory() : routeCategory;
+            int routePage = route.intParam("page", 1);
+
+            if (currentState.category != resolvedCategory) {
+                currentState.category = resolvedCategory;
+                currentState.currentPage = routePage;
+                currentState.currentCursor = null;
+                currentState.nextCursor = null;
+                currentState.backStack.clear();
+            }
+
+            return currentState;
+        }
+
         @Override
         public Class<TopMenuState> stateType() {
             return TopMenuState.class;
@@ -155,7 +175,7 @@ public class TopMenu extends Menu {
             }
 
             List<MenuButton> bottomNav = new ArrayList<>();
-            if (session.hasHistory()) {
+            if (session.hasHistory() || session.hasRouteHistory()) {
                 bottomNav.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             bottomNav.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -201,6 +221,9 @@ public class TopMenu extends Menu {
                     int savedPage = state.currentPage;
                     Deque<LeaderboardCursor> savedBackStack = new ArrayDeque<>(state.backStack);
                     LeaderboardCursor savedNextCursor = state.nextCursor;
+                    // This handoff still needs an immutable snapshot. Route history alone only restores
+                    // the route params, while this callback also preserves cursor/back-stack state even
+                    // if the draft is later reset by opening a different leaderboard route.
                     session.pushHistory(() -> {
                         session.clear();
                         TopMenuState histState = session.getDraft(TopMenuState.class);
@@ -209,37 +232,98 @@ public class TopMenu extends Menu {
                         histState.currentPage = savedPage;
                         histState.backStack = savedBackStack;
                         histState.nextCursor = savedNextCursor;
-                        session.menuService.renderFlow(session, new TopMenuFlow());
+                        session.menuService.renderRoute(session, MenuRoute.of(ROUTE_TOP_LIST)
+                                .withParam("category", savedCategory.name()));
                     });
                     session.menuService.hideFollowUp(session);
-                    categories(session.data.uuid, state.category);
+                    session.menuService.renderRoute(session, MenuRoute.of(ROUTE_TOP_CATEGORIES)
+                            .withParam("category", state.category.name()));
                 }
-                case ACTION_BACK -> {
-                    Runnable previousMenu = session.popHistory();
-                    if (previousMenu != null) {
-                        session.menuService.hideFollowUp(session);
-                        previousMenu.run();
-                    }
-                }
+                case ACTION_BACK -> context.goBack();
                 case ACTION_CLOSE -> context.close();
                 default -> {
                     if (actionId.startsWith(ACTION_PROFILE_PREFIX)) {
                         String targetUuid = actionId.substring(ACTION_PROFILE_PREFIX.length());
                         PlayerData target = session.playerDataRepository.findByUuid(targetUuid);
                         if (target != null) {
-                            session.pushHistory(() -> {
-                                session.clear();
-                                TopMenuState histState = session.getDraft(TopMenuState.class);
-                                histState.category = state.category;
-                                histState.currentCursor = state.currentCursor;
-                                histState.currentPage = state.currentPage;
-                                histState.backStack = new ArrayDeque<>(state.backStack);
-                                histState.nextCursor = state.nextCursor;
-                                session.menuService.renderFlow(session, new TopMenuFlow());
-                            });
+                            if (context.route() != null) {
+                                session.pushRouteHistory(context.route());
+                            }
                             session.menuService.hideFollowUp(session);
                             playerMenu.player(session.data.uuid, target);
                         }
+                    }
+                }
+            }
+        }
+    }
+
+    private final class CategoriesFlow implements RoutedMenuFlow<TopCategoriesState> {
+        @Override
+        public String routeId() {
+            return ROUTE_TOP_CATEGORIES;
+        }
+
+        @Override
+        public TopCategoriesState createState(Session session, MenuRoute route, TopCategoriesState currentState) {
+            return currentState == null ? new TopCategoriesState() : currentState;
+        }
+
+        @Override
+        public Class<TopCategoriesState> stateType() {
+            return TopCategoriesState.class;
+        }
+
+        @Override
+        public MenuScreen render(MenuRenderContext<TopCategoriesState> context) {
+            Session session = context.session();
+            Localization local = context.locale();
+
+            TopCategory currentCategory = parseCategory(context.route().param("category"));
+            if (currentCategory == null) {
+                currentCategory = topMenuService.resolveDefaultCategory();
+            }
+
+            String categoryName = local.t(currentCategory.bundleKey());
+
+            List<List<MenuButton>> rows = new ArrayList<>();
+            rows.add(List.of(
+                    MenuButton.of(categoryButton(session, TopCategory.MINI_PVP, currentCategory), TopCategory.MINI_PVP.name()),
+                    MenuButton.of(categoryButton(session, TopCategory.PLAYTIME, currentCategory), TopCategory.PLAYTIME.name())
+            ));
+            rows.add(List.of(
+                    MenuButton.of(categoryButton(session, TopCategory.HEXED, currentCategory), TopCategory.HEXED.name())
+            ));
+
+            List<MenuButton> navRow = new ArrayList<>();
+            if (session.hasHistory() || session.hasRouteHistory()) {
+                navRow.add(MenuButton.of(local.t("back"), ACTION_BACK));
+            }
+            navRow.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
+            rows.add(navRow);
+
+            return MenuScreen.normal(
+                    local.t("top-menu-categories-title"),
+                    local.t("top-menu-categories-content", args("category", categoryName)),
+                    rows
+            );
+        }
+
+        @Override
+        public void onAction(MenuRenderContext<TopCategoriesState> context, String actionId) {
+            Session session = context.session();
+            switch (actionId) {
+                case ACTION_BACK -> context.goBack();
+                case ACTION_CLOSE -> context.close();
+                default -> {
+                    try {
+                        TopCategory category = TopCategory.valueOf(actionId);
+                        session.clear();
+                        session.clearDraft(TopMenuState.class);
+                        session.menuService.renderRoute(session, MenuRoute.of(ROUTE_TOP_LIST)
+                                .withParam("category", category.name())
+                                .withParam("page", "1"));
+                    } catch (IllegalArgumentException ignored) {
                     }
                 }
             }
@@ -303,5 +387,8 @@ public class TopMenu extends Menu {
         public Deque<LeaderboardCursor> backStack = new ArrayDeque<>();
         public LeaderboardCursor currentCursor;
         public LeaderboardCursor nextCursor;
+    }
+
+    public static final class TopCategoriesState {
     }
 }

--- a/src/main/java/org/xcore/plugin/ui/menu/TopMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/TopMenu.java
@@ -175,7 +175,7 @@ public class TopMenu extends Menu {
             }
 
             List<MenuButton> bottomNav = new ArrayList<>();
-            if (session.canGoBack(true)) {
+            if (session.canGoBack()) {
                 bottomNav.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             bottomNav.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
@@ -296,7 +296,7 @@ public class TopMenu extends Menu {
             ));
 
             List<MenuButton> navRow = new ArrayList<>();
-            if (session.canGoBack(true)) {
+            if (session.canGoBack()) {
                 navRow.add(MenuButton.of(local.t("back"), ACTION_BACK));
             }
             navRow.add(MenuButton.of(local.t("close"), ACTION_CLOSE));

--- a/src/main/java/org/xcore/plugin/ui/route/MenuRoute.java
+++ b/src/main/java/org/xcore/plugin/ui/route/MenuRoute.java
@@ -1,0 +1,47 @@
+package org.xcore.plugin.ui.route;
+
+import java.util.Map;
+
+public record MenuRoute(String id, Map<String, String> params) {
+
+    public MenuRoute {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("Route id cannot be blank");
+        }
+        params = params == null ? Map.of() : Map.copyOf(params);
+    }
+
+    public MenuRoute(String id) {
+        this(id, Map.of());
+    }
+
+    public static MenuRoute of(String id) {
+        return new MenuRoute(id);
+    }
+
+    public MenuRoute withParam(String key, String value) {
+        var nextParams = new java.util.LinkedHashMap<>(params);
+        nextParams.put(key, value);
+        return new MenuRoute(id, nextParams);
+    }
+
+    public String param(String key) {
+        return params.get(key);
+    }
+
+    public boolean hasParam(String key) {
+        return params.containsKey(key);
+    }
+
+    public int intParam(String key, int fallback) {
+        String value = params.get(key);
+        if (value == null || value.isBlank()) {
+            return fallback;
+        }
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException ignored) {
+            return fallback;
+        }
+    }
+}

--- a/src/main/java/org/xcore/plugin/ui/route/RoutedMenuFlow.java
+++ b/src/main/java/org/xcore/plugin/ui/route/RoutedMenuFlow.java
@@ -1,0 +1,11 @@
+package org.xcore.plugin.ui.route;
+
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.ui.flow.MenuFlow;
+
+public interface RoutedMenuFlow<TState> extends MenuFlow<TState> {
+
+    String routeId();
+
+    TState createState(Session session, MenuRoute route, TState currentState);
+}

--- a/src/test/java/org/xcore/plugin/session/SessionUiStateTest.java
+++ b/src/test/java/org/xcore/plugin/session/SessionUiStateTest.java
@@ -13,6 +13,7 @@ import org.xcore.plugin.ui.MenuService;
 import org.xcore.plugin.ui.flow.ActiveMenuPrompt;
 import org.xcore.plugin.ui.flow.ActiveMenuScreen;
 import org.xcore.plugin.ui.flow.MenuMode;
+import org.xcore.plugin.ui.route.MenuRoute;
 
 import java.util.List;
 
@@ -69,22 +70,56 @@ class SessionUiStateTest {
     void clearUiState_preservesHistoryDraftsSortStatus() {
         Session session = session();
         session.pushHistory(() -> {});
+        session.pushRouteHistory(MenuRoute.of("player.profile"));
         session.setDraft("draft");
         session.sortStatus.put("key", StatusEnum.Active);
 
         session.clearUiState();
 
         assertThat(session.hasHistory()).isTrue();
+        assertThat(session.hasRouteHistory()).isTrue();
         assertThat(session.hasDraft(String.class)).isTrue();
         assertThat(session.sortStatus).containsKey("key");
     }
 
+    @Test
+    @DisplayName("route history is LIFO")
+    void routeHistory_isLifo() {
+        Session session = session();
+        session.pushRouteHistory(MenuRoute.of("route.one"));
+        session.pushRouteHistory(MenuRoute.of("route.two"));
+
+        assertThat(session.popRouteHistory()).isEqualTo(MenuRoute.of("route.two"));
+        assertThat(session.popRouteHistory()).isEqualTo(MenuRoute.of("route.one"));
+        assertThat(session.popRouteHistory()).isNull();
+    }
+
+    @Test
+    @DisplayName("route history over max history drops oldest entry")
+    void routeHistory_overMaxHistory_dropsOldestEntry() {
+        GlobalConfig globalConfig = new GlobalConfig();
+        globalConfig.maxHistory = 2;
+        Session session = session(globalConfig);
+
+        session.pushRouteHistory(MenuRoute.of("route.one"));
+        session.pushRouteHistory(MenuRoute.of("route.two"));
+        session.pushRouteHistory(MenuRoute.of("route.three"));
+
+        assertThat(session.popRouteHistory()).isEqualTo(MenuRoute.of("route.three"));
+        assertThat(session.popRouteHistory()).isEqualTo(MenuRoute.of("route.two"));
+        assertThat(session.popRouteHistory()).isNull();
+    }
+
     private Session session() {
+        return session(new GlobalConfig());
+    }
+
+    private Session session(GlobalConfig globalConfig) {
         Player player = Player.create();
         player.con = mock(NetConnection.class);
         PlayerData data = new PlayerData("uuid-1", true);
         return new Session(
-                new GlobalConfig(),
+                globalConfig,
                 mock(Bundle.class),
                 mock(MenuService.class),
                 mock(PlayerDataRepository.class),

--- a/src/test/java/org/xcore/plugin/ui/AuditHistoryMenuFlowTest.java
+++ b/src/test/java/org/xcore/plugin/ui/AuditHistoryMenuFlowTest.java
@@ -54,7 +54,7 @@ class AuditHistoryMenuFlowTest {
     void historyFlow_rendersNextWhenHasNextAndHidesPreviousOnFirstPage() {
         SessionService sessionService = mock(SessionService.class);
         AuditService auditService = mock(AuditService.class);
-        AuditHistoryMenu menu = new AuditHistoryMenu(new Config(), new GlobalConfig(), sessionService, auditService);
+        AuditHistoryMenu menu = createMenu(sessionService, auditService);
 
         Session session = session("viewer-1");
         PlayerData target = playerData("target-1", 1);
@@ -86,7 +86,7 @@ class AuditHistoryMenuFlowTest {
     void nextAction_pushesFirstPageMarkerAndLoadsNextCursorPage() {
         SessionService sessionService = mock(SessionService.class);
         AuditService auditService = mock(AuditService.class);
-        AuditHistoryMenu menu = new AuditHistoryMenu(new Config(), new GlobalConfig(), sessionService, auditService);
+        AuditHistoryMenu menu = createMenu(sessionService, auditService);
 
         Session session = session("viewer-1");
         PlayerData target = playerData("target-1", 1);
@@ -117,11 +117,54 @@ class AuditHistoryMenuFlowTest {
     }
 
     @Test
+    @DisplayName("fresh history open resets pagination state while keeping route metadata")
+    void freshHistoryOpen_resetsPaginationStateWhileKeepingRouteMetadata() {
+        SessionService sessionService = mock(SessionService.class);
+        AuditService auditService = mock(AuditService.class);
+        AuditHistoryMenu menu = createMenu(sessionService, auditService);
+
+        Session session = session("viewer-1");
+        PlayerData target = playerData("target-1", 1);
+        when(sessionService.get("viewer-1")).thenReturn(session);
+
+        AuditCursor nextCursor = new AuditCursor(100L, "audit-2");
+        AuditRecordSummary firstSummary = new AuditRecordSummary(
+                "audit-3", AuditAction.BAN, "T", "A", "R", null, null, 20L
+        );
+        AuditRecordSummary nextSummary = new AuditRecordSummary(
+                "audit-2", AuditAction.MUTE, "T", "A", "R", null, null, 10L
+        );
+
+        when(auditService.findSummaryByTargetUuid("target-1", null, 10))
+                .thenReturn(new Slice<>(List.of(firstSummary), true, nextCursor));
+        when(auditService.findSummaryByTargetUuid("target-1", nextCursor, 10))
+                .thenReturn(new Slice<>(List.of(nextSummary), false, null));
+
+        menu.history("viewer-1", target);
+        menuService.onMenuOption(session, optionIndexOf(session.activeScreen(), "next"));
+
+        AuditHistoryMenu.AuditHistoryState pagedState = session.getDraft(AuditHistoryMenu.AuditHistoryState.class);
+        assertThat(pagedState.currentCursor).isEqualTo(nextCursor);
+        assertThat(pagedState.backStack).hasSize(1);
+
+        menu.history("viewer-1", target);
+
+        AuditHistoryMenu.AuditHistoryState resetState = session.getDraft(AuditHistoryMenu.AuditHistoryState.class);
+        assertThat(resetState.currentCursor).isNull();
+        assertThat(resetState.backStack).isEmpty();
+        assertThat(session.hasRouteHistory()).isTrue();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("audit.history");
+        verify(auditService, times(2)).findSummaryByTargetUuid("target-1", null, 10);
+    }
+
+    @Test
     @DisplayName("previous action restores first page cursor from marker")
     void previousAction_restoresFirstPageCursorFromMarker() {
         SessionService sessionService = mock(SessionService.class);
         AuditService auditService = mock(AuditService.class);
-        AuditHistoryMenu menu = new AuditHistoryMenu(new Config(), new GlobalConfig(), sessionService, auditService);
+        AuditHistoryMenu menu = createMenu(sessionService, auditService);
 
         Session session = session("viewer-1");
         PlayerData target = playerData("target-1", 1);
@@ -156,7 +199,7 @@ class AuditHistoryMenuFlowTest {
     void detailsAction_opensDetailsViaFollowUpMenu() {
         SessionService sessionService = mock(SessionService.class);
         AuditService auditService = mock(AuditService.class);
-        AuditHistoryMenu menu = new AuditHistoryMenu(new Config(), new GlobalConfig(), sessionService, auditService);
+        AuditHistoryMenu menu = createMenu(sessionService, auditService);
 
         Session session = session("viewer-1");
         PlayerData target = playerData("target-1", 1);
@@ -181,7 +224,7 @@ class AuditHistoryMenuFlowTest {
         int detailsIndex = optionIndexOf(session.activeScreen(), "details:audit-3");
         menuService.onMenuOption(session, detailsIndex);
 
-        assertThat(session.hasHistory()).isTrue();
+        assertThat(session.hasRouteHistory()).isTrue();
         ActiveMenuScreen detailsScreen = session.activeScreen();
         assertThat(detailsScreen).isNotNull();
         assertThat(detailsScreen.mode()).isEqualTo(MenuMode.FOLLOW_UP);
@@ -193,7 +236,7 @@ class AuditHistoryMenuFlowTest {
     void backFromDetails_hidesFollowUpAndRestoresList() {
         SessionService sessionService = mock(SessionService.class);
         AuditService auditService = mock(AuditService.class);
-        AuditHistoryMenu menu = new AuditHistoryMenu(new Config(), new GlobalConfig(), sessionService, auditService);
+        AuditHistoryMenu menu = createMenu(sessionService, auditService);
 
         Session session = session("viewer-1");
         PlayerData target = playerData("target-1", 1);
@@ -237,7 +280,7 @@ class AuditHistoryMenuFlowTest {
     void closeFromDetails_hidesFollowUpAndClearsActiveScreen() {
         SessionService sessionService = mock(SessionService.class);
         AuditService auditService = mock(AuditService.class);
-        AuditHistoryMenu menu = new AuditHistoryMenu(new Config(), new GlobalConfig(), sessionService, auditService);
+        AuditHistoryMenu menu = createMenu(sessionService, auditService);
 
         Session session = session("viewer-1");
         PlayerData target = playerData("target-1", 1);
@@ -275,7 +318,7 @@ class AuditHistoryMenuFlowTest {
     void dismissFromDetails_hidesFollowUpAndClearsActiveScreen() {
         SessionService sessionService = mock(SessionService.class);
         AuditService auditService = mock(AuditService.class);
-        AuditHistoryMenu menu = new AuditHistoryMenu(new Config(), new GlobalConfig(), sessionService, auditService);
+        AuditHistoryMenu menu = createMenu(sessionService, auditService);
 
         Session session = session("viewer-1");
         PlayerData target = playerData("target-1", 1);
@@ -300,7 +343,7 @@ class AuditHistoryMenuFlowTest {
         int detailsIndex = optionIndexOf(session.activeScreen(), "details:audit-3");
         menuService.onMenuOption(session, detailsIndex);
 
-        assertThat(session.hasHistory()).isTrue();
+        assertThat(session.hasRouteHistory()).isTrue();
 
         // Dismiss with option == -1
         menuService.onMenuOption(session, -1);
@@ -308,7 +351,7 @@ class AuditHistoryMenuFlowTest {
         verify(gateway).followUpMenu(eq(session.player), eq(0), eq("audit-menu-details-title"), any(), any());
         verify(gateway).hideFollowUpMenu(eq(session.player), eq(0));
         assertThat(session.activeScreen()).isNull();
-        assertThat(session.hasHistory()).isTrue();
+        assertThat(session.hasRouteHistory()).isTrue();
     }
 
     @Test
@@ -316,7 +359,7 @@ class AuditHistoryMenuFlowTest {
     void closeAction_clearsActiveScreen() {
         SessionService sessionService = mock(SessionService.class);
         AuditService auditService = mock(AuditService.class);
-        AuditHistoryMenu menu = new AuditHistoryMenu(new Config(), new GlobalConfig(), sessionService, auditService);
+        AuditHistoryMenu menu = createMenu(sessionService, auditService);
 
         Session session = session("viewer-1");
         PlayerData target = playerData("target-1", 1);
@@ -330,6 +373,12 @@ class AuditHistoryMenuFlowTest {
         menuService.onMenuOption(session, optionIndexOf(session.activeScreen(), "close"));
 
         assertThat(session.activeScreen()).isNull();
+    }
+
+    private AuditHistoryMenu createMenu(SessionService sessionService, AuditService auditService) {
+        var menu = new AuditHistoryMenu(new Config(), new GlobalConfig(), sessionService, auditService, menuService);
+        menu.init();
+        return menu;
     }
 
     private static int optionIndexOf(ActiveMenuScreen screen, String actionId) {

--- a/src/test/java/org/xcore/plugin/ui/BanMenuTest.java
+++ b/src/test/java/org/xcore/plugin/ui/BanMenuTest.java
@@ -58,7 +58,8 @@ class BanMenuTest {
         Provider<SessionService> sessionProvider = mock(Provider.class);
         when(sessionProvider.get()).thenReturn(sessionService);
         menuService = new MenuService(sessionProvider, gateway);
-        banMenu = new BanMenu(new Config(), new GlobalConfig(), sessionService, moderationService, timeService);
+        banMenu = new BanMenu(new Config(), new GlobalConfig(), sessionService, moderationService, timeService, menuService);
+        banMenu.init();
 
         session = session("admin-uuid", 1);
         target = target("target-uuid");
@@ -238,7 +239,7 @@ class BanMenuTest {
     @SuppressWarnings("unchecked")
     private static Class<Object> draftClass() {
         try {
-            return (Class<Object>) Class.forName("org.xcore.plugin.ui.menu.BanMenu$BanDraft");
+            return (Class<Object>) Class.forName("org.xcore.plugin.ui.menu.BanMenu$BanFlowState");
         } catch (ClassNotFoundException e) {
             throw new AssertionError(e);
         }

--- a/src/test/java/org/xcore/plugin/ui/DiscordMenuTest.java
+++ b/src/test/java/org/xcore/plugin/ui/DiscordMenuTest.java
@@ -55,7 +55,8 @@ class DiscordMenuTest {
         globalConfig.discordUrl = "https://discord.example";
 
         discordLinkService = mock(DiscordLinkService.class);
-        discordMenu = new DiscordMenu(config, globalConfig, sessionService, discordLinkService);
+        discordMenu = new DiscordMenu(config, globalConfig, sessionService, discordLinkService, menuService);
+        discordMenu.init();
 
         session = session();
         when(sessionService.get("viewer-1")).thenReturn(session);

--- a/src/test/java/org/xcore/plugin/ui/EventMenuTest.java
+++ b/src/test/java/org/xcore/plugin/ui/EventMenuTest.java
@@ -1,10 +1,17 @@
 package org.xcore.plugin.ui;
 
 import com.ospx.flubundle.Bundle;
+import arc.files.Fi;
+import arc.struct.Seq;
+import arc.struct.StringMap;
 import jakarta.inject.Provider;
+import mindustry.core.GameState;
+import mindustry.game.Gamemode;
 import mindustry.gen.Player;
+import mindustry.maps.Map;
 import mindustry.net.NetConnection;
 import org.bson.types.ObjectId;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,11 +33,11 @@ import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
 import org.xcore.plugin.ui.menu.EventMenu;
 import org.xcore.plugin.ui.menu.MapMenu;
+import org.xcore.plugin.ui.route.MenuRoute;
 import org.xcore.plugin.vote.VoteService;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,6 +48,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -57,7 +65,10 @@ class EventMenuTest {
     private MindustryMenuGateway gateway;
     private MenuService menuService;
     private EventMenu eventMenu;
+    private MapMenu mapMenu;
     private Session session;
+    private GlobalConfig globalConfig;
+    private GameState originalState;
 
     @BeforeEach
     @SuppressWarnings("unchecked")
@@ -76,7 +87,7 @@ class EventMenuTest {
         when(sessionProvider.get()).thenReturn(sessionService);
         menuService = new MenuService(sessionProvider, gateway);
 
-        GlobalConfig globalConfig = new GlobalConfig();
+        globalConfig = new GlobalConfig();
         globalConfig.eventsPerPage = 10;
         globalConfig.mapsPerPage = 10;
         EventEditorService eventEditorService = new EventEditorService(eventDataRepository, mapDataRepository, playerDataRepository);
@@ -90,8 +101,31 @@ class EventMenuTest {
                 eventEditorService,
                 eventViewService,
                 voteService,
-                mapMenuProvider
+                mapMenuProvider,
+                menuService
         );
+        eventMenu.init();
+
+        Provider<EventMenu> eventMenuProvider = mock(Provider.class);
+        when(eventMenuProvider.get()).thenReturn(eventMenu);
+        mapMenu = new MapMenu(
+                new Config(),
+                globalConfig,
+                sessionService,
+                mapDataRepository,
+                eventDataRepository,
+                mapService,
+                eventMenuProvider,
+                menuService
+        );
+        mapMenu.init();
+        when(mapMenuProvider.get()).thenReturn(mapMenu);
+
+        originalState = mindustry.Vars.state;
+        mindustry.Vars.state = new GameState();
+        mindustry.game.Rules rules = mock(mindustry.game.Rules.class);
+        when(rules.mode()).thenReturn(Gamemode.pvp);
+        mindustry.Vars.state.rules = rules;
 
         session = session();
         when(sessionService.get(session.data.uuid)).thenReturn(session);
@@ -99,6 +133,12 @@ class EventMenuTest {
         when(eventDataRepository.findActive()).thenReturn(Optional.empty());
         when(eventDataRepository.count(anyMapOfStatus())).thenReturn(0L);
         when(eventDataRepository.findPage(anyInt(), anyInt(), any())).thenReturn(List.of());
+        when(eventDataRepository.findById(any(ObjectId.class))).thenReturn(null);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mindustry.Vars.state = originalState;
     }
 
     @Test
@@ -114,7 +154,21 @@ class EventMenuTest {
         assertThat(draft.map).isEqualTo(map.id);
         assertThat(session.textHandler).isNull();
         assertThat(session.activePrompt()).isNotNull();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("event.create-start"));
         verify(gateway).textInput(eq(session.player), eq(0), eq("event-menu-create-start-title"), eq("event-menu-create-start-message"), eq(20), anyString(), eq(false));
+    }
+
+    @Test
+    @DisplayName("main createStart action opens prompt without adding legacy history")
+    void main_createStartAction_opensPromptWithoutAddingLegacyHistory() {
+        eventMenu.main(session.data.uuid);
+
+        menuService.onMenuOption(session, 0);
+
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.activePrompt()).isNotNull();
     }
 
     @Test
@@ -132,6 +186,8 @@ class EventMenuTest {
         assertThat(draft.name).isEqualTo("My Event");
         assertThat(session.activePrompt()).isNull();
         assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("event.edit"));
     }
 
     @Test
@@ -172,6 +228,8 @@ class EventMenuTest {
         assertThat(session.activePrompt()).isNull();
         assertThat(session.textHandler).isNull();
         assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("event.edit"));
     }
 
     @Test
@@ -224,6 +282,311 @@ class EventMenuTest {
         assertThat(session.activePrompt()).isNull();
     }
 
+    @Test
+    @DisplayName("main renders routed screen with route metadata")
+    void main_rendersRoutedScreenWithRouteMetadata() {
+        eventMenu.main(session.data.uuid);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("event.main"));
+        verify(gateway).menu(eq(session.player), eq(0), eq("event-menu-main-title"), eq("event-menu-main-content"), any());
+    }
+
+    @Test
+    @DisplayName("main events action opens routed events via route history")
+    void main_eventsAction_opensRoutedEventsViaRouteHistory() {
+        eventMenu.main(session.data.uuid);
+
+        menuService.onMenuOption(session, 1);
+
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.hasRouteHistory()).isTrue();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("event.events").withParam("page", "1"));
+    }
+
+    @Test
+    @DisplayName("events empty renders routed screen with empty content")
+    void events_empty_rendersRoutedEmptyScreen() {
+        eventMenu.events(session.data.uuid, 1);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("event.events").withParam("page", "1"));
+        verify(gateway).menu(eq(session.player), eq(0), eq("event-menu-events-title"), eq("event-menu-events-empty"), any());
+    }
+
+    @Test
+    @DisplayName("events with events renders page and lists events")
+    void events_withEvents_rendersPageWithEvents() {
+        EventData event1 = new EventData();
+        event1.id = new ObjectId();
+        event1.name = "Event One";
+        event1.isActive = false;
+
+        when(eventDataRepository.count(anyMapOfStatus())).thenReturn(1L);
+        when(eventDataRepository.findPage(anyInt(), anyInt(), any())).thenReturn(List.of(event1));
+
+        eventMenu.events(session.data.uuid, 1);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("event.events").withParam("page", "1"));
+        assertThat(session.activeScreen().actionCount()).isGreaterThan(0);
+        verify(gateway).menu(eq(session.player), eq(0), eq("event-menu-events-title"), eq("event-menu-events-content"), any());
+    }
+
+    @Test
+    @DisplayName("events next page navigation renders second page")
+    void events_nextPage_rendersSecondPage() {
+        EventData event1 = new EventData();
+        event1.id = new ObjectId();
+        event1.name = "Event One";
+
+        EventData event2 = new EventData();
+        event2.id = new ObjectId();
+        event2.name = "Event Two";
+
+        globalConfig.eventsPerPage = 1;
+        when(eventDataRepository.count(anyMapOfStatus())).thenReturn(2L);
+        when(eventDataRepository.findPage(anyInt(), anyInt(), any())).thenReturn(List.of(event1), List.of(event2));
+
+        eventMenu.events(session.data.uuid, 1);
+
+        // rows: finished (0), major (1), active (2), next (3), event1 (4), main (5), close (6)
+        menuService.onMenuOption(session, 3);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("event.events").withParam("page", "2"));
+        verify(gateway, times(2)).menu(eq(session.player), eq(0), eq("event-menu-events-title"), anyString(), any());
+    }
+
+    @Test
+    @DisplayName("events status toggle changes filter and resets to page 1")
+    void events_statusToggle_changesFilter() {
+        eventMenu.events(session.data.uuid, 2);
+
+        // rows: finished (0), major (1), active (2), main (3), close (4)
+        menuService.onMenuOption(session, 0);
+
+        assertThat(session.sortStatus.get("finished")).isEqualTo(StatusEnum.Active);
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("event.events").withParam("page", "1"));
+    }
+
+    @Test
+    @DisplayName("events click event opens routed event detail and back returns to events")
+    void events_clickEvent_opensRoutedEventAndBackReturnsToEvents() {
+        EventData event1 = new EventData();
+        event1.id = new ObjectId();
+        event1.name = "Event One";
+        event1.author = session.data.id;
+
+        when(eventDataRepository.count(anyMapOfStatus())).thenReturn(1L);
+        when(eventDataRepository.findPage(anyInt(), anyInt(), any())).thenReturn(List.of(event1));
+        when(eventDataRepository.findById(event1.id)).thenReturn(event1);
+
+        eventMenu.events(session.data.uuid, 1);
+
+        // rows: finished (0), major (1), active (2), event1 (3), main (4), back (5), close (6)
+        menuService.onMenuOption(session, 3);
+
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.hasRouteHistory()).isTrue();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("event.details").withParam("eventId", event1.id.toHexString()));
+
+        menuService.goBack(session);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("event.events").withParam("page", "1"));
+    }
+
+    @Test
+    @DisplayName("event renders routed screen with route metadata")
+    void event_rendersRoutedScreenWithRouteMetadata() {
+        EventData event = new EventData();
+        event.id = new ObjectId();
+        event.name = "Event One";
+        event.author = session.data.id;
+
+        when(eventDataRepository.findById(event.id)).thenReturn(event);
+
+        eventMenu.event(session.data.uuid, event);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("event.details").withParam("eventId", event.id.toHexString()));
+        verify(gateway).menu(eq(session.player), eq(0), eq("event-menu-event-title"), eq("event-menu-event-content"), any());
+    }
+
+    @Test
+    @DisplayName("event events action opens routed events via route history")
+    void event_eventsAction_opensRoutedEventsViaRouteHistory() {
+        EventData event = new EventData();
+        event.id = new ObjectId();
+        event.name = "Event One";
+        event.author = session.data.id;
+
+        when(eventDataRepository.findById(event.id)).thenReturn(event);
+
+        eventMenu.event(session.data.uuid, event);
+
+        menuService.onMenuOption(session, 4);
+
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.hasRouteHistory()).isTrue();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("event.events").withParam("page", "1"));
+    }
+
+    @Test
+    @DisplayName("event edit action opens legacy edit without adding legacy history")
+    void event_editAction_opensRoutedEditWithoutAddingLegacyHistory() {
+        EventData event = new EventData();
+        event.id = new ObjectId();
+        event.name = "Event One";
+        event.author = session.data.id;
+
+        when(eventDataRepository.findById(event.id)).thenReturn(event);
+
+        eventMenu.event(session.data.uuid, event);
+
+        menuService.onMenuOption(session, 3);
+
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("event.edit"));
+        assertThat(session.hasDraft(EventData.class)).isTrue();
+        assertThat(session.getDraft(EventData.class)).isSameAs(event);
+    }
+
+    @Test
+    @DisplayName("edit renders routed screen with route metadata")
+    void edit_rendersRoutedScreenWithRouteMetadata() {
+        EventData draft = new EventData();
+        draft.name = "Event";
+        draft.author = session.data.id;
+        session.setDraft(draft);
+
+        eventMenu.edit(session.data.uuid);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("event.edit"));
+        verify(gateway).menu(eq(session.player), eq(0), eq("event-menu-edit-title"), eq("event-menu-edit-content"), any());
+    }
+
+    @Test
+    @DisplayName("edit map action opens routed map selection via route history")
+    void edit_mapAction_opensRoutedMapSelectionViaRouteHistory() {
+        EventData draft = new EventData();
+        draft.name = "Event";
+        draft.author = session.data.id;
+        session.setDraft(draft);
+        when(mapService.getAvailableMaps()).thenReturn(Seq.with(createMap("Map1")));
+
+        eventMenu.edit(session.data.uuid);
+
+        menuService.onMenuOption(session, 3);
+
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.hasRouteHistory()).isTrue();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("event.map-selection").withParam("page", "1"));
+    }
+
+    @Test
+    @DisplayName("map selection choosing map updates draft and returns to routed edit")
+    void mapSelection_chooseMap_updatesDraftAndReturnsToRoutedEdit() {
+        EventData draft = new EventData();
+        draft.name = "Event";
+        draft.author = session.data.id;
+        session.setDraft(draft);
+
+        MapData selectedMap = new MapData("Map1", "Map1.msav", "author", "pvp");
+        selectedMap.id = new ObjectId();
+        when(mapService.getAvailableMaps()).thenReturn(Seq.with(createMap("Map1")));
+        when(mapDataRepository.findOrCreate("Map1", "Map1.msav", "author", "pvp")).thenReturn(selectedMap);
+        when(mapDataRepository.findById(selectedMap.id)).thenReturn(selectedMap);
+
+        eventMenu.edit(session.data.uuid);
+        menuService.onMenuOption(session, 3);
+        menuService.onMenuOption(session, 0);
+
+        assertThat(draft.map).isEqualTo(selectedMap.id);
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("event.edit"));
+    }
+
+    @Test
+    @DisplayName("map selection back returns to routed edit")
+    void mapSelection_back_returnsToRoutedEdit() {
+        EventData draft = new EventData();
+        draft.name = "Event";
+        draft.author = session.data.id;
+        session.setDraft(draft);
+        when(mapService.getAvailableMaps()).thenReturn(Seq.with(createMap("Map1")));
+
+        eventMenu.edit(session.data.uuid);
+        menuService.onMenuOption(session, 3);
+        menuService.onMenuOption(session, 1);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("event.edit"));
+    }
+
+    @Test
+    @DisplayName("event map action opens routed map via route history")
+    void event_mapAction_opensRoutedMapViaRouteHistory() {
+        EventData event = new EventData();
+        event.id = new ObjectId();
+        event.name = "Event One";
+        event.author = session.data.id;
+
+        MapData map = new MapData("Map One", "Map One.msav", "author", "pvp");
+        map.id = new ObjectId();
+        event.map = map.id;
+
+        when(eventDataRepository.findById(event.id)).thenReturn(event);
+        when(mapDataRepository.findById(map.id)).thenReturn(map);
+
+        eventMenu.event(session.data.uuid, event);
+
+        menuService.onMenuOption(session, 5);
+
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.hasRouteHistory()).isTrue();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("map.details").withParam("mapId", map.id.toHexString()));
+    }
+
+    @Test
+    @DisplayName("event not found renders routed fallback screen")
+    void event_notFoundRendersRoutedFallbackScreen() {
+        ObjectId missingId = new ObjectId();
+        EventData event = new EventData();
+        event.id = missingId;
+
+        when(eventDataRepository.findById(missingId)).thenReturn(null);
+
+        eventMenu.event(session.data.uuid, event);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("event.details").withParam("eventId", missingId.toHexString()));
+        verify(gateway).menu(eq(session.player), eq(0), eq("event-menu-event-title"), eq("error-internal"), any());
+    }
+
     private Session session() {
         Player player = Player.create();
         player.con = mock(NetConnection.class);
@@ -248,8 +611,18 @@ class EventMenuTest {
         return session;
     }
 
+    private mindustry.maps.Map createMap(String name) {
+        return new mindustry.maps.Map(
+                new Fi(name + ".msav"),
+                100,
+                100,
+                StringMap.of("name", name, "author", "author"),
+                true
+        );
+    }
+
     @SuppressWarnings("unchecked")
-    private static Map<String, StatusEnum> anyMapOfStatus() {
-        return any(Map.class);
+    private static java.util.Map<String, StatusEnum> anyMapOfStatus() {
+        return any(java.util.Map.class);
     }
 }

--- a/src/test/java/org/xcore/plugin/ui/HelpMenuTest.java
+++ b/src/test/java/org/xcore/plugin/ui/HelpMenuTest.java
@@ -1,0 +1,205 @@
+package org.xcore.plugin.ui;
+
+import arc.util.CommandHandler;
+import com.ospx.flubundle.Bundle;
+import jakarta.inject.Provider;
+import mindustry.Vars;
+import mindustry.core.NetServer;
+import mindustry.gen.Player;
+import mindustry.net.NetConnection;
+import org.incendo.cloud.Command;
+import org.incendo.cloud.help.HelpHandler;
+import org.incendo.cloud.help.result.IndexCommandResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.xcore.plugin.cloud.CloudService;
+import org.xcore.plugin.cloud.XCoreSender;
+import org.xcore.plugin.config.Config;
+import org.xcore.plugin.config.GlobalConfig;
+import org.xcore.plugin.database.repository.PlayerDataRepository;
+import org.xcore.plugin.localization.Localization;
+import org.xcore.plugin.model.PlayerData;
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.flow.MenuMode;
+import org.xcore.plugin.ui.menu.HelpMenu;
+import org.xcore.plugin.ui.route.MenuRoute;
+
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@SuppressWarnings("unchecked")
+class HelpMenuTest {
+
+    private SessionService sessionService;
+    private MindustryMenuGateway gateway;
+    private MenuService menuService;
+    private HelpMenu helpMenu;
+    private Session session;
+    private GlobalConfig globalConfig;
+    private NetServer previousNetServer;
+    private CloudService cloudService;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        sessionService = mock(SessionService.class);
+        gateway = mock(MindustryMenuGateway.class);
+        Provider<SessionService> sessionProvider = mock(Provider.class);
+        when(sessionProvider.get()).thenReturn(sessionService);
+        menuService = new MenuService(sessionProvider, gateway);
+
+        Config config = new Config();
+        globalConfig = new GlobalConfig();
+        globalConfig.commandsPerPage = 2;
+
+        cloudService = mock(CloudService.class);
+        HelpHandler<XCoreSender> helpHandler = mock(HelpHandler.class);
+        IndexCommandResult<XCoreSender> indexResult = mock(IndexCommandResult.class);
+        when(cloudService.getHelpHandler()).thenReturn(helpHandler);
+        when(helpHandler.queryRootIndex(any())).thenReturn(indexResult);
+        when(indexResult.entries()).thenReturn(java.util.List.of());
+        when(cloudService.isCommandDisabled(any(Command.class))).thenReturn(false);
+        when(cloudService.isCommandDisabled(anyString())).thenReturn(false);
+
+        Provider<CloudService> cloudProvider = mock(Provider.class);
+        when(cloudProvider.get()).thenReturn(cloudService);
+
+        helpMenu = new HelpMenu(config, globalConfig, sessionService, cloudProvider, menuService);
+        helpMenu.init();
+
+        previousNetServer = Vars.netServer;
+        NetServer netServer = mock(NetServer.class);
+        netServer.clientCommands = new CommandHandler("");
+        Vars.netServer = netServer;
+
+        session = session();
+        when(sessionService.get("viewer-1")).thenReturn(session);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Vars.netServer = previousNetServer;
+    }
+
+    @Test
+    @DisplayName("sender missing sends error-internal and does not render menu")
+    void senderMissing_sendsErrorInternalAndDoesNotRenderMenu() {
+        session.sender = null;
+
+        helpMenu.help("viewer-1", 1);
+
+        assertThat(session.activeScreen()).isNull();
+        verify(gateway, never()).menu(any(), anyInt(), anyString(), anyString(), any());
+    }
+
+    @Test
+    @DisplayName("first page render shows commands and pagination")
+    void firstPageRender_showsCommandsAndPagination() {
+        registerLegacyCommands("help", "info", "rules");
+
+        helpMenu.help("viewer-1", 1);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.NORMAL);
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("help.list").withParam("page", "1"));
+        assertThat(session.activeScreen().actionCount()).isEqualTo(4);
+        verify(gateway).menu(eq(session.player), eq(0), eq("help-menu-title"), eq("help-menu-content"), any());
+    }
+
+    @Test
+    @DisplayName("next page navigation renders second page")
+    void nextPageNavigation_rendersSecondPage() {
+        registerLegacyCommands("help", "info", "rules");
+        helpMenu.help("viewer-1", 1);
+
+        menuService.onMenuOption(session, 0);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("help.list").withParam("page", "2"));
+        assertThat(session.activeScreen().actionCount()).isEqualTo(3);
+        verify(gateway, times(2)).menu(eq(session.player), eq(0), eq("help-menu-title"), eq("help-menu-content"), any());
+    }
+
+    @Test
+    @DisplayName("previous page navigation renders first page")
+    void previousPageNavigation_rendersFirstPage() {
+        registerLegacyCommands("help", "info", "rules");
+        helpMenu.help("viewer-1", 2);
+
+        menuService.onMenuOption(session, 0);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("help.list").withParam("page", "1"));
+        assertThat(session.activeScreen().actionCount()).isEqualTo(4);
+        verify(gateway, times(2)).menu(eq(session.player), eq(0), eq("help-menu-title"), eq("help-menu-content"), any());
+    }
+
+    @Test
+    @DisplayName("opening command details renders details route")
+    void openingCommandDetails_rendersDetailsRoute() {
+        registerLegacyCommands("help", "info", "rules");
+        helpMenu.help("viewer-1", 1);
+
+        menuService.onMenuOption(session, 1);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(
+                MenuRoute.of("help.details").withParam("cmd", "help").withParam("returnPage", "1")
+        );
+        assertThat(session.activeScreen().actionCount()).isEqualTo(3);
+        verify(gateway).menu(eq(session.player), eq(0), eq("help-command-title"), anyString(), any());
+    }
+
+    @Test
+    @DisplayName("back from details returns to list")
+    void backFromDetails_returnsToList() {
+        registerLegacyCommands("help", "info", "rules");
+        helpMenu.help("viewer-1", 1);
+        menuService.onMenuOption(session, 1);
+
+        menuService.onMenuOption(session, 0);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("help.list").withParam("page", "1"));
+        assertThat(session.activeScreen().actionCount()).isEqualTo(4);
+        verify(gateway, times(2)).menu(eq(session.player), eq(0), eq("help-menu-title"), eq("help-menu-content"), any());
+    }
+
+    private void registerLegacyCommands(String... names) {
+        for (String name : names) {
+            Vars.netServer.clientCommands.register(name, name + " desc", (args, player) -> {});
+        }
+    }
+
+    private Session session() {
+        Player player = Player.create();
+        player.con = mock(NetConnection.class);
+        PlayerData data = new PlayerData("viewer-1", true);
+        data.uuid = "viewer-1";
+        Session session = new Session(
+                globalConfig,
+                mock(Bundle.class),
+                menuService,
+                mock(PlayerDataRepository.class),
+                player,
+                data
+        );
+        Localization localization = mock(Localization.class);
+        when(localization.t(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.t(anyString(), anyMap())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.getLocale()).thenReturn(Locale.US);
+        session.localization = localization;
+
+        XCoreSender sender = mock(XCoreSender.class);
+        session.sender = sender;
+        return session;
+    }
+}

--- a/src/test/java/org/xcore/plugin/ui/InformationMenuTest.java
+++ b/src/test/java/org/xcore/plugin/ui/InformationMenuTest.java
@@ -33,6 +33,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 class InformationMenuTest {
@@ -43,6 +44,10 @@ class InformationMenuTest {
     private InformationMenu informationMenu;
     private Session session;
     private GlobalConfig globalConfig;
+    private Provider<MapMenu> map;
+    private Provider<EventMenu> event;
+    private Provider<HelpMenu> help;
+    private Provider<PlayerMenu> player;
 
     @BeforeEach
     @SuppressWarnings("unchecked")
@@ -64,14 +69,55 @@ class InformationMenuTest {
 
         BuildInfo buildInfo = new BuildInfo();
         buildInfo.setVersion("test-version");
-        Provider<MapMenu> map = mock(Provider.class);
-        Provider<EventMenu> event = mock(Provider.class);
-        Provider<HelpMenu> help = mock(Provider.class);
-        Provider<PlayerMenu> player = mock(Provider.class);
-        informationMenu = new InformationMenu(config, globalConfig, sessionService, buildInfo, map, event, help, player);
+        map = mock(Provider.class);
+        event = mock(Provider.class);
+        help = mock(Provider.class);
+        player = mock(Provider.class);
+        informationMenu = new InformationMenu(config, globalConfig, sessionService, buildInfo, menuService, map, event, help, player);
+        informationMenu.init();
 
         session = session();
         when(sessionService.get("viewer-1")).thenReturn(session);
+    }
+
+    @Test
+    @DisplayName("main renders through route-backed flow runtime")
+    void main_rendersThroughRouteBackedFlowRuntime() {
+        informationMenu.main("viewer-1");
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.NORMAL);
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().actionCount()).isEqualTo(5);
+        verify(gateway).menu(eq(session.player), eq(0), eq("menu-main-title"), eq("menu-main-content"), any());
+    }
+
+    @Test
+    @DisplayName("main opens information route from action")
+    void main_opensInformationRouteFromAction() {
+        informationMenu.main("viewer-1");
+
+        menuService.onMenuOption(session, 0);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        verify(gateway).menu(eq(session.player), eq(0), eq("menu-main-title"), eq("menu-main-content"), any());
+        verify(gateway).followUpMenu(eq(session.player), eq(0), eq("commands-info-title"), eq("commands-info-text"), any());
+    }
+
+    @Test
+    @DisplayName("information back action reopens main route")
+    void information_backActionReopensMainRoute() {
+        informationMenu.main("viewer-1");
+        menuService.onMenuOption(session, 0);
+
+        menuService.onMenuOption(session, 5);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.NORMAL);
+        verify(gateway).hideFollowUpMenu(eq(session.player), eq(0));
+        verify(gateway, times(2)).menu(eq(session.player), eq(0), eq("menu-main-title"), eq("menu-main-content"), any());
     }
 
     @Test
@@ -110,6 +156,108 @@ class InformationMenuTest {
     }
 
     @Test
+    @DisplayName("main help action uses route history and opens help menu")
+    void main_helpActionUsesRouteHistoryAndOpensHelpMenu() {
+        HelpMenu helpMenu = mock(HelpMenu.class);
+        when(help.get()).thenReturn(helpMenu);
+
+        informationMenu.main("viewer-1");
+        menuService.onMenuOption(session, 1);
+
+        verify(helpMenu).help("viewer-1", 1);
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.hasRouteHistory()).isTrue();
+    }
+
+    @Test
+    @DisplayName("main maps action uses route history and opens maps menu")
+    void main_mapsActionUsesRouteHistoryAndOpensMapsMenu() {
+        MapMenu mapMenu = mock(MapMenu.class);
+        when(map.get()).thenReturn(mapMenu);
+
+        informationMenu.main("viewer-1");
+        menuService.onMenuOption(session, 2);
+
+        verify(mapMenu).maps("viewer-1", 1);
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.hasRouteHistory()).isTrue();
+    }
+
+    @Test
+    @DisplayName("main players action uses route history and opens players menu")
+    void main_playersActionUsesRouteHistoryAndOpensPlayersMenu() {
+        PlayerMenu playerMenu = mock(PlayerMenu.class);
+        when(player.get()).thenReturn(playerMenu);
+
+        informationMenu.main("viewer-1");
+        menuService.onMenuOption(session, 3);
+
+        verify(playerMenu).players("viewer-1", 1);
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.hasRouteHistory()).isTrue();
+    }
+
+    @Test
+    @DisplayName("main event main action uses route history and opens event main menu")
+    void main_eventMainActionUsesRouteHistoryAndOpensEventMainMenu() {
+        SessionService localSessionService = mock(SessionService.class);
+        MindustryMenuGateway localGateway = mock(MindustryMenuGateway.class);
+        Provider<SessionService> localSessionProvider = mock(Provider.class);
+        when(localSessionProvider.get()).thenReturn(localSessionService);
+        MenuService localMenuService = new MenuService(localSessionProvider, localGateway);
+        Session localSession = session(localMenuService);
+        when(localSessionService.get("viewer-1")).thenReturn(localSession);
+
+        EventMenu eventMenu = mock(EventMenu.class);
+        Provider<EventMenu> localEvent = mock(Provider.class);
+        when(localEvent.get()).thenReturn(eventMenu);
+
+        Config eventConfig = new Config();
+        eventConfig.server = "event";
+        BuildInfo buildInfo = new BuildInfo();
+        buildInfo.setVersion("test-version");
+        InformationMenu eventInformationMenu = new InformationMenu(eventConfig, globalConfig, localSessionService, buildInfo, localMenuService, map, localEvent, help, player);
+        eventInformationMenu.init();
+
+        eventInformationMenu.main("viewer-1");
+        localMenuService.onMenuOption(localSession, 4);
+
+        verify(eventMenu).main("viewer-1");
+        assertThat(localSession.hasHistory()).isFalse();
+        assertThat(localSession.hasRouteHistory()).isTrue();
+    }
+
+    @Test
+    @DisplayName("main event list action uses route history and opens event list menu")
+    void main_eventListActionUsesRouteHistoryAndOpensEventListMenu() {
+        SessionService localSessionService = mock(SessionService.class);
+        MindustryMenuGateway localGateway = mock(MindustryMenuGateway.class);
+        Provider<SessionService> localSessionProvider = mock(Provider.class);
+        when(localSessionProvider.get()).thenReturn(localSessionService);
+        MenuService localMenuService = new MenuService(localSessionProvider, localGateway);
+        Session localSession = session(localMenuService);
+        when(localSessionService.get("viewer-1")).thenReturn(localSession);
+
+        EventMenu eventMenu = mock(EventMenu.class);
+        Provider<EventMenu> localEvent = mock(Provider.class);
+        when(localEvent.get()).thenReturn(eventMenu);
+
+        Config eventConfig = new Config();
+        eventConfig.server = "event";
+        BuildInfo buildInfo = new BuildInfo();
+        buildInfo.setVersion("test-version");
+        InformationMenu eventInformationMenu = new InformationMenu(eventConfig, globalConfig, localSessionService, buildInfo, localMenuService, map, localEvent, help, player);
+        eventInformationMenu.init();
+
+        eventInformationMenu.main("viewer-1");
+        localMenuService.onMenuOption(localSession, 5);
+
+        verify(eventMenu).events("viewer-1", 1);
+        assertThat(localSession.hasHistory()).isFalse();
+        assertThat(localSession.hasRouteHistory()).isTrue();
+    }
+
+    @Test
     @DisplayName("information close action clears active screen")
     void information_closeActionClearsActiveScreen() {
         informationMenu.information("viewer-1");
@@ -131,6 +279,10 @@ class InformationMenuTest {
     }
 
     private Session session() {
+        return session(menuService);
+    }
+
+    private Session session(MenuService menuService) {
         Player player = Player.create();
         player.con = mock(NetConnection.class);
         PlayerData data = new PlayerData("viewer-1", true);

--- a/src/test/java/org/xcore/plugin/ui/MenuBuilderTest.java
+++ b/src/test/java/org/xcore/plugin/ui/MenuBuilderTest.java
@@ -89,30 +89,15 @@ class MenuBuilderTest {
     }
 
     @Test
-    @DisplayName("legacy add and addLocal delegate to explicit text and key behavior")
-    void legacyAddMethods_delegateToExplicitBehavior() {
-        MenuBuilder builder = new MenuBuilder(menuService, session);
-
-        builder.start()
-                .add("Raw", () -> {})
-                .addLocal("key", () -> {})
-                .end();
-
-        assertThat(builder.rows).containsExactly(
-                java.util.List.of("Raw", "localized:key")
-        );
-    }
-
-    @Test
-    @DisplayName("addNavigationRow hides back when only route history exists for legacy screens")
-    void addNavigationRow_hidesBackWhenOnlyRouteHistoryExistsForLegacyScreens() {
+    @DisplayName("addNavigationRow shows back when route history exists")
+    void addNavigationRow_showsBackWhenRouteHistoryExists() {
         MenuBuilder builder = new MenuBuilder(menuService, session);
         session.pushRouteHistory(org.xcore.plugin.ui.route.MenuRoute.of("route.one"));
 
         builder.addNavigationRow();
 
         assertThat(builder.rows).containsExactly(
-                java.util.List.of("localized:close")
+                java.util.List.of("localized:back", "localized:close")
         );
     }
 

--- a/src/test/java/org/xcore/plugin/ui/MenuBuilderTest.java
+++ b/src/test/java/org/xcore/plugin/ui/MenuBuilderTest.java
@@ -103,6 +103,32 @@ class MenuBuilderTest {
         );
     }
 
+    @Test
+    @DisplayName("addNavigationRow hides back when only route history exists for legacy screens")
+    void addNavigationRow_hidesBackWhenOnlyRouteHistoryExistsForLegacyScreens() {
+        MenuBuilder builder = new MenuBuilder(menuService, session);
+        session.pushRouteHistory(org.xcore.plugin.ui.route.MenuRoute.of("route.one"));
+
+        builder.addNavigationRow();
+
+        assertThat(builder.rows).containsExactly(
+                java.util.List.of("localized:close")
+        );
+    }
+
+    @Test
+    @DisplayName("addNavigationRow shows back when legacy history exists")
+    void addNavigationRow_showsBackWhenLegacyHistoryExists() {
+        MenuBuilder builder = new MenuBuilder(menuService, session);
+        session.pushHistory(() -> {});
+
+        builder.addNavigationRow();
+
+        assertThat(builder.rows).containsExactly(
+                java.util.List.of("localized:back", "localized:close")
+        );
+    }
+
     private Session session() {
         Player player = Player.create();
         player.con = mock(NetConnection.class);

--- a/src/test/java/org/xcore/plugin/ui/MenuBuilderTest.java
+++ b/src/test/java/org/xcore/plugin/ui/MenuBuilderTest.java
@@ -1,0 +1,127 @@
+package org.xcore.plugin.ui;
+
+import com.ospx.flubundle.Bundle;
+import jakarta.inject.Provider;
+import mindustry.gen.Player;
+import mindustry.net.NetConnection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.xcore.plugin.config.GlobalConfig;
+import org.xcore.plugin.database.repository.PlayerDataRepository;
+import org.xcore.plugin.localization.Localization;
+import org.xcore.plugin.model.PlayerData;
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.session.SessionService;
+
+import java.util.Locale;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MenuBuilderTest {
+
+    private MenuService menuService;
+    private Session session;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        Provider<SessionService> sessionServiceProvider = mock(Provider.class);
+        menuService = new MenuService(sessionServiceProvider, mock(MindustryMenuGateway.class));
+        session = session();
+    }
+
+    @Test
+    @DisplayName("addButtonText keeps raw button text")
+    void addButtonText_keepsRawButtonText() {
+        MenuBuilder builder = new MenuBuilder(menuService, session);
+
+        builder.start()
+                .addButtonText("[green]Save", () -> {})
+                .end();
+
+        assertThat(builder.rows).containsExactly(
+                java.util.List.of("[green]Save")
+        );
+    }
+
+    @Test
+    @DisplayName("addButtonKey localizes button key once")
+    void addButtonKey_localizesButtonKeyOnce() {
+        MenuBuilder builder = new MenuBuilder(menuService, session);
+
+        builder.start()
+                .addButtonKey("save", () -> {})
+                .end();
+
+        assertThat(builder.rows).containsExactly(
+                java.util.List.of("localized:save")
+        );
+    }
+
+    @Test
+    @DisplayName("addRowText keeps raw row text")
+    void addRowText_keepsRawRowText() {
+        MenuBuilder builder = new MenuBuilder(menuService, session);
+
+        builder.addRowText("[red]Cancel", () -> {});
+
+        assertThat(builder.rows).containsExactly(
+                java.util.List.of("[red]Cancel")
+        );
+    }
+
+    @Test
+    @DisplayName("addRowKey localizes row key once")
+    void addRowKey_localizesRowKeyOnce() {
+        MenuBuilder builder = new MenuBuilder(menuService, session);
+
+        builder.addRowKey("cancel", () -> {});
+
+        assertThat(builder.rows).containsExactly(
+                java.util.List.of("localized:cancel")
+        );
+    }
+
+    @Test
+    @DisplayName("legacy add and addLocal delegate to explicit text and key behavior")
+    void legacyAddMethods_delegateToExplicitBehavior() {
+        MenuBuilder builder = new MenuBuilder(menuService, session);
+
+        builder.start()
+                .add("Raw", () -> {})
+                .addLocal("key", () -> {})
+                .end();
+
+        assertThat(builder.rows).containsExactly(
+                java.util.List.of("Raw", "localized:key")
+        );
+    }
+
+    private Session session() {
+        Player player = Player.create();
+        player.con = mock(NetConnection.class);
+        PlayerData data = new PlayerData("uuid-1", true);
+        Session session = new Session(
+                new GlobalConfig(),
+                mock(Bundle.class),
+                menuService,
+                mock(PlayerDataRepository.class),
+                player,
+                data
+        );
+        Localization localization = mock(Localization.class);
+        when(localization.t(anyString())).thenAnswer(invocation -> "localized:" + invocation.getArgument(0));
+        when(localization.t(anyString(), anyMap())).thenAnswer(invocation -> "localized:" + invocation.getArgument(0));
+        when(localization.format(anyString())).thenAnswer(invocation -> "localized:" + invocation.getArgument(0));
+        when(localization.format(anyString(), anyMap())).thenAnswer(invocation -> "localized:" + invocation.getArgument(0));
+        when(localization.getLocale()).thenReturn(Locale.US);
+        session.localization = localization;
+        return session;
+    }
+}

--- a/src/test/java/org/xcore/plugin/ui/MenuServiceFlowTest.java
+++ b/src/test/java/org/xcore/plugin/ui/MenuServiceFlowTest.java
@@ -361,6 +361,20 @@ class MenuServiceFlowTest {
     }
 
     @Test
+    @DisplayName("goBack does not consume route history for non routed active screen")
+    void goBack_doesNotConsumeRouteHistoryForNonRoutedActiveScreen() {
+        session.pushRouteHistory(MenuRoute.of("route.one"));
+        menuService.show(session, "Title", "Content", List.of(), List.of(), MenuMode.NORMAL);
+
+        boolean navigated = menuService.goBack(session);
+
+        assertThat(navigated).isFalse();
+        assertThat(session.hasRouteHistory()).isTrue();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isFalse();
+    }
+
+    @Test
     @DisplayName("flow prompt carries route into prompt callbacks")
     void flowPrompt_carriesRouteIntoPromptCallbacks() {
         AtomicReference<MenuRoute> promptRoute = new AtomicReference<>();

--- a/src/test/java/org/xcore/plugin/ui/MenuServiceFlowTest.java
+++ b/src/test/java/org/xcore/plugin/ui/MenuServiceFlowTest.java
@@ -11,6 +11,8 @@ import org.xcore.plugin.database.repository.PlayerDataRepository;
 import org.xcore.plugin.model.PlayerData;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.ui.flow.*;
+import org.xcore.plugin.ui.route.MenuRoute;
+import org.xcore.plugin.ui.route.RoutedMenuFlow;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -295,6 +297,111 @@ class MenuServiceFlowTest {
         assertThat(session.activePrompt()).isNull();
     }
 
+    @Test
+    @DisplayName("renderRoute hydrates state and stores route metadata")
+    void renderRoute_hydratesStateAndStoresRouteMetadata() {
+        AtomicReference<String> renderedState = new AtomicReference<>();
+
+        RoutedMenuFlow<StringBuilder> flow = new RoutedMenuFlow<>() {
+            @Override
+            public String routeId() {
+                return "player.profile";
+            }
+
+            @Override
+            public StringBuilder createState(Session session, MenuRoute route, StringBuilder currentState) {
+                StringBuilder next = currentState == null ? new StringBuilder() : currentState;
+                next.setLength(0);
+                next.append(route.param("targetUuid"));
+                return next;
+            }
+
+            @Override
+            public Class<StringBuilder> stateType() {
+                return StringBuilder.class;
+            }
+
+            @Override
+            public MenuScreen render(MenuRenderContext<StringBuilder> context) {
+                renderedState.set(context.state().toString());
+                assertThat(context.route()).isEqualTo(MenuRoute.of("player.profile").withParam("targetUuid", "uuid-42"));
+                return MenuScreen.normal("Profile", "Content", List.of(List.of(MenuButton.of("Open", "open"))));
+            }
+        };
+
+        menuService.registerRoute(flow);
+        menuService.renderRoute(session, MenuRoute.of("player.profile").withParam("targetUuid", "uuid-42"));
+
+        assertThat(renderedState.get()).isEqualTo("uuid-42");
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("player.profile").withParam("targetUuid", "uuid-42"));
+        verify(gateway).menu(eq(session.player), eq(0), eq("Profile"), eq("Content"), any());
+    }
+
+    @Test
+    @DisplayName("openRoute pushes previous route and goBack reopens it")
+    void openRoute_pushesPreviousRouteAndGoBackReopensIt() {
+        menuService.registerRoute(simpleRouteFlow("route.one", "Screen One"));
+        menuService.registerRoute(simpleRouteFlow("route.two", "Screen Two"));
+
+        menuService.renderRoute(session, MenuRoute.of("route.one"));
+        menuService.openRoute(session, MenuRoute.of("route.two"));
+
+        assertThat(session.hasRouteHistory()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("route.two"));
+
+        boolean navigated = menuService.goBack(session);
+
+        assertThat(navigated).isTrue();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("route.one"));
+        verify(gateway, times(2)).menu(eq(session.player), eq(0), eq("Screen One"), eq("Content"), any());
+        verify(gateway).menu(eq(session.player), eq(0), eq("Screen Two"), eq("Content"), any());
+    }
+
+    @Test
+    @DisplayName("flow prompt carries route into prompt callbacks")
+    void flowPrompt_carriesRouteIntoPromptCallbacks() {
+        AtomicReference<MenuRoute> promptRoute = new AtomicReference<>();
+
+        RoutedMenuFlow<StringBuilder> flow = new RoutedMenuFlow<>() {
+            @Override
+            public String routeId() {
+                return "prompt.route";
+            }
+
+            @Override
+            public StringBuilder createState(Session session, MenuRoute route, StringBuilder currentState) {
+                return currentState == null ? new StringBuilder(route.id()) : currentState;
+            }
+
+            @Override
+            public Class<StringBuilder> stateType() {
+                return StringBuilder.class;
+            }
+
+            @Override
+            public MenuScreen render(MenuRenderContext<StringBuilder> context) {
+                return MenuScreen.normal("Prompt", "Content", List.of());
+            }
+
+            @Override
+            public void onPromptSubmit(MenuRenderContext<StringBuilder> context, String promptId, String text) {
+                promptRoute.set(context.route());
+            }
+        };
+
+        MenuRoute route = MenuRoute.of("prompt.route").withParam("id", "7");
+        menuService.registerRoute(flow);
+        menuService.renderRoute(session, route);
+        menuService.openPrompt(session, flow, session.getDraft(StringBuilder.class), new MenuPrompt("prompt", "Title", "Content", 20, "", false));
+
+        menuService.onTextInput(session, "hello");
+
+        assertThat(promptRoute.get()).isEqualTo(route);
+    }
+
     private MenuFlow<String> mockFlow(String title, String content) {
         return new MenuFlow<>() {
             @Override
@@ -305,6 +412,33 @@ class MenuServiceFlowTest {
             @Override
             public MenuScreen render(MenuRenderContext<String> context) {
                 return MenuScreen.normal(title, content, List.of());
+            }
+        };
+    }
+
+    private RoutedMenuFlow<StringBuilder> simpleRouteFlow(String routeId, String title) {
+        return new RoutedMenuFlow<>() {
+            @Override
+            public String routeId() {
+                return routeId;
+            }
+
+            @Override
+            public StringBuilder createState(Session session, MenuRoute route, StringBuilder currentState) {
+                StringBuilder next = currentState == null ? new StringBuilder() : currentState;
+                next.setLength(0);
+                next.append(route.id());
+                return next;
+            }
+
+            @Override
+            public Class<StringBuilder> stateType() {
+                return StringBuilder.class;
+            }
+
+            @Override
+            public MenuScreen render(MenuRenderContext<StringBuilder> context) {
+                return MenuScreen.normal(title, "Content", List.of(List.of(MenuButton.of("Open", "open"))));
             }
         };
     }

--- a/src/test/java/org/xcore/plugin/ui/MessageMenuTest.java
+++ b/src/test/java/org/xcore/plugin/ui/MessageMenuTest.java
@@ -17,6 +17,7 @@ import org.xcore.plugin.model.PrivateMessage;
 import org.xcore.plugin.service.PrivateMessageService;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.flow.MenuMode;
 import org.xcore.plugin.ui.menu.MessageMenu;
 
 import java.util.List;
@@ -56,7 +57,8 @@ class MessageMenuTest {
         GlobalConfig globalConfig = new GlobalConfig();
         globalConfig.privateMessageMaxLength = 300;
         globalConfig.privateMessagesPerPage = 10;
-        messageMenu = new MessageMenu(new Config(), globalConfig, sessionService, privateMessageService);
+        messageMenu = new MessageMenu(new Config(), globalConfig, sessionService, privateMessageService, menuService);
+        messageMenu.init();
 
         session = session();
         when(sessionService.get("viewer-1")).thenReturn(session);
@@ -73,14 +75,97 @@ class MessageMenuTest {
     }
 
     @Test
+    @DisplayName("inbox renders through route-backed flow runtime")
+    void inbox_rendersThroughRouteBackedFlowRuntime() {
+        when(privateMessageService.countInbox(session.data.uuid)).thenReturn(0L);
+        when(privateMessageService.countUnread(session.data.uuid)).thenReturn(0L);
+
+        messageMenu.inbox("viewer-1", 1);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.NORMAL);
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+    }
+
+    @Test
+    @DisplayName("inbox blocked action uses route history and opens blocked route")
+    void inbox_blockedActionUsesRouteHistoryAndOpensBlockedRoute() {
+        when(privateMessageService.countInbox(session.data.uuid)).thenReturn(0L);
+        when(privateMessageService.countUnread(session.data.uuid)).thenReturn(0L);
+        when(privateMessageService.listBlocked(session)).thenReturn(List.of());
+
+        messageMenu.inbox("viewer-1", 1);
+        menuService.onMenuOption(session, 1);
+
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.hasRouteHistory()).isTrue();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+    }
+
+    @Test
+    @DisplayName("inbox message selection uses route history and opens details")
+    void inbox_messageSelectionUsesRouteHistoryAndOpensDetails() {
+        when(privateMessageService.countInbox(session.data.uuid)).thenReturn(1L);
+        when(privateMessageService.countUnread(session.data.uuid)).thenReturn(1L);
+        when(privateMessageService.inbox(session.data.uuid, 1)).thenReturn(List.of(message));
+
+        messageMenu.inbox("viewer-1", 1);
+        menuService.onMenuOption(session, 0);
+
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.hasRouteHistory()).isTrue();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+    }
+
+    @Test
+    @DisplayName("details not found renders routed fallback screen when opened from routed inbox")
+    void details_notFoundRendersRoutedFallbackScreenWhenOpenedFromRoutedInbox() {
+        ObjectId missingId = new ObjectId();
+        when(privateMessageService.countInbox(session.data.uuid)).thenReturn(1L);
+        when(privateMessageService.countUnread(session.data.uuid)).thenReturn(1L);
+        when(privateMessageService.inbox(session.data.uuid, 1)).thenReturn(List.of(message));
+        when(privateMessageService.getMessage(missingId, session.data.uuid)).thenReturn(null);
+
+        message.id = missingId;
+        messageMenu.inbox("viewer-1", 1);
+        menuService.onMenuOption(session, 0);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.hasRouteHistory()).isTrue();
+    }
+
+    @Test
     @DisplayName("reply opens active prompt through menu service")
     void reply_opensActivePromptThroughMenuService() {
         messageMenu.details("viewer-1", message.id, 1);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
         menuService.onMenuOption(session, 0);
 
         assertThat(session.activePrompt()).isNotNull();
         assertThat(session.textHandler).isNull();
         verify(gateway).textInput(eq(session.player), eq(0), eq("private-message-reply-title"), eq("private-message-reply-message"), eq(300), eq(""), eq(false));
+    }
+
+    @Test
+    @DisplayName("details delete returns through route history when opened from routed inbox")
+    void details_deleteReturnsThroughRouteHistoryWhenOpenedFromRoutedInbox() {
+        when(privateMessageService.countInbox(session.data.uuid)).thenReturn(1L);
+        when(privateMessageService.countUnread(session.data.uuid)).thenReturn(1L);
+        when(privateMessageService.inbox(session.data.uuid, 1)).thenReturn(List.of(message));
+
+        messageMenu.inbox("viewer-1", 1);
+        menuService.onMenuOption(session, 0);
+        menuService.onMenuOption(session, 1);
+
+        verify(privateMessageService).softDelete(message.id, session.data.uuid);
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
     }
 
     @Test
@@ -112,6 +197,8 @@ class MessageMenuTest {
     @Test
     @DisplayName("compose opens target prompt then body prompt")
     void compose_opensTargetPromptThenBodyPrompt() {
+        when(privateMessageService.countInbox(session.data.uuid)).thenReturn(0L);
+        when(privateMessageService.countUnread(session.data.uuid)).thenReturn(0L);
         messageMenu.inbox("viewer-1", 1);
         menuService.onMenuOption(session, 0);
 
@@ -128,6 +215,8 @@ class MessageMenuTest {
     @Test
     @DisplayName("compose body submit sends message and returns")
     void composeBodySubmit_sendsMessageAndReturns() {
+        when(privateMessageService.countInbox(session.data.uuid)).thenReturn(0L);
+        when(privateMessageService.countUnread(session.data.uuid)).thenReturn(0L);
         messageMenu.inbox("viewer-1", 1);
         menuService.onMenuOption(session, 0);
         when(privateMessageService.parseMenuPid("#55")).thenReturn(55);
@@ -143,6 +232,8 @@ class MessageMenuTest {
     @Test
     @DisplayName("compose target cancel returns without opening stale handler")
     void composeTargetCancel_returnsWithoutOpeningStaleHandler() {
+        when(privateMessageService.countInbox(session.data.uuid)).thenReturn(0L);
+        when(privateMessageService.countUnread(session.data.uuid)).thenReturn(0L);
         messageMenu.inbox("viewer-1", 1);
         menuService.onMenuOption(session, 0);
 
@@ -158,6 +249,8 @@ class MessageMenuTest {
     @Test
     @DisplayName("compose invalid target returns without leaving stale prompt")
     void composeInvalidTarget_returnsWithoutLeavingStalePrompt() {
+        when(privateMessageService.countInbox(session.data.uuid)).thenReturn(0L);
+        when(privateMessageService.countUnread(session.data.uuid)).thenReturn(0L);
         messageMenu.inbox("viewer-1", 1);
         menuService.onMenuOption(session, 0);
         when(privateMessageService.parseMenuPid("bad")).thenReturn(null);

--- a/src/test/java/org/xcore/plugin/ui/flow/ActiveMenuPromptTest.java
+++ b/src/test/java/org/xcore/plugin/ui/flow/ActiveMenuPromptTest.java
@@ -2,6 +2,7 @@ package org.xcore.plugin.ui.flow;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.xcore.plugin.ui.route.MenuRoute;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -46,5 +47,15 @@ class ActiveMenuPromptTest {
         ActiveMenuPrompt prompt = ActiveMenuPrompt.create(1L, 42, null, null);
 
         prompt.cancel(); // should not throw
+    }
+
+    @Test
+    @DisplayName("flow prompt stores route metadata")
+    void flowPrompt_storesRouteMetadata() {
+        MenuRoute route = MenuRoute.of("player.profile").withParam("targetUuid", "uuid-9");
+        ActiveMenuPrompt prompt = ActiveMenuPrompt.create(1L, 42, null, null, null, null, "prompt", route);
+
+        assertThat(prompt.hasRoute()).isTrue();
+        assertThat(prompt.route()).isEqualTo(route);
     }
 }

--- a/src/test/java/org/xcore/plugin/ui/flow/ActiveMenuScreenTest.java
+++ b/src/test/java/org/xcore/plugin/ui/flow/ActiveMenuScreenTest.java
@@ -2,6 +2,7 @@ package org.xcore.plugin.ui.flow;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.xcore.plugin.ui.route.MenuRoute;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -63,5 +64,24 @@ class ActiveMenuScreenTest {
         assertThat(screen.actionCount()).isEqualTo(1);
         original.clear();
         assertThat(screen.actionCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("create stores route metadata for routed flow screens")
+    void create_storesRouteMetadataForRoutedFlowScreens() {
+        MenuRoute route = MenuRoute.of("player.profile").withParam("targetUuid", "uuid-7");
+
+        ActiveMenuScreen screen = ActiveMenuScreen.create(
+                1L,
+                MenuMode.NORMAL,
+                List.of(),
+                null,
+                null,
+                List.of(),
+                route
+        );
+
+        assertThat(screen.hasRoute()).isTrue();
+        assertThat(screen.route()).isEqualTo(route);
     }
 }

--- a/src/test/java/org/xcore/plugin/ui/menu/MapMenuTest.java
+++ b/src/test/java/org/xcore/plugin/ui/menu/MapMenuTest.java
@@ -1,0 +1,322 @@
+package org.xcore.plugin.ui;
+
+import arc.files.Fi;
+import arc.struct.Seq;
+import arc.struct.StringMap;
+import com.ospx.flubundle.Bundle;
+import jakarta.inject.Provider;
+import mindustry.core.GameState;
+import mindustry.game.Gamemode;
+import mindustry.gen.Player;
+import mindustry.maps.Map;
+import mindustry.net.NetConnection;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.xcore.plugin.config.Config;
+import org.xcore.plugin.config.GlobalConfig;
+import org.xcore.plugin.database.repository.EventDataRepository;
+import org.xcore.plugin.database.repository.MapDataRepository;
+import org.xcore.plugin.localization.Localization;
+import org.xcore.plugin.model.MapData;
+import org.xcore.plugin.model.PlayerData;
+import org.xcore.plugin.service.MapService;
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.MenuService;
+import org.xcore.plugin.ui.MindustryMenuGateway;
+import org.xcore.plugin.ui.flow.MenuMode;
+import org.xcore.plugin.ui.menu.EventMenu;
+import org.xcore.plugin.ui.menu.MapMenu;
+import org.xcore.plugin.ui.route.MenuRoute;
+import org.xcore.plugin.service.EventEditorService;
+import org.xcore.plugin.service.EventService;
+import org.xcore.plugin.service.EventViewService;
+import org.xcore.plugin.vote.VoteService;
+
+import java.util.Locale;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class MapMenuTest {
+
+    private SessionService sessionService;
+    private MapDataRepository mapDataRepository;
+    private EventDataRepository eventDataRepository;
+    private MapService mapService;
+    private MindustryMenuGateway gateway;
+    private MenuService menuService;
+    private MapMenu mapMenu;
+    private Session session;
+    private GlobalConfig globalConfig;
+    private GameState originalState;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        sessionService = mock(SessionService.class);
+        mapDataRepository = mock(MapDataRepository.class);
+        eventDataRepository = mock(EventDataRepository.class);
+        mapService = mock(MapService.class);
+        gateway = mock(MindustryMenuGateway.class);
+
+        Provider<SessionService> sessionProvider = mock(Provider.class);
+        when(sessionProvider.get()).thenReturn(sessionService);
+        menuService = new MenuService(sessionProvider, gateway);
+
+        Config config = new Config();
+        globalConfig = new GlobalConfig();
+        globalConfig.mapsPerPage = 2;
+
+        Provider<EventMenu> eventMenu = mock(Provider.class);
+
+        mapMenu = new MapMenu(config, globalConfig, sessionService,
+                mapDataRepository, eventDataRepository, mapService, eventMenu, menuService);
+        mapMenu.init();
+
+        originalState = mindustry.Vars.state;
+        mindustry.Vars.state = new GameState();
+        mindustry.game.Rules rules = mock(mindustry.game.Rules.class);
+        when(rules.mode()).thenReturn(Gamemode.pvp);
+        mindustry.Vars.state.rules = rules;
+
+        session = session();
+        when(sessionService.get("viewer-1")).thenReturn(session);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mindustry.Vars.state = originalState;
+    }
+
+    @Test
+    @DisplayName("maps renders routed screen with route metadata")
+    void maps_rendersRoutedScreenWithRouteMetadata() {
+        when(mapService.getAvailableMaps()).thenReturn(Seq.with(
+                createMap("Map1"), createMap("Map2")
+        ));
+
+        mapMenu.maps("viewer-1", 1);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("map.maps");
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.NORMAL);
+        verify(gateway).menu(eq(session.player), eq(0), eq("commands-maps-title"), any(), any());
+    }
+
+    @Test
+    @DisplayName("maps pagination next and previous transitions pages")
+    void maps_pagination_nextAndPreviousTransitionsPages() {
+        when(mapService.getAvailableMaps()).thenReturn(Seq.with(
+                createMap("Map1"), createMap("Map2"), createMap("Map3")
+        ));
+
+        mapMenu.maps("viewer-1", 1);
+
+        assertThat(session.activeScreen().route().intParam("page", 0)).isEqualTo(1);
+
+        menuService.onMenuOption(session, 0); // next
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().route().intParam("page", 0)).isEqualTo(2);
+        verify(gateway, times(2)).menu(eq(session.player), eq(0), eq("commands-maps-title"), any(), any());
+
+        menuService.onMenuOption(session, 0); // previous
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().route().intParam("page", 0)).isEqualTo(1);
+        verify(gateway, times(3)).menu(eq(session.player), eq(0), eq("commands-maps-title"), any(), any());
+    }
+
+    @Test
+    @DisplayName("maps selecting a map opens legacy map detail and pushes history")
+    void maps_selectingMap_opensRoutedMapDetailViaRouteHistory() {
+        when(mapService.getAvailableMaps()).thenReturn(Seq.with(createMap("Map1")));
+        MapData mapData = new MapData("Map1", "Map1.msav", "author", "pvp");
+        mapData.id = new org.bson.types.ObjectId();
+        when(mapDataRepository.findOrCreate(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(mapData);
+        when(mapDataRepository.findById(mapData.id)).thenReturn(mapData);
+        when(mapService.findPersistedMap(any())).thenReturn(null);
+
+        mapMenu.maps("viewer-1", 1);
+
+        menuService.onMenuOption(session, 0); // select map
+
+        verify(mapDataRepository).findOrCreate(anyString(), anyString(), anyString(), anyString());
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.hasRouteHistory()).isTrue();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(
+                MenuRoute.of("map.details").withParam("mapId", mapData.id.toHexString())
+        );
+    }
+
+    @Test
+    @DisplayName("map renders routed screen with route metadata")
+    void map_rendersRoutedScreenWithRouteMetadata() {
+        MapData mapData = new MapData("Map1", "Map1.msav", "author", "pvp");
+        mapData.id = new org.bson.types.ObjectId();
+        when(mapDataRepository.findById(mapData.id)).thenReturn(mapData);
+        when(mapService.findPersistedMap(any())).thenReturn(null);
+
+        mapMenu.map("viewer-1", mapData);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(
+                MenuRoute.of("map.details").withParam("mapId", mapData.id.toHexString())
+        );
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.NORMAL);
+        verify(gateway).menu(eq(session.player), eq(0), eq("commands-map-title"), eq("commands-map-content"), any());
+    }
+
+    @Test
+    @DisplayName("map maps action opens routed maps via route history")
+    void map_mapsAction_opensRoutedMapsViaRouteHistory() {
+        MapData mapData = new MapData("Map1", "Map1.msav", "author", "pvp");
+        mapData.id = new org.bson.types.ObjectId();
+        when(mapDataRepository.findById(mapData.id)).thenReturn(mapData);
+        when(mapService.findPersistedMap(any())).thenReturn(null);
+        when(mapService.getAvailableMaps()).thenReturn(Seq.with(createMap("Map1")));
+
+        mapMenu.map("viewer-1", mapData);
+
+        menuService.onMenuOption(session, 3); // maps
+
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.hasRouteHistory()).isTrue();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().route()).isEqualTo(MenuRoute.of("map.maps").withParam("page", "1"));
+    }
+
+    @Test
+    @DisplayName("map create start action opens prompt without adding legacy history")
+    @SuppressWarnings("unchecked")
+    void map_createStartAction_opensPromptWithoutAddingLegacyHistory() {
+        Config eventConfig = new Config();
+        eventConfig.server = "event";
+
+        SessionService localSessionService = mock(SessionService.class);
+        MindustryMenuGateway localGateway = mock(MindustryMenuGateway.class);
+        Provider<SessionService> localSessionProvider = mock(Provider.class);
+        when(localSessionProvider.get()).thenReturn(localSessionService);
+        MenuService localMenuService = new MenuService(localSessionProvider, localGateway);
+
+        Session eventSession = session(eventConfig, localMenuService);
+        when(localSessionService.get("viewer-1")).thenReturn(eventSession);
+
+        EventService eventService = mock(EventService.class);
+        VoteService voteService = mock(VoteService.class);
+        EventEditorService eventEditorService = new EventEditorService(eventDataRepository, mapDataRepository,
+                mock(org.xcore.plugin.database.repository.PlayerDataRepository.class));
+        EventViewService eventViewService = new EventViewService(eventDataRepository, mapDataRepository,
+                mock(org.xcore.plugin.database.repository.PlayerDataRepository.class));
+
+        Provider<MapMenu> localMapProvider = mock(Provider.class);
+        EventMenu realEventMenu = new EventMenu(eventConfig, globalConfig, localSessionService,
+                mapService, eventService, eventEditorService, eventViewService, voteService, localMapProvider, localMenuService);
+        realEventMenu.init();
+
+        Provider<EventMenu> eventMenuProvider = mock(Provider.class);
+        when(eventMenuProvider.get()).thenReturn(realEventMenu);
+        MapMenu eventMapMenu = new MapMenu(eventConfig, globalConfig, localSessionService,
+                mapDataRepository, eventDataRepository, mapService, eventMenuProvider, localMenuService);
+        eventMapMenu.init();
+        when(localMapProvider.get()).thenReturn(eventMapMenu);
+
+        MapData mapData = new MapData("Map1", "Map1.msav", "author", "pvp");
+        mapData.id = new org.bson.types.ObjectId();
+        when(mapDataRepository.findById(mapData.id)).thenReturn(mapData);
+        when(mapService.findPersistedMap(any())).thenReturn(null);
+        when(eventDataRepository.findActive()).thenReturn(Optional.empty());
+
+        eventMapMenu.map("viewer-1", mapData);
+
+        localMenuService.onMenuOption(eventSession, 4);
+
+        assertThat(eventSession.hasHistory()).isFalse();
+        assertThat(eventSession.activePrompt()).isNotNull();
+        assertThat(eventSession.textHandler).isNull();
+        verify(localGateway).textInput(eq(eventSession.player), eq(0), eq("event-menu-create-start-title"), eq("event-menu-create-start-message"), eq(20), anyString(), eq(false));
+    }
+
+    @Test
+    @DisplayName("maps empty sends empty message and does not render menu")
+    void maps_empty_sendsEmptyMessage() {
+        when(mapService.getAvailableMaps()).thenReturn(Seq.with());
+
+        mapMenu.maps("viewer-1", 1);
+
+        assertThat(session.activeScreen()).isNull();
+        verify(gateway, never()).menu(any(), anyInt(), anyString(), anyString(), any());
+    }
+
+    @Test
+    @DisplayName("maps back action returns to previous menu")
+    void maps_backAction_returnsToPreviousMenu() {
+        when(mapService.getAvailableMaps()).thenReturn(Seq.with(createMap("Map1")));
+
+        final boolean[] ran = {false};
+        session.pushHistory(() -> ran[0] = true);
+
+        mapMenu.maps("viewer-1", 1);
+
+        menuService.onMenuOption(session, 1); // back (after map row)
+
+        assertThat(ran[0]).isTrue();
+    }
+
+    @Test
+    @DisplayName("maps close action clears active screen")
+    void maps_closeAction_clearsActiveScreen() {
+        when(mapService.getAvailableMaps()).thenReturn(Seq.with(createMap("Map1")));
+
+        mapMenu.maps("viewer-1", 1);
+
+        menuService.onMenuOption(session, 1); // close
+
+        assertThat(session.activeScreen()).isNull();
+    }
+
+    private Map createMap(String name) {
+        return new Map(
+                new Fi(name + ".msav"),
+                100,
+                100,
+                StringMap.of("name", name, "author", "author"),
+                true
+        );
+    }
+
+    private Session session() {
+        return session(new Config(), menuService);
+    }
+
+    private Session session(Config config, MenuService menuService) {
+        Player player = Player.create();
+        player.con = mock(NetConnection.class);
+        PlayerData data = new PlayerData("viewer-1", true);
+        data.uuid = "viewer-1";
+        Session session = new Session(
+                globalConfig,
+                mock(Bundle.class),
+                menuService,
+                mock(org.xcore.plugin.database.repository.PlayerDataRepository.class),
+                player,
+                data
+        );
+        Localization localization = mock(Localization.class);
+        when(localization.t(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.t(anyString(), anyMap())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.getLocale()).thenReturn(Locale.US);
+        session.localization = localization;
+        return session;
+    }
+}

--- a/src/test/java/org/xcore/plugin/ui/menu/PlayerMenuTest.java
+++ b/src/test/java/org/xcore/plugin/ui/menu/PlayerMenuTest.java
@@ -1,5 +1,6 @@
 package org.xcore.plugin.ui;
 
+import arc.struct.Seq;
 import com.ospx.flubundle.Bundle;
 import jakarta.inject.Provider;
 import mindustry.gen.Player;
@@ -13,11 +14,14 @@ import org.xcore.plugin.database.repository.GameDataRepository;
 import org.xcore.plugin.database.repository.PlayerDataRepository;
 import org.xcore.plugin.localization.Localization;
 import org.xcore.plugin.model.AggregatedPlayerStats;
+import org.xcore.plugin.model.AuditRecordSummary;
 import org.xcore.plugin.model.ModeStatsSummary;
 import org.xcore.plugin.model.PlayerData;
 import org.xcore.plugin.model.PlayerStatsOverview;
+import org.xcore.plugin.model.Slice;
 import org.xcore.plugin.service.PlayerDisplayService;
 import org.xcore.plugin.service.PlayerProfileSettingsService;
+import org.xcore.plugin.service.moderation.AuditService;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
 import org.xcore.plugin.ui.MenuService;
@@ -26,15 +30,20 @@ import org.xcore.plugin.ui.menu.AuditHistoryMenu;
 import org.xcore.plugin.ui.menu.PlayerMenu;
 
 import java.util.Locale;
+import java.util.stream.Stream;
+
+import org.xcore.plugin.common.StatusEnum;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -44,12 +53,15 @@ class PlayerMenuTest {
     private GameDataRepository gameDataRepository;
     private PlayerDisplayService playerDisplayService;
     private PlayerProfileSettingsService profileSettings;
+    private AuditService auditService;
     private AuditHistoryMenu auditHistoryMenu;
     private MindustryMenuGateway gateway;
     private MenuService menuService;
     private PlayerMenu playerMenu;
     private Session session;
     private PlayerData targetData;
+    private PlayerDataRepository playerDataRepository;
+    private Bundle bundle;
 
     @BeforeEach
     @SuppressWarnings("unchecked")
@@ -58,7 +70,7 @@ class PlayerMenuTest {
         gameDataRepository = mock(GameDataRepository.class);
         playerDisplayService = mock(PlayerDisplayService.class);
         profileSettings = mock(PlayerProfileSettingsService.class);
-        auditHistoryMenu = mock(AuditHistoryMenu.class);
+        auditService = mock(AuditService.class);
         gateway = mock(MindustryMenuGateway.class);
 
         Provider<SessionService> sessionProvider = mock(Provider.class);
@@ -68,16 +80,31 @@ class PlayerMenuTest {
         Config config = new Config();
         config.server = "mini-pvp";
         GlobalConfig globalConfig = new GlobalConfig();
+        globalConfig.eventsPerPage = 2;
+
+        bundle = mock(Bundle.class);
+        when(bundle.getAvailableLocales()).thenReturn(new Seq<>());
+
+        playerDataRepository = mock(PlayerDataRepository.class);
+        auditHistoryMenu = new AuditHistoryMenu(config, globalConfig, sessionService, auditService, menuService);
+        auditHistoryMenu.init();
+        when(playerDisplayService.resolveBaseName(any(), any())).thenAnswer(invocation -> {
+            PlayerData data = invocation.getArgument(0);
+            return data.nickname;
+        });
 
         playerMenu = new PlayerMenu(
                 config, globalConfig, sessionService,
                 gameDataRepository,
-                mock(Bundle.class),
+                bundle,
                 playerDisplayService, profileSettings,
-                auditHistoryMenu);
+                auditHistoryMenu,
+                menuService);
+        playerMenu.init();
 
         session = session();
         targetData = session.data;
+        when(playerDataRepository.findByUuid(targetData.uuid)).thenReturn(targetData);
 
         when(sessionService.get("viewer-1")).thenReturn(session);
         when(gameDataRepository.aggregatePlayerStatsOverview(anyString()))
@@ -86,8 +113,66 @@ class PlayerMenuTest {
                         ModeStatsSummary.EMPTY,
                         ModeStatsSummary.EMPTY,
                         ModeStatsSummary.EMPTY));
+        when(auditService.findSummaryByTargetUuid(anyString(), any(), anyInt()))
+                .thenReturn(new Slice<AuditRecordSummary>(java.util.List.of(), false, null));
         when(profileSettings.validateCustomNickname(anyString()))
                 .thenReturn(PlayerProfileSettingsService.NicknameValidationResult.ok());
+    }
+
+    @Test
+    @DisplayName("player renders routed screen with route metadata")
+    void player_rendersRoutedScreenWithRouteMetadata() {
+        playerMenu.player("viewer-1", targetData);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.profile");
+        verify(gateway).menu(eq(session.player), eq(0), eq("player-menu-player-title"), any(), any());
+    }
+
+    @Test
+    @DisplayName("player settings navigation opens routed settings via route history")
+    void player_settingsNavigation_opensRoutedSettingsViaRouteHistory() {
+        playerMenu.player("viewer-1", targetData);
+
+        menuService.onMenuOption(session, 0);
+
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.hasRouteHistory()).isTrue();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.settings");
+    }
+
+    @Test
+    @DisplayName("player players navigation opens routed players via route history")
+    void player_playersNavigation_opensRoutedPlayersViaRouteHistory() {
+        playerMenu.player("viewer-1", targetData);
+
+        menuService.onMenuOption(session, 1);
+
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.hasRouteHistory()).isTrue();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.players");
+    }
+
+    @Test
+    @DisplayName("player admin audit navigation opens routed audit history via route history")
+    void player_adminAuditNavigation_opensRoutedAuditHistoryViaRouteHistory() {
+        session.player.admin = true;
+        targetData.admin = true;
+
+        playerMenu.player("viewer-1", targetData);
+
+        menuService.onMenuOption(session, 1);
+
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.hasRouteHistory()).isTrue();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("audit.history");
     }
 
     @Test
@@ -182,12 +267,403 @@ class PlayerMenuTest {
         assertThat(session.activePrompt()).isNull();
     }
 
+    @Test
+    @DisplayName("settings renders routed screen with route metadata")
+    void settings_rendersRoutedScreenWithRouteMetadata() {
+        playerMenu.settings("viewer-1", targetData);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.settings");
+        verify(gateway).menu(eq(session.player), eq(0), eq("player-menu-settings-title"), any(), any());
+    }
+
+    @Test
+    @DisplayName("settings leaderboard toggle updates service and re-renders")
+    void settings_leaderboardToggle_updatesServiceAndRerenders() {
+        playerMenu.settings("viewer-1", targetData);
+
+        menuService.onMenuOption(session, 5);
+
+        verify(profileSettings).updateLeaderboard(targetData, false);
+        verify(gateway, times(2)).menu(eq(session.player), eq(0), eq("player-menu-settings-title"), any(), any());
+    }
+
+    @Test
+    @DisplayName("settings chat settings navigation opens routed child via route history")
+    void settings_chatSettingsNavigation_opensRoutedChildViaRouteHistory() {
+        playerMenu.settings("viewer-1", targetData);
+
+        menuService.onMenuOption(session, 3);
+
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.hasRouteHistory()).isTrue();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.chat-settings");
+    }
+
+    @Test
+    @DisplayName("settings badges navigation opens routed child via route history")
+    void settings_badgesNavigation_opensRoutedChildViaRouteHistory() {
+        playerMenu.settings("viewer-1", targetData);
+
+        menuService.onMenuOption(session, 4);
+
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.hasRouteHistory()).isTrue();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.badges");
+    }
+
+    @Test
+    @DisplayName("settings language selection opens routed language selection")
+    void settings_languageSelection_opensRoutedLanguageSelection() {
+        playerMenu.settings("viewer-1", targetData);
+
+        menuService.onMenuOption(session, 6);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.language-selection");
+        verify(gateway).menu(eq(session.player), eq(0), eq("player-menu-settings-language-title"), any(), any());
+    }
+
+    @Test
+    @DisplayName("settings denies access for non-admin viewing another player")
+    void settings_accessDenied_forNonAdminViewingAnotherPlayer() {
+        PlayerData otherData = new PlayerData("other-1", true);
+        otherData.uuid = "other-1";
+
+        playerMenu.settings("viewer-1", otherData);
+
+        verify(gateway, never()).menu(any(), anyInt(), anyString(), anyString(), any());
+        assertThat(session.activeScreen()).isNull();
+    }
+
+    @Test
+    @DisplayName("chatSettings renders routed screen with route metadata")
+    void chatSettings_rendersRoutedScreenWithRouteMetadata() {
+        playerMenu.chatSettings("viewer-1", targetData);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.chat-settings");
+        verify(gateway).menu(eq(session.player), eq(0), eq("player-menu-settings-chat-title"), any(), any());
+    }
+
+    @Test
+    @DisplayName("chatSettings toggle global chat updates service and re-renders")
+    void chatSettings_toggleGlobalChat_updatesServiceAndRerenders() {
+        playerMenu.chatSettings("viewer-1", targetData);
+
+        menuService.onMenuOption(session, 0);
+
+        verify(profileSettings).updateGlobalChatVisible(targetData, false);
+        verify(gateway, times(2)).menu(eq(session.player), eq(0), eq("player-menu-settings-chat-title"), any(), any());
+    }
+
+    @Test
+    @DisplayName("chatSettings toggle discord relay updates service and re-renders")
+    void chatSettings_toggleDiscordRelay_updatesServiceAndRerenders() {
+        playerMenu.chatSettings("viewer-1", targetData);
+
+        menuService.onMenuOption(session, 1);
+
+        verify(profileSettings).updateDiscordRelayVisible(targetData, false);
+        verify(gateway, times(2)).menu(eq(session.player), eq(0), eq("player-menu-settings-chat-title"), any(), any());
+    }
+
+    @Test
+    @DisplayName("chatSettings translator language action opens routed language selection")
+    void chatSettings_translatorLanguage_opensRoutedLanguageSelection() {
+        playerMenu.chatSettings("viewer-1", targetData);
+
+        menuService.onMenuOption(session, 2);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.language-selection");
+        verify(gateway).menu(eq(session.player), eq(0), eq("player-menu-settings-translator-title"), any(), any());
+    }
+
+    @Test
+    @DisplayName("language selection renders routed screen for interface language")
+    void languageSelection_interfaceLanguage_rendersRoutedScreen() {
+        playerMenu.languageSelectionMenu("viewer-1", targetData, false);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.language-selection");
+        verify(gateway).menu(eq(session.player), eq(0), eq("player-menu-settings-language-title"), any(), any());
+    }
+
+    @Test
+    @DisplayName("language selection renders routed screen for translator language")
+    void languageSelection_translatorLanguage_rendersRoutedScreen() {
+        playerMenu.languageSelectionMenu("viewer-1", targetData, true);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.language-selection");
+        verify(gateway).menu(eq(session.player), eq(0), eq("player-menu-settings-translator-title"), any(), any());
+    }
+
+    @Test
+    @DisplayName("language selection auto option updates language and returns to settings")
+    void languageSelection_auto_updatesLanguageAndReturnsToSettings() {
+        playerMenu.settings("viewer-1", targetData);
+
+        menuService.onMenuOption(session, 6); // open language selection from settings
+
+        menuService.onMenuOption(session, 0); // select auto
+
+        verify(profileSettings).updateLanguage(targetData, "auto");
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.settings");
+    }
+
+    @Test
+    @DisplayName("language selection default option updates translator language and returns to chat settings")
+    void languageSelection_default_updatesTranslatorLanguageAndReturnsToChatSettings() {
+        playerMenu.chatSettings("viewer-1", targetData);
+
+        menuService.onMenuOption(session, 2); // open language selection from chat settings
+
+        menuService.onMenuOption(session, 0); // select default
+
+        verify(profileSettings).updateTranslatorLanguage(targetData, "off");
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.chat-settings");
+    }
+
+    @Test
+    @DisplayName("language selection locale option updates language and returns to parent")
+    void languageSelection_locale_updatesLanguageAndReturnsToParent() {
+        when(bundle.getAvailableLocales()).thenReturn(Seq.with(Locale.ENGLISH));
+
+        playerMenu.settings("viewer-1", targetData);
+
+        menuService.onMenuOption(session, 6); // open language selection from settings
+        // Row 0: auto
+        // Row 1: English
+        // Row 2: back, close
+        menuService.onMenuOption(session, 1); // select English
+
+        verify(profileSettings).updateLanguage(targetData, "en");
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.settings");
+    }
+
+    @Test
+    @DisplayName("language selection maps uk locale to uk_UA code")
+    void languageSelection_ukLocale_mapsToUkUa() {
+        Locale ukLocale = new Locale("uk");
+        when(bundle.getAvailableLocales()).thenReturn(Seq.with(ukLocale));
+
+        playerMenu.settings("viewer-1", targetData);
+
+        menuService.onMenuOption(session, 6); // open language selection from settings
+        menuService.onMenuOption(session, 1); // select Ukrainian
+
+        verify(profileSettings).updateLanguage(targetData, "uk_UA");
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.settings");
+    }
+
+    @Test
+    @DisplayName("chatSettings denies access for non-admin viewing another player")
+    void chatSettings_accessDenied_forNonAdminViewingAnotherPlayer() {
+        PlayerData otherData = new PlayerData("other-1", true);
+        otherData.uuid = "other-1";
+
+        playerMenu.chatSettings("viewer-1", otherData);
+
+        verify(gateway, never()).menu(any(), anyInt(), anyString(), anyString(), any());
+        assertThat(session.activeScreen()).isNull();
+    }
+
+    @Test
+    @DisplayName("badgeSymbolColorMode renders routed screen with route metadata")
+    void badgeSymbolColorMode_rendersRoutedScreenWithRouteMetadata() {
+        playerMenu.badgeSymbolColorMode("viewer-1", targetData);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.badge-symbol-color");
+        verify(gateway).menu(eq(session.player), eq(0), eq("badge-menu-symbol-color-title"), any(), any());
+    }
+
+    @Test
+    @DisplayName("badgeSymbolColorMode selecting default mode updates service and re-renders")
+    void badgeSymbolColorMode_selectDefaultMode_updatesServiceAndRerenders() {
+        playerMenu.badgeSymbolColorMode("viewer-1", targetData);
+
+        menuService.onMenuOption(session, 0);
+
+        verify(profileSettings).updateBadgeSymbolColorMode(targetData, "default", true, true);
+        verify(gateway, times(2)).menu(eq(session.player), eq(0), eq("badge-menu-symbol-color-title"), any(), any());
+    }
+
+    @Test
+    @DisplayName("badgeSymbolColorMode selecting player-color mode updates service and re-renders")
+    void badgeSymbolColorMode_selectPlayerColorMode_updatesServiceAndRerenders() {
+        playerMenu.badgeSymbolColorMode("viewer-1", targetData);
+
+        menuService.onMenuOption(session, 1);
+
+        verify(profileSettings).updateBadgeSymbolColorMode(targetData, "player-color", true, true);
+        verify(gateway, times(2)).menu(eq(session.player), eq(0), eq("badge-menu-symbol-color-title"), any(), any());
+    }
+
+    @Test
+    @DisplayName("badgeSymbolColorMode denies access for non-admin viewing another player")
+    void badgeSymbolColorMode_accessDenied_forNonAdminViewingAnotherPlayer() {
+        PlayerData otherData = new PlayerData("other-1", true);
+        otherData.uuid = "other-1";
+
+        playerMenu.badgeSymbolColorMode("viewer-1", otherData);
+
+        verify(gateway, never()).menu(any(), anyInt(), anyString(), anyString(), any());
+        assertThat(session.activeScreen()).isNull();
+    }
+
+    @Test
+    @DisplayName("badges renders routed screen with route metadata")
+    void badges_rendersRoutedScreenWithRouteMetadata() {
+        playerMenu.badges("viewer-1", targetData);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.badges");
+        verify(gateway).menu(eq(session.player), eq(0), eq("badge-menu-title"), any(), any());
+    }
+
+    @Test
+    @DisplayName("badges selecting unlocked badge updates service and re-renders")
+    void badges_selectingUnlockedBadge_updatesServiceAndRerenders() {
+        targetData.unlockedBadges.add("developer");
+
+        playerMenu.badges("viewer-1", targetData);
+
+        menuService.onMenuOption(session, 0);
+
+        verify(profileSettings).updateActiveBadge(targetData, "developer", true, true);
+        verify(gateway, times(2)).menu(eq(session.player), eq(0), eq("badge-menu-title"), any(), any());
+    }
+
+    @Test
+    @DisplayName("badges symbol color button opens routed symbol color mode via route history")
+    void badges_symbolColorButton_opensRoutedSymbolColorModeViaRouteHistory() {
+        playerMenu.badges("viewer-1", targetData);
+
+        menuService.onMenuOption(session, 0);
+
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.hasRouteHistory()).isTrue();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.badge-symbol-color");
+    }
+
+    @Test
+    @DisplayName("badges view all button opens routed all badges via route history")
+    void badges_viewAllButton_opensRoutedAllBadgesViaRouteHistory() {
+        playerMenu.badges("viewer-1", targetData);
+
+        menuService.onMenuOption(session, 1);
+
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.hasRouteHistory()).isTrue();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.all-badges");
+    }
+
+    @Test
+    @DisplayName("badges clear button clears active badge and re-renders")
+    void badges_clearButton_clearsActiveBadgeAndRerenders() {
+        targetData.activeBadge = "developer";
+
+        playerMenu.badges("viewer-1", targetData);
+
+        menuService.onMenuOption(session, 2);
+
+        verify(profileSettings).updateActiveBadge(targetData, "", true, true);
+        verify(gateway, times(2)).menu(eq(session.player), eq(0), eq("badge-menu-title"), any(), any());
+    }
+
+    @Test
+    @DisplayName("badges denies access for non-admin viewing another player")
+    void badges_accessDenied_forNonAdminViewingAnotherPlayer() {
+        PlayerData otherData = new PlayerData("other-1", true);
+        otherData.uuid = "other-1";
+
+        playerMenu.badges("viewer-1", otherData);
+
+        verify(gateway, never()).menu(any(), anyInt(), anyString(), anyString(), any());
+        assertThat(session.activeScreen()).isNull();
+    }
+
+    @Test
+    @DisplayName("allBadges renders routed screen with route metadata")
+    void allBadges_rendersRoutedScreenWithRouteMetadata() {
+        playerMenu.allBadges("viewer-1", targetData);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.all-badges");
+        verify(gateway).menu(eq(session.player), eq(0), eq("badge-menu-all-title"), any(), any());
+    }
+
+    @Test
+    @DisplayName("allBadges selecting owned selectable badge updates service and re-renders")
+    void allBadges_selectingOwnedSelectableBadge_updatesServiceAndRerenders() {
+        targetData.unlockedBadges.add("developer");
+
+        playerMenu.allBadges("viewer-1", targetData);
+
+        menuService.onMenuOption(session, 1); // DEVELOPER
+
+        verify(profileSettings).updateActiveBadge(targetData, "developer", true, true);
+        verify(gateway, times(2)).menu(eq(session.player), eq(0), eq("badge-menu-all-title"), any(), any());
+    }
+
+    @Test
+    @DisplayName("allBadges selecting locked or system badge does not update service and re-renders")
+    void allBadges_selectingLockedOrSystemBadge_doesNotUpdateServiceAndRerenders() {
+        playerMenu.allBadges("viewer-1", targetData);
+
+        menuService.onMenuOption(session, 0); // ADMIN (system)
+
+        verify(profileSettings, never()).updateActiveBadge(any(), anyString(), anyBoolean(), anyBoolean());
+        verify(gateway, times(2)).menu(eq(session.player), eq(0), eq("badge-menu-all-title"), any(), any());
+    }
+
+    @Test
+    @DisplayName("allBadges denies access for non-admin viewing another player")
+    void allBadges_accessDenied_forNonAdminViewingAnotherPlayer() {
+        PlayerData otherData = new PlayerData("other-1", true);
+        otherData.uuid = "other-1";
+
+        playerMenu.allBadges("viewer-1", otherData);
+
+        verify(gateway, never()).menu(any(), anyInt(), anyString(), anyString(), any());
+        assertThat(session.activeScreen()).isNull();
+    }
+
     private Session session() {
         Player player = Player.create();
         player.con = mock(NetConnection.class);
         PlayerData data = new PlayerData("viewer-1", true);
         data.uuid = "viewer-1";
         data.pid = 7;
+        data.nickname = "viewer";
         data.customNickname = "old nick";
         data.description = "old desc";
         data.language = "auto";
@@ -198,11 +674,13 @@ class PlayerMenuTest {
         data.activeBadge = "";
         data.badgeSymbolColorMode = "default";
 
+        when(playerDataRepository.findByUuid("viewer-1")).thenReturn(data);
+
         Session session = new Session(
                 new GlobalConfig(),
                 mock(Bundle.class),
                 menuService,
-                mock(PlayerDataRepository.class),
+                playerDataRepository,
                 player,
                 data
         );
@@ -217,5 +695,129 @@ class PlayerMenuTest {
         session.localization = localization;
 
         return session;
+    }
+
+    private Session createOnlineSession(String uuid, String nickname, int pid, boolean admin) {
+        Player player = Player.create();
+        player.con = mock(NetConnection.class);
+        player.admin = admin;
+        PlayerData data = new PlayerData(uuid, true);
+        data.uuid = uuid;
+        data.pid = pid;
+        data.nickname = nickname;
+        data.admin = admin;
+        data.customNickname = "";
+        data.description = "";
+        data.language = "auto";
+        data.translatorLanguage = "off";
+        data.globalChatVisible = true;
+        data.discordRelayVisible = true;
+        data.leaderboard = true;
+        data.activeBadge = "";
+        data.badgeSymbolColorMode = "default";
+
+        Session s = new Session(
+                new GlobalConfig(),
+                mock(Bundle.class),
+                menuService,
+                playerDataRepository,
+                player,
+                data
+        );
+
+        Localization localization = mock(Localization.class);
+        when(localization.t(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.t(anyString(), anyMap())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.format(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.format(anyString(), anyMap())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(localization.getLocale()).thenReturn(Locale.US);
+        when(localization.getLanguageName(anyString(), anyString())).thenReturn("English");
+        s.localization = localization;
+
+        return s;
+    }
+
+    @Test
+    @DisplayName("players renders routed screen with route metadata")
+    void players_rendersRoutedScreenWithRouteMetadata() {
+        when(sessionService.streamCached()).thenReturn(Stream.of(session));
+
+        playerMenu.players("viewer-1", 1);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.players");
+        verify(gateway).menu(eq(session.player), eq(0), eq("player-menu-players-title"), any(), any());
+    }
+
+    @Test
+    @DisplayName("players pagination next and previous transitions pages")
+    void players_pagination_nextAndPreviousTransitionsPages() {
+        Session adminSession = createOnlineSession("admin-1", "admin", 1, true);
+        Session player2 = createOnlineSession("player-2", "player2", 2, false);
+        when(sessionService.streamCached()).thenAnswer(invocation -> Stream.of(session, adminSession, player2));
+
+        playerMenu.players("viewer-1", 1);
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.players");
+
+        // Page 1 layout: admin-filter(0), next(1), select-0(2), select-1(3), back(4), close(5)
+        menuService.onMenuOption(session, 1); // next
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.players");
+        verify(gateway, times(2)).menu(eq(session.player), eq(0), eq("player-menu-players-title"), any(), any());
+
+        // Page 2 layout: admin-filter(0), prev(1), select-0(2), back(3), close(4)
+        menuService.onMenuOption(session, 1); // prev
+
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.players");
+        verify(gateway, times(3)).menu(eq(session.player), eq(0), eq("player-menu-players-title"), any(), any());
+    }
+
+    @Test
+    @DisplayName("players admin filter toggles through neutral active inactive")
+    void players_adminFilter_togglesThroughNeutralActiveInactive() {
+        Session adminSession = createOnlineSession("admin-1", "admin", 1, true);
+        Session player2 = createOnlineSession("player-2", "player2", 2, false);
+        when(sessionService.streamCached()).thenAnswer(invocation -> Stream.of(session, adminSession, player2));
+
+        playerMenu.players("viewer-1", 1);
+
+        // Toggle to Active
+        menuService.onMenuOption(session, 0);
+        assertThat(session.sortStatus.get("admin")).isEqualTo(StatusEnum.Active);
+        assertThat(session.activeScreen()).isNotNull();
+
+        // Toggle to Inactive
+        menuService.onMenuOption(session, 0);
+        assertThat(session.sortStatus.get("admin")).isEqualTo(StatusEnum.Inactive);
+        assertThat(session.activeScreen()).isNotNull();
+
+        // Toggle to Neutral
+        menuService.onMenuOption(session, 0);
+        assertThat(session.sortStatus.get("admin")).isEqualTo(StatusEnum.Neutral);
+        assertThat(session.activeScreen()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("players selecting a player opens routed profile via route history")
+    void players_selectingPlayer_opensRoutedProfileViaRouteHistory() {
+        Session adminSession = createOnlineSession("admin-1", "admin", 1, true);
+        when(sessionService.streamCached()).thenAnswer(invocation -> Stream.of(session, adminSession));
+
+        playerMenu.players("viewer-1", 1);
+
+        // Page 1 layout with 2 players (perPage=2): admin-filter(0), select-0(1), select-1(2), back(3), close(4)
+        menuService.onMenuOption(session, 1); // select admin player
+
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.hasRouteHistory()).isTrue();
+        assertThat(session.activeScreen()).isNotNull();
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("player.profile");
+        verify(gateway).menu(eq(session.player), eq(0), eq("player-menu-player-title"), any(), any());
     }
 }

--- a/src/test/java/org/xcore/plugin/ui/menu/TopMenuTest.java
+++ b/src/test/java/org/xcore/plugin/ui/menu/TopMenuTest.java
@@ -16,11 +16,12 @@ import org.xcore.plugin.model.enums.TopCategory;
 import org.xcore.plugin.service.TopMenuService;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
-import org.xcore.plugin.ui.menu.PlayerMenu;
-import org.xcore.plugin.ui.menu.TopMenu;
 import org.xcore.plugin.ui.flow.ActiveMenuScreen;
 import org.xcore.plugin.ui.flow.MenuMode;
 import org.xcore.plugin.database.repository.PlayerDataRepository;
+import org.xcore.plugin.ui.menu.PlayerMenu;
+import org.xcore.plugin.ui.menu.TopMenu;
+import org.xcore.plugin.ui.route.MenuRoute;
 
 import java.util.List;
 import java.util.Locale;
@@ -47,7 +48,8 @@ class TopMenuTest {
         SessionService sessionService = mock(SessionService.class);
         TopMenuService topMenuService = mock(TopMenuService.class);
         PlayerMenu playerMenu = mock(PlayerMenu.class);
-        TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, topMenuService, playerMenu);
+        TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, menuService, topMenuService, playerMenu);
+        menu.init();
 
         Session session = session("viewer-1");
         when(sessionService.get("viewer-1")).thenReturn(session);
@@ -70,6 +72,10 @@ class TopMenuTest {
         menu.top("viewer-1", TopCategory.MINI_PVP, 1);
 
         assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(
+                MenuRoute.of("top.list").withParam("category", "MINI_PVP").withParam("page", "1")
+        );
         verify(gateway).followUpMenu(eq(session.player), eq(menuService.getMenuId()), any(), any(), any());
 
         TopMenu.TopMenuState state = session.getDraft(TopMenu.TopMenuState.class);
@@ -90,7 +96,8 @@ class TopMenuTest {
         SessionService sessionService = mock(SessionService.class);
         TopMenuService topMenuService = mock(TopMenuService.class);
         PlayerMenu playerMenu = mock(PlayerMenu.class);
-        TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, topMenuService, playerMenu);
+        TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, menuService, topMenuService, playerMenu);
+        menu.init();
 
         Session session = session("viewer-1");
         when(sessionService.get("viewer-1")).thenReturn(session);
@@ -137,7 +144,8 @@ class TopMenuTest {
         SessionService sessionService = mock(SessionService.class);
         TopMenuService topMenuService = mock(TopMenuService.class);
         PlayerMenu playerMenu = mock(PlayerMenu.class);
-        TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, topMenuService, playerMenu);
+        TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, menuService, topMenuService, playerMenu);
+        menu.init();
 
         Session session = session("viewer-1");
         when(sessionService.get("viewer-1")).thenReturn(session);
@@ -177,7 +185,8 @@ class TopMenuTest {
         SessionService sessionService = mock(SessionService.class);
         TopMenuService topMenuService = mock(TopMenuService.class);
         PlayerMenu playerMenu = mock(PlayerMenu.class);
-        TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, topMenuService, playerMenu);
+        TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, menuService, topMenuService, playerMenu);
+        menu.init();
 
         Session session = session("viewer-1");
         when(sessionService.get("viewer-1")).thenReturn(session);
@@ -230,7 +239,8 @@ class TopMenuTest {
         SessionService sessionService = mock(SessionService.class);
         TopMenuService topMenuService = mock(TopMenuService.class);
         PlayerMenu playerMenu = mock(PlayerMenu.class);
-        TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, topMenuService, playerMenu);
+        TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, menuService, topMenuService, playerMenu);
+        menu.init();
 
         Session session = session("viewer-1");
         TopMenu.TopMenuState state = session.getDraft(TopMenu.TopMenuState.class);
@@ -258,12 +268,13 @@ class TopMenuTest {
     }
 
     @Test
-    @DisplayName("player row action pushes history with current cursor and page before opening profile")
-    void playerRowAction_pushesHistoryWithCurrentCursorAndPageBeforeOpeningProfile() {
+    @DisplayName("player row action uses route history before opening profile")
+    void playerRowAction_usesRouteHistoryBeforeOpeningProfile() {
         SessionService sessionService = mock(SessionService.class);
         TopMenuService topMenuService = mock(TopMenuService.class);
         PlayerMenu playerMenu = mock(PlayerMenu.class);
-        TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, topMenuService, playerMenu);
+        TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, menuService, topMenuService, playerMenu);
+        menu.init();
 
         Session session = session("viewer-1");
         PlayerData target = player("target-1", 14);
@@ -285,16 +296,19 @@ class TopMenuTest {
         int profileIndex = optionIndexOf(screen, "profile:target-1");
         menuService.onMenuOption(session, profileIndex);
 
-        assertThat(session.hasHistory()).isTrue();
-        Runnable historyCallback = session.popHistory();
+        assertThat(session.hasHistory()).isFalse();
+        assertThat(session.hasRouteHistory()).isTrue();
 
         InOrder inOrder = inOrder(gateway, playerMenu);
         inOrder.verify(gateway).hideFollowUpMenu(eq(session.player), eq(menuService.getMenuId()));
         inOrder.verify(playerMenu).player("viewer-1", target);
 
-        historyCallback.run();
+        menuService.goBack(session);
         assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
-        verify(topMenuService, times(1)).loadCursorPage(TopCategory.MINI_PVP, currentCursor, 2, 10, session.data);
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("top.list");
+        verify(topMenuService).loadCursorPage(TopCategory.MINI_PVP, null, 2, 10, session.data);
+        verify(topMenuService).loadCursorPage(TopCategory.MINI_PVP, currentCursor, 2, 10, session.data);
     }
 
     @Test
@@ -303,7 +317,8 @@ class TopMenuTest {
         SessionService sessionService = mock(SessionService.class);
         TopMenuService topMenuService = mock(TopMenuService.class);
         PlayerMenu playerMenu = mock(PlayerMenu.class);
-        TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, topMenuService, playerMenu);
+        TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, menuService, topMenuService, playerMenu);
+        menu.init();
 
         Session session = session("viewer-1");
         when(sessionService.get("viewer-1")).thenReturn(session);
@@ -325,6 +340,7 @@ class TopMenuTest {
 
         menu.top("viewer-1", TopCategory.MINI_PVP, 2);
         assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
+        assertThat(session.activeScreen().route().id()).isEqualTo("top.list");
 
         ActiveMenuScreen screen = session.activeScreen();
         int categoryIndex = optionIndexOf(screen, "category");
@@ -334,6 +350,9 @@ class TopMenuTest {
         inOrder.verify(gateway).hideFollowUpMenu(eq(session.player), eq(menuService.getMenuId()));
         inOrder.verify(gateway).menu(eq(session.player), eq(menuService.getMenuId()), any(), any(), any());
 
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.NORMAL);
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("top.categories");
         assertThat(session.hasHistory()).isTrue();
         Runnable historyCallback = session.popHistory();
 
@@ -342,6 +361,8 @@ class TopMenuTest {
 
         historyCallback.run();
         assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route().id()).isEqualTo("top.list");
 
         verify(topMenuService, times(1)).loadCursorPage(TopCategory.MINI_PVP, miniCursor, 2, 10, session.data);
         verify(topMenuService, times(1)).loadCursorPage(TopCategory.PLAYTIME, null, 1, 10, session.data);
@@ -353,7 +374,8 @@ class TopMenuTest {
         SessionService sessionService = mock(SessionService.class);
         TopMenuService topMenuService = mock(TopMenuService.class);
         PlayerMenu playerMenu = mock(PlayerMenu.class);
-        TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, topMenuService, playerMenu);
+        TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, menuService, topMenuService, playerMenu);
+        menu.init();
 
         Session session = session("viewer-1");
         when(sessionService.get("viewer-1")).thenReturn(session);
@@ -382,7 +404,8 @@ class TopMenuTest {
         SessionService sessionService = mock(SessionService.class);
         TopMenuService topMenuService = mock(TopMenuService.class);
         PlayerMenu playerMenu = mock(PlayerMenu.class);
-        TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, topMenuService, playerMenu);
+        TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, menuService, topMenuService, playerMenu);
+        menu.init();
 
         Session session = session("viewer-1");
         when(sessionService.get("viewer-1")).thenReturn(session);
@@ -406,6 +429,91 @@ class TopMenuTest {
         InOrder inOrder = inOrder(gateway, previousMenu);
         inOrder.verify(gateway).hideFollowUpMenu(eq(session.player), eq(menuService.getMenuId()));
         inOrder.verify(previousMenu).run();
+    }
+
+    @Test
+    @DisplayName("categories renders routed categories screen with route metadata")
+    void categories_rendersRoutedCategoriesScreen() {
+        SessionService sessionService = mock(SessionService.class);
+        TopMenuService topMenuService = mock(TopMenuService.class);
+        PlayerMenu playerMenu = mock(PlayerMenu.class);
+        TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, menuService, topMenuService, playerMenu);
+        menu.init();
+
+        Session session = session("viewer-1");
+        when(sessionService.get("viewer-1")).thenReturn(session);
+        when(topMenuService.resolveDefaultCategory()).thenReturn(TopCategory.MINI_PVP);
+        TopMenuService.TopCursorPage hexedPage = new TopMenuService.TopCursorPage(
+                TopCategory.HEXED, 1, 1, 10, 0, null,
+                List.of(), null, null, false
+        );
+        when(topMenuService.loadCursorPage(TopCategory.HEXED, null, 1, 10, session.data)).thenReturn(hexedPage);
+
+        menu.categories("viewer-1", TopCategory.PLAYTIME);
+
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.NORMAL);
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(
+                MenuRoute.of("top.categories").withParam("category", "PLAYTIME")
+        );
+        verify(gateway).menu(eq(session.player), eq(menuService.getMenuId()), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("categories selecting category renders top list route")
+    void categories_selectingCategoryRendersTopListRoute() {
+        SessionService sessionService = mock(SessionService.class);
+        TopMenuService topMenuService = mock(TopMenuService.class);
+        PlayerMenu playerMenu = mock(PlayerMenu.class);
+        TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, menuService, topMenuService, playerMenu);
+        menu.init();
+
+        Session session = session("viewer-1");
+        when(sessionService.get("viewer-1")).thenReturn(session);
+        when(topMenuService.resolveDefaultCategory()).thenReturn(TopCategory.MINI_PVP);
+        TopMenuService.TopCursorPage hexedPage = new TopMenuService.TopCursorPage(
+                TopCategory.HEXED, 1, 1, 10, 0, null,
+                List.of(), null, null, false
+        );
+        when(topMenuService.loadCursorPage(TopCategory.HEXED, null, 1, 10, session.data)).thenReturn(hexedPage);
+
+        menu.categories("viewer-1", TopCategory.PLAYTIME);
+
+        ActiveMenuScreen screen = session.activeScreen();
+        int hexedIndex = optionIndexOf(screen, "HEXED");
+        menuService.onMenuOption(session, hexedIndex);
+
+        assertThat(session.activeScreen().mode()).isEqualTo(MenuMode.FOLLOW_UP);
+        assertThat(session.activeScreen().hasRoute()).isTrue();
+        assertThat(session.activeScreen().route()).isEqualTo(
+                MenuRoute.of("top.list").withParam("category", "HEXED").withParam("page", "1")
+        );
+    }
+
+    @Test
+    @DisplayName("categories back button restores previous menu via goBack")
+    void categories_backButtonRestoresPreviousMenu() {
+        SessionService sessionService = mock(SessionService.class);
+        TopMenuService topMenuService = mock(TopMenuService.class);
+        PlayerMenu playerMenu = mock(PlayerMenu.class);
+        TopMenu menu = new TopMenu(new Config(), new GlobalConfig(), sessionService, menuService, topMenuService, playerMenu);
+        menu.init();
+
+        Session session = session("viewer-1");
+        when(sessionService.get("viewer-1")).thenReturn(session);
+
+        Runnable previousMenu = mock(Runnable.class);
+        session.pushHistory(previousMenu);
+
+        when(topMenuService.resolveDefaultCategory()).thenReturn(TopCategory.MINI_PVP);
+
+        menu.categories("viewer-1", TopCategory.PLAYTIME);
+
+        ActiveMenuScreen screen = session.activeScreen();
+        int backIndex = optionIndexOf(screen, "back");
+        menuService.onMenuOption(session, backIndex);
+
+        verify(previousMenu).run();
     }
 
     private static int optionIndexOf(ActiveMenuScreen screen, String actionId) {


### PR DESCRIPTION
## Summary
- introduce the routed menu runtime and route-aware session/screen plumbing so menus can reopen screens through structured route history instead of ad-hoc callbacks
- migrate the remaining menu flows to routed navigation, keeping `TopMenu` as the one intentional snapshot-based exception where immutable cursor/back-stack restoration is still required
- split oversized routed menu classes into focused `*Flows` helpers for events, players, messages, help, audit history, maps, and Discord while preserving existing behavior and test coverage

## Validation
- `./gradlew :test --tests 'org.xcore.plugin.ui.InformationMenuTest' --tests 'org.xcore.plugin.ui.menu.TopMenuTest' --tests 'org.xcore.plugin.ui.MenuServiceFlowTest' --tests 'org.xcore.plugin.ui.flow.ActiveMenuScreenTest'`
- `./gradlew :test --tests 'org.xcore.plugin.ui.EventMenuTest' --tests 'org.xcore.plugin.ui.MenuServiceFlowTest' --tests 'org.xcore.plugin.ui.flow.ActiveMenuScreenTest'`
- `./gradlew :test --tests 'org.xcore.plugin.ui.PlayerMenuTest' --tests 'org.xcore.plugin.ui.MenuServiceFlowTest' --tests 'org.xcore.plugin.ui.flow.ActiveMenuScreenTest'`
- `./gradlew :test --tests 'org.xcore.plugin.ui.MessageMenuTest' --tests 'org.xcore.plugin.ui.MenuServiceFlowTest' --tests 'org.xcore.plugin.ui.flow.ActiveMenuScreenTest'`
- `./gradlew :test --tests 'org.xcore.plugin.ui.HelpMenuTest' --tests 'org.xcore.plugin.ui.InformationMenuTest' --tests 'org.xcore.plugin.ui.MenuServiceFlowTest' --tests 'org.xcore.plugin.ui.flow.ActiveMenuScreenTest'`
- `./gradlew :test --tests 'org.xcore.plugin.ui.AuditHistoryMenuFlowTest' --tests 'org.xcore.plugin.ui.menu.AuditHistoryMenuTest' --tests 'org.xcore.plugin.ui.MenuServiceFlowTest' --tests 'org.xcore.plugin.ui.flow.ActiveMenuScreenTest'`
- `./gradlew :test --tests 'org.xcore.plugin.ui.menu.MapMenuTest' --tests 'org.xcore.plugin.ui.EventMenuTest' --tests 'org.xcore.plugin.ui.InformationMenuTest' --tests 'org.xcore.plugin.ui.MenuServiceFlowTest' --tests 'org.xcore.plugin.ui.flow.ActiveMenuScreenTest'`
- `./gradlew :test --tests 'org.xcore.plugin.ui.DiscordMenuTest' --tests 'org.xcore.plugin.ui.InformationMenuTest' --tests 'org.xcore.plugin.ui.MenuServiceFlowTest' --tests 'org.xcore.plugin.ui.flow.ActiveMenuScreenTest' --tests 'org.xcore.plugin.ui.flow.ActiveMenuPromptTest'`
- `./gradlew test`
