### PR TITLE
refactor(ui): migrate menu flows to declarative BaseMenuFlow and MenuGrid

### DIFF
--- a/docs/architecture/ui-flow-refactoring-spec.md
+++ b/docs/architecture/ui-flow-refactoring-spec.md
@@ -1,0 +1,112 @@
+### Refactoring Specification File
+
+```markdown
+# XCore UI Flow Refactoring Spec
+
+## 1. Motivation & Context
+The current `MenuFlow` and `RoutedMenuFlow` architecture provides excellent state management and routing capabilities. However, it requires a significant amount of boilerplate for every menu implementation. Specifically:
+- `List.of(List.of(...))` structures make the UI `render` methods hard to read.
+- `switch(actionId)` and `switch(promptId)` blocks inside `onAction`, `onPromptSubmit`, and `onPromptCancel` mix routing logic with business logic.
+- `actionId.startsWith(...)` checks require manual substring parsing for dynamic IDs.
+- Stateless menus require the creation of empty dummy `State` classes.
+
+**Goal:** Migrate to a declarative, fluent, and routing-based approach within the flows using `BaseMenuFlow<T>` and a `MenuGrid` UI builder, drastically reducing boilerplate and improving Developer Experience (DX).
+
+---
+
+## 2. Core Components to Implement
+
+### 2.1. `MenuGrid` (UI Builder)
+A helper class to construct `List<List<MenuButton>>` fluently.
+**Required API:**
+- `row(MenuButton... buttons)`
+- `rowIf(boolean condition, MenuButton... buttons)`
+- `pagination(int currentPage, int totalPages, String prevAction, String nextAction, Localization loc)`
+- `defaultNavigation(Session session, Localization loc)` (adds `back` if available, and `close`)
+- `build()` -> returns `List<List<MenuButton>>`
+
+### 2.2. `NoState`
+A standardized empty record for stateless flows to prevent the proliferation of `MainState`, `ListState`, etc.
+```java
+public record NoState() {}
+```
+
+### 2.3. `BaseMenuFlow<T>`
+An abstract base class implementing `RoutedMenuFlow<T>`.
+**Responsibilities:**
+- Manage a registry of actions: `Map<String, Consumer<MenuRenderContext<T>>>`.
+- Manage prefix actions: `Map<String, BiConsumer<MenuRenderContext<T>, String>>` (payload is the suffix after the prefix).
+- Manage prompts: `Map<String, Consumer<MenuPromptContext<T>>>` (submit) and `Map<String, Consumer<MenuRenderContext<T>>>` (cancel).
+- Pre-register `back` and `close` default actions.
+- Provide a default `createState` implementation that instantiates `T` via reflection (if `T` has a no-args constructor) or returns `currentState`.
+
+---
+
+## 3. Migration Execution Plan & Checklist
+
+The refactoring MUST be executed in phases to ensure the application remains stable and testable.
+
+### Phase 1: Core Foundation
+- [ ] Create `org.xcore.plugin.ui.flow.MenuGrid` class.
+- [ ] Create `org.xcore.plugin.ui.flow.NoState` record.
+- [ ] Create `org.xcore.plugin.ui.flow.BaseMenuFlow<T>` abstract class.
+- [ ] Implement declarative routing methods in `BaseMenuFlow` (`action()`, `actionPrefix()`, `onPrompt()`).
+- [ ] Implement default `onAction`, `onPromptSubmit`, and `onPromptCancel` in `BaseMenuFlow` that delegate to the registered handlers.
+
+### Phase 2: Stateless Menus (Low Risk)
+Refactor the following flows to extend `BaseMenuFlow<NoState>` and use `MenuGrid`. Delete their custom empty state classes.
+- [ ] `InformationMenu.java` (`MainFlow`, `InformationFlow`).
+- [ ] `DiscordFlows.java` (`MainFlow`). Note: `LinkingFlow` has state, keep it as `BaseMenuFlow<LinkingState>`.
+- [ ] `HelpFlows.java` (`HelpListFlow` - change to `NoState` but use `route.intParam` inside render; `HelpDetailsFlow`).
+
+### Phase 3: Dynamic ID Menus (Medium Risk)
+Refactor flows that use dynamic action IDs (e.g., `select:1`, `details:audit-123`). Use `actionPrefix()` to handle the string parsing automatically.
+- [ ] `AuditHistoryFlows.java` (`HistoryFlow`, `DetailsFlow`). Use `actionPrefix("details:", ...)`
+- [ ] `MessageFlows.java` (`InboxFlow`, `BlockedFlow`, `DetailsFlow`). Refactor `PROMPT_REPLY`, `PROMPT_COMPOSE_TARGET`, etc. using `onPrompt()`.
+- [ ] `PlayerProfileFlows.java` (`PlayersFlow`, `PlayerFlow`).
+
+### Phase 4: Complex Stateful Menus & Prompts (High Risk)
+Refactor menus that heavily rely on `Session.getDraft()` and multi-step prompts.
+- [ ] `PlayerSettingsFlows.java` (All flows). Migrate all `onPromptSubmit` switches to declarative `onPrompt()` calls in constructors.
+- [ ] `EventDraftFlows.java` (All flows).
+- [ ] `EventFlows.java` (All flows).
+- [ ] `MapFlows.java` (All flows).
+- [ ] `BanMenu.java` (`BanFlow`).
+
+### Phase 5: Cleanup
+- [ ] Remove unused `ACTION_*` and `PROMPT_*` string constants if they are now inlined in the `BaseMenuFlow` constructors.
+- [ ] Ensure all tests pass (`./gradlew test`). Update tests if they relied on internal `MenuScreen` structures that slightly changed.
+
+---
+
+## 4. Conventions & Guidelines
+
+- **Action Naming:** Use kebab-case for action IDs (e.g., `edit-name`, `toggle-major`).
+- **Prefix Naming:** Prefix actions must end with a colon `:` (e.g., `select:`, `map:`). The handler payload will receive the string immediately following the colon.
+- **Dependency Injection:** Dependencies should still be passed via constructors in the Flow classes, but action registration should happen immediately in the constructor body.
+- **Context Wrappers:** For prompts, use a record `MenuPromptContext<T>(MenuRenderContext<T> renderContext, String text)` to pass both the context and the user input cleanly.
+
+---
+
+## 5. Pull Request Recommendations
+
+### PR Title Convention
+`refactor(ui): migrate menu flows to declarative BaseMenuFlow and MenuGrid`
+
+### PR Description Template
+```markdown
+## Overview
+Refactored the UI Flow architecture to reduce boilerplate, removing massive `switch` statements and `List.of` chains.
+
+## Key Changes
+1. **Core:** Introduced `BaseMenuFlow`, `MenuGrid`, and `NoState`.
+2. **Routing:** Actions and Prompts are now registered declaratively in Flow constructors via `action()`, `actionPrefix()`, and `onPrompt()`.
+3. **UI Building:** `MenuGrid` handles row construction, pagination, and default navigation.
+4. **Cleanup:** Removed over 20+ empty state classes and hundreds of lines of `switch/case` boilerplate.
+
+## Testing
+- [x] Unit tests passed.
+- [x] Verified prefix routing (`select:`, `details:`) works correctly.
+- [x] Verified multi-step prompts (e.g., `BanMenu`, `EventDraftFlows`) execute callbacks correctly.
+```
+```

--- a/src/main/java/org/xcore/plugin/ui/flow/BaseMenuFlow.java
+++ b/src/main/java/org/xcore/plugin/ui/flow/BaseMenuFlow.java
@@ -1,0 +1,122 @@
+package org.xcore.plugin.ui.flow;
+
+import org.xcore.plugin.session.Session;
+import org.xcore.plugin.ui.route.MenuRoute;
+import org.xcore.plugin.ui.route.RoutedMenuFlow;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+public abstract class BaseMenuFlow<T> implements RoutedMenuFlow<T> {
+
+    private final String routeId;
+    private final Class<T> stateType;
+
+    private final Map<String, Consumer<MenuRenderContext<T>>> actions = new LinkedHashMap<>();
+    private final Map<String, BiConsumer<MenuRenderContext<T>, String>> prefixActions = new LinkedHashMap<>();
+    private final Map<String, Consumer<MenuPromptContext<T>>> promptSubmits = new LinkedHashMap<>();
+    private final Map<String, Consumer<MenuRenderContext<T>>> promptCancels = new LinkedHashMap<>();
+    private BiConsumer<MenuRenderContext<T>, String> defaultActionHandler;
+
+    protected BaseMenuFlow(String routeId, Class<T> stateType) {
+        this.routeId = routeId;
+        this.stateType = stateType;
+        action("back", ctx -> ctx.goBack());
+        action("close", ctx -> ctx.close());
+    }
+
+    @Override
+    public final String routeId() {
+        return routeId;
+    }
+
+    @Override
+    public final Class<T> stateType() {
+        return stateType;
+    }
+
+    protected void action(String id, Consumer<MenuRenderContext<T>> handler) {
+        actions.put(id, handler);
+    }
+
+    protected void actionPrefix(String prefix, BiConsumer<MenuRenderContext<T>, String> handler) {
+        if (!prefix.endsWith(":")) {
+            throw new IllegalArgumentException("Prefix actions must end with a colon (:): " + prefix);
+        }
+        prefixActions.put(prefix, handler);
+    }
+
+    protected void defaultAction(BiConsumer<MenuRenderContext<T>, String> handler) {
+        this.defaultActionHandler = handler;
+    }
+
+    protected void onPrompt(String id, Consumer<MenuPromptContext<T>> submitHandler) {
+        promptSubmits.put(id, submitHandler);
+    }
+
+    protected void onPrompt(String id, Consumer<MenuPromptContext<T>> submitHandler, Consumer<MenuRenderContext<T>> cancelHandler) {
+        promptSubmits.put(id, submitHandler);
+        promptCancels.put(id, cancelHandler);
+    }
+
+    protected void onPromptCancel(String id, Consumer<MenuRenderContext<T>> handler) {
+        promptCancels.put(id, handler);
+    }
+
+    @Override
+    public void onAction(MenuRenderContext<T> context, String actionId) {
+        var handler = actions.get(actionId);
+        if (handler != null) {
+            handler.accept(context);
+            return;
+        }
+
+        for (var entry : prefixActions.entrySet()) {
+            String prefix = entry.getKey();
+            if (actionId.startsWith(prefix)) {
+                String suffix = actionId.substring(prefix.length());
+                entry.getValue().accept(context, suffix);
+                return;
+            }
+        }
+
+        if (defaultActionHandler != null) {
+            defaultActionHandler.accept(context, actionId);
+        }
+    }
+
+    @Override
+    public void onPromptSubmit(MenuRenderContext<T> context, String promptId, String text) {
+        var handler = promptSubmits.get(promptId);
+        if (handler != null) {
+            handler.accept(new MenuPromptContext<>(context, text));
+        }
+    }
+
+    @Override
+    public void onPromptCancel(MenuRenderContext<T> context, String promptId) {
+        var handler = promptCancels.get(promptId);
+        if (handler != null) {
+            handler.accept(context);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public T createState(Session session, MenuRoute route, T currentState) {
+        Class<T> type = stateType();
+        if (type == null) {
+            return currentState;
+        }
+        if (type == NoState.class) {
+            return (T) NoState.INSTANCE;
+        }
+        try {
+            return type.getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            return currentState;
+        }
+    }
+}

--- a/src/main/java/org/xcore/plugin/ui/flow/MenuGrid.java
+++ b/src/main/java/org/xcore/plugin/ui/flow/MenuGrid.java
@@ -1,0 +1,51 @@
+package org.xcore.plugin.ui.flow;
+
+import org.xcore.plugin.localization.Localization;
+import org.xcore.plugin.session.Session;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MenuGrid {
+    private final List<List<MenuButton>> rows = new ArrayList<>();
+
+    public MenuGrid row(MenuButton... buttons) {
+        rows.add(List.of(buttons));
+        return this;
+    }
+
+    public MenuGrid rowIf(boolean condition, MenuButton... buttons) {
+        if (condition) {
+            rows.add(List.of(buttons));
+        }
+        return this;
+    }
+
+    public MenuGrid pagination(int currentPage, int totalPages, String prevAction, String nextAction, Localization loc) {
+        var buttons = new ArrayList<MenuButton>();
+        if (currentPage > 1) {
+            buttons.add(MenuButton.of(loc.t("previous"), prevAction));
+        }
+        if (currentPage < totalPages) {
+            buttons.add(MenuButton.of(loc.t("next"), nextAction));
+        }
+        if (!buttons.isEmpty()) {
+            rows.add(List.copyOf(buttons));
+        }
+        return this;
+    }
+
+    public MenuGrid defaultNavigation(Session session, Localization loc) {
+        var buttons = new ArrayList<MenuButton>();
+        if (session.canGoBack()) {
+            buttons.add(MenuButton.of(loc.t("back"), "back"));
+        }
+        buttons.add(MenuButton.of(loc.t("close"), "close"));
+        rows.add(List.copyOf(buttons));
+        return this;
+    }
+
+    public List<List<MenuButton>> build() {
+        return List.copyOf(rows);
+    }
+}

--- a/src/main/java/org/xcore/plugin/ui/flow/MenuPromptContext.java
+++ b/src/main/java/org/xcore/plugin/ui/flow/MenuPromptContext.java
@@ -1,0 +1,3 @@
+package org.xcore.plugin.ui.flow;
+
+public record MenuPromptContext<T>(MenuRenderContext<T> renderContext, String text) {}

--- a/src/main/java/org/xcore/plugin/ui/flow/NoState.java
+++ b/src/main/java/org/xcore/plugin/ui/flow/NoState.java
@@ -1,0 +1,5 @@
+package org.xcore.plugin.ui.flow;
+
+public record NoState() {
+    public static final NoState INSTANCE = new NoState();
+}

--- a/src/main/java/org/xcore/plugin/ui/menu/AuditHistoryFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/AuditHistoryFlows.java
@@ -4,14 +4,12 @@ import org.xcore.plugin.localization.Localization;
 import org.xcore.plugin.model.AuditActorType;
 import org.xcore.plugin.model.AuditCursor;
 import org.xcore.plugin.model.AuditRecord;
+import org.xcore.plugin.ui.flow.BaseMenuFlow;
 import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuGrid;
 import org.xcore.plugin.ui.flow.MenuRenderContext;
 import org.xcore.plugin.ui.flow.MenuScreen;
 import org.xcore.plugin.ui.route.MenuRoute;
-import org.xcore.plugin.ui.route.RoutedMenuFlow;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static com.ospx.flubundle.Bundle.args;
 
@@ -20,31 +18,44 @@ final class AuditHistoryFlows {
     static final String ROUTE_HISTORY = "audit.history";
     static final String ROUTE_DETAILS = "audit.details";
 
-    private static final String ACTION_PREVIOUS = "previous";
-    private static final String ACTION_NEXT = "next";
-    private static final String ACTION_DETAILS_PREFIX = "details:";
-    private static final String ACTION_BACK = "back";
-    private static final String ACTION_CLOSE = "close";
-
     private AuditHistoryFlows() {
     }
 
-    static final class HistoryFlow implements RoutedMenuFlow<AuditHistoryMenu.AuditHistoryState> {
+    static final class HistoryFlow extends BaseMenuFlow<AuditHistoryMenu.AuditHistoryState> {
         private final AuditHistoryMenu menu;
 
         HistoryFlow(AuditHistoryMenu menu) {
+            super(ROUTE_HISTORY, AuditHistoryMenu.AuditHistoryState.class);
             this.menu = menu;
-        }
 
-        @Override
-        public String routeId() {
-            return ROUTE_HISTORY;
+            action("previous", ctx -> {
+                var state = ctx.state();
+                AuditCursor previous = state.backStack.pollLast();
+                state.currentCursor = AuditHistoryMenu.restoreCursor(previous);
+                ctx.render();
+            });
+            action("next", ctx -> {
+                var state = ctx.state();
+                state.backStack.addLast(state.currentCursor == null ? AuditHistoryMenu.FIRST_PAGE_MARKER : state.currentCursor);
+                state.currentCursor = state.nextCursor;
+                ctx.render();
+            });
+            actionPrefix("details:", (ctx, auditId) -> {
+                var session = ctx.session();
+                AuditRecord record = menu.auditService.findByAuditId(auditId).orElse(null);
+                if (record == null) {
+                    session.locale().send("error-processing-request", args());
+                    ctx.render();
+                } else {
+                    ctx.openRoute(MenuRoute.of(ROUTE_DETAILS).withParam("auditId", auditId));
+                }
+            });
         }
 
         @Override
         public AuditHistoryMenu.AuditHistoryState createState(org.xcore.plugin.session.Session session,
-                                                              MenuRoute route,
-                                                              AuditHistoryMenu.AuditHistoryState currentState) {
+                                                               MenuRoute route,
+                                                               AuditHistoryMenu.AuditHistoryState currentState) {
             if (AuditHistoryMenu.shouldReuseHistoryState(session, route, currentState)) {
                 return currentState;
             }
@@ -58,11 +69,6 @@ final class AuditHistoryFlows {
         }
 
         @Override
-        public Class<AuditHistoryMenu.AuditHistoryState> stateType() {
-            return AuditHistoryMenu.AuditHistoryState.class;
-        }
-
-        @Override
         public MenuScreen render(MenuRenderContext<AuditHistoryMenu.AuditHistoryState> context) {
             var session = context.session();
             var state = context.state();
@@ -72,7 +78,7 @@ final class AuditHistoryFlows {
                 return MenuScreen.normal(
                         local.t(state.mode == AuditHistoryMenu.AuditViewMode.TARGET ? "audit-menu-history-title" : "audit-menu-actions-title"),
                         local.t("error-internal"),
-                        List.of(List.of(MenuButton.of(local.t("close"), ACTION_CLOSE)))
+                        new MenuGrid().row(MenuButton.of(local.t("close"), "close")).build()
                 );
             }
 
@@ -89,96 +95,48 @@ final class AuditHistoryFlows {
 
             String content = menu.buildSummaryContent(session, state.targetNickname, state.targetPid, state.mode, slice.items().size(), state.currentCursor, slice.hasNext());
 
-            List<List<MenuButton>> rows = new ArrayList<>();
-
-            List<MenuButton> paginationRow = new ArrayList<>();
+            var grid = new MenuGrid();
+            var paginationRow = new java.util.ArrayList<MenuButton>();
             if (!state.backStack.isEmpty()) {
-                paginationRow.add(MenuButton.of(local.t("previous"), ACTION_PREVIOUS));
+                paginationRow.add(MenuButton.of(local.t("previous"), "previous"));
             }
             if (slice.hasNext() && state.nextCursor != null) {
-                paginationRow.add(MenuButton.of(local.t("next"), ACTION_NEXT));
+                paginationRow.add(MenuButton.of(local.t("next"), "next"));
             }
             if (!paginationRow.isEmpty()) {
-                rows.add(paginationRow);
+                grid.row(paginationRow.toArray(new MenuButton[0]));
             }
 
             for (var item : slice.items()) {
-                rows.add(List.of(MenuButton.of(
+                grid.row(MenuButton.of(
                         AuditHistoryMenu.formatSummaryRow(local, item, state.mode),
-                        ACTION_DETAILS_PREFIX + item.auditId()
-                )));
+                        "details:" + item.auditId()
+                ));
             }
 
-            List<MenuButton> navRow = new ArrayList<>();
-            if (session.canGoBack()) {
-                navRow.add(MenuButton.of(local.t("back"), ACTION_BACK));
-            }
-            navRow.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
-            rows.add(navRow);
+            grid.defaultNavigation(session, local);
 
             return MenuScreen.normal(
                     local.t(state.mode == AuditHistoryMenu.AuditViewMode.TARGET ? "audit-menu-history-title" : "audit-menu-actions-title"),
                     content,
-                    rows
+                    grid.build()
             );
-        }
-
-        @Override
-        public void onAction(MenuRenderContext<AuditHistoryMenu.AuditHistoryState> context, String actionId) {
-            var state = context.state();
-            var session = context.session();
-
-            switch (actionId) {
-                case ACTION_PREVIOUS -> {
-                    AuditCursor previous = state.backStack.pollLast();
-                    state.currentCursor = AuditHistoryMenu.restoreCursor(previous);
-                    context.render();
-                }
-                case ACTION_NEXT -> {
-                    state.backStack.addLast(state.currentCursor == null ? AuditHistoryMenu.FIRST_PAGE_MARKER : state.currentCursor);
-                    state.currentCursor = state.nextCursor;
-                    context.render();
-                }
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                default -> {
-                    if (actionId.startsWith(ACTION_DETAILS_PREFIX)) {
-                        String auditId = actionId.substring(ACTION_DETAILS_PREFIX.length());
-                        AuditRecord record = menu.auditService.findByAuditId(auditId).orElse(null);
-                        if (record == null) {
-                            session.locale().send("error-processing-request", args());
-                            context.render();
-                        } else {
-                            context.openRoute(MenuRoute.of(ROUTE_DETAILS).withParam("auditId", auditId));
-                        }
-                    }
-                }
-            }
         }
     }
 
-    static final class DetailsFlow implements RoutedMenuFlow<AuditHistoryMenu.AuditHistoryState> {
+    static final class DetailsFlow extends BaseMenuFlow<AuditHistoryMenu.AuditHistoryState> {
         private final AuditHistoryMenu menu;
 
         DetailsFlow(AuditHistoryMenu menu) {
+            super(ROUTE_DETAILS, AuditHistoryMenu.AuditHistoryState.class);
             this.menu = menu;
         }
 
         @Override
-        public String routeId() {
-            return ROUTE_DETAILS;
-        }
-
-        @Override
         public AuditHistoryMenu.AuditHistoryState createState(org.xcore.plugin.session.Session session,
-                                                              MenuRoute route,
-                                                              AuditHistoryMenu.AuditHistoryState currentState) {
+                                                               MenuRoute route,
+                                                               AuditHistoryMenu.AuditHistoryState currentState) {
             return currentState != null ? currentState : new AuditHistoryMenu.AuditHistoryState();
-        }
-
-        @Override
-        public Class<AuditHistoryMenu.AuditHistoryState> stateType() {
-            return AuditHistoryMenu.AuditHistoryState.class;
         }
 
         @Override
@@ -201,36 +159,20 @@ final class AuditHistoryFlows {
 
             String content = menu.formatDetailsContent(session, state.targetNickname, state.targetPid, record);
 
-            List<List<MenuButton>> rows = new ArrayList<>();
-            List<MenuButton> navRow = new ArrayList<>();
-            if (session.canGoBack()) {
-                navRow.add(MenuButton.of(local.t("back"), ACTION_BACK));
-            }
-            navRow.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
-            rows.add(navRow);
+            var grid = new MenuGrid().defaultNavigation(session, local);
 
             return MenuScreen.followUp(
                     local.t("audit-menu-details-title"),
                     content,
-                    rows
+                    grid.build()
             );
         }
 
-        @Override
-        public void onAction(MenuRenderContext<AuditHistoryMenu.AuditHistoryState> context, String actionId) {
-            switch (actionId) {
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-            }
-        }
-
         private MenuScreen errorScreen(Localization local) {
-            List<List<MenuButton>> rows = new ArrayList<>();
-            rows.add(List.of(MenuButton.of(local.t("back"), ACTION_BACK)));
             return MenuScreen.followUp(
                     local.t("audit-menu-details-title"),
                     local.t("error-processing-request"),
-                    rows
+                    new MenuGrid().row(MenuButton.of(local.t("back"), "back")).build()
             );
         }
     }

--- a/src/main/java/org/xcore/plugin/ui/menu/BanMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/BanMenu.java
@@ -12,12 +12,13 @@ import org.xcore.plugin.service.moderation.ModerationService;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
 import org.xcore.plugin.ui.MenuService;
+import org.xcore.plugin.ui.flow.BaseMenuFlow;
 import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuGrid;
 import org.xcore.plugin.ui.flow.MenuPrompt;
 import org.xcore.plugin.ui.flow.MenuRenderContext;
 import org.xcore.plugin.ui.flow.MenuScreen;
 import org.xcore.plugin.ui.route.MenuRoute;
-import org.xcore.plugin.ui.route.RoutedMenuFlow;
 
 import java.time.Duration;
 import java.util.List;
@@ -31,8 +32,6 @@ public class BanMenu extends Menu {
     private static final String ROUTE_FLOW = "ban.flow";
     private static final String PROMPT_DURATION = "ban-duration";
     private static final String PROMPT_REASON = "ban-reason";
-    private static final String ACTION_APPLY = "apply";
-    private static final String ACTION_CANCEL = "cancel";
 
     private final ModerationService moderationService;
     private final TimeService timeService;
@@ -78,20 +77,43 @@ public class BanMenu extends Menu {
         session.menuService.renderRoute(session, MenuRoute.of(ROUTE_FLOW));
     }
 
-    private final class BanFlow implements RoutedMenuFlow<BanFlowState> {
-        @Override
-        public String routeId() {
-            return ROUTE_FLOW;
+    private final class BanFlow extends BaseMenuFlow<BanFlowState> {
+        BanFlow() {
+            super(ROUTE_FLOW, BanFlowState.class);
+            action("apply", ctx -> applyBan(ctx));
+            action("cancel", ctx -> cancel(ctx));
+
+            onPrompt(PROMPT_DURATION, ctx -> {
+                var state = ctx.renderContext().state();
+                var session = ctx.renderContext().session();
+                String durationInput = ctx.text() == null ? "" : ctx.text().trim();
+                var parsed = timeService.parsePeriod(durationInput, TimeUnit.DAYS);
+                if (parsed == null || parsed.toEpochMilli() <= 0) {
+                    session.locale().send("error-wrong-period-format", args());
+                    ctx.renderContext().render();
+                    return;
+                }
+                state.durationInput = durationInput;
+                state.duration = Duration.ofMillis(parsed.toEpochMilli());
+                state.step = BanFlowState.Step.REASON;
+                ctx.renderContext().render();
+            }, ctx -> cancel(ctx));
+
+            onPrompt(PROMPT_REASON, ctx -> {
+                var state = ctx.renderContext().state();
+                state.reason = (ctx.text() == null || ctx.text().trim().isEmpty()) ? null : ctx.text().trim();
+                state.step = BanFlowState.Step.CONFIRM;
+                ctx.renderContext().render();
+            }, ctx -> {
+                var state = ctx.state();
+                state.step = BanFlowState.Step.DURATION;
+                ctx.render();
+            });
         }
 
         @Override
         public BanFlowState createState(Session session, MenuRoute route, BanFlowState currentState) {
             return currentState == null ? new BanFlowState() : currentState;
-        }
-
-        @Override
-        public Class<BanFlowState> stateType() {
-            return BanFlowState.class;
         }
 
         @Override
@@ -129,6 +151,11 @@ public class BanMenu extends Menu {
                     return placeholderScreen();
                 }
                 case CONFIRM -> {
+                    var grid = new MenuGrid();
+                    grid.row(
+                            MenuButton.of(local.t("ban-menu-confirm-action"), "apply"),
+                            MenuButton.of(local.t("cancel"), "cancel")
+                    );
                     return MenuScreen.followUp(
                             local.t("ban-menu-confirm-title"),
                             local.t("ban-menu-confirm-content", args(
@@ -136,62 +163,11 @@ public class BanMenu extends Menu {
                                     "duration", state.durationInput,
                                     "reason", state.reason == null ? local.t("none") : state.reason
                             )),
-                            List.of(List.of(
-                                    MenuButton.of(local.t("ban-menu-confirm-action"), ACTION_APPLY),
-                                    MenuButton.of(local.t("cancel"), ACTION_CANCEL)
-                            ))
+                            grid.build()
                     );
                 }
                 default -> {
                     return placeholderScreen();
-                }
-            }
-        }
-
-        @Override
-        public void onAction(MenuRenderContext<BanFlowState> context, String actionId) {
-            switch (actionId) {
-                case ACTION_APPLY -> applyBan(context);
-                case ACTION_CANCEL -> cancel(context);
-            }
-        }
-
-        @Override
-        public void onPromptSubmit(MenuRenderContext<BanFlowState> context, String promptId, String text) {
-            var state = context.state();
-            var session = context.session();
-
-            switch (promptId) {
-                case PROMPT_DURATION -> {
-                    String durationInput = text == null ? "" : text.trim();
-                    var parsed = timeService.parsePeriod(durationInput, TimeUnit.DAYS);
-                    if (parsed == null || parsed.toEpochMilli() <= 0) {
-                        session.locale().send("error-wrong-period-format", args());
-                        context.render();
-                        return;
-                    }
-                    state.durationInput = durationInput;
-                    state.duration = Duration.ofMillis(parsed.toEpochMilli());
-                    state.step = BanFlowState.Step.REASON;
-                    context.render();
-                }
-                case PROMPT_REASON -> {
-                    state.reason = (text == null || text.trim().isEmpty()) ? null : text.trim();
-                    state.step = BanFlowState.Step.CONFIRM;
-                    context.render();
-                }
-            }
-        }
-
-        @Override
-        public void onPromptCancel(MenuRenderContext<BanFlowState> context, String promptId) {
-            var state = context.state();
-
-            switch (promptId) {
-                case PROMPT_DURATION -> cancel(context);
-                case PROMPT_REASON -> {
-                    state.step = BanFlowState.Step.DURATION;
-                    context.render();
                 }
             }
         }

--- a/src/main/java/org/xcore/plugin/ui/menu/DiscordFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/DiscordFlows.java
@@ -2,14 +2,13 @@ package org.xcore.plugin.ui.menu;
 
 import org.xcore.plugin.service.DiscordLinkService;
 import org.xcore.plugin.session.Session;
+import org.xcore.plugin.ui.flow.BaseMenuFlow;
 import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuGrid;
 import org.xcore.plugin.ui.flow.MenuRenderContext;
 import org.xcore.plugin.ui.flow.MenuScreen;
+import org.xcore.plugin.ui.flow.NoState;
 import org.xcore.plugin.ui.route.MenuRoute;
-import org.xcore.plugin.ui.route.RoutedMenuFlow;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static com.ospx.flubundle.Bundle.args;
 
@@ -18,45 +17,37 @@ final class DiscordFlows {
     static final String ROUTE_MAIN = "discord.main";
     static final String ROUTE_LINKING = "discord.linking";
 
-    private static final String ACTION_OPEN = "open";
-    private static final String ACTION_STATUS = "status";
-    private static final String ACTION_LINK = "link";
-    private static final String ACTION_UNLINK = "unlink";
-    private static final String ACTION_COPY = "copy";
-    private static final String ACTION_REFRESH = "refresh";
-    private static final String ACTION_REGENERATE = "regenerate";
-    private static final String ACTION_BACK = "back";
-    private static final String ACTION_CLOSE = "close";
-
     private DiscordFlows() {
     }
 
-    static final class MainFlow implements RoutedMenuFlow<MainState> {
+    static final class MainFlow extends BaseMenuFlow<NoState> {
         private final DiscordMenu menu;
         private final DiscordLinkService discordLinkService;
 
         MainFlow(DiscordMenu menu, DiscordLinkService discordLinkService) {
+            super(ROUTE_MAIN, NoState.class);
             this.menu = menu;
             this.discordLinkService = discordLinkService;
+
+            action("open", ctx -> ctx.session().menuService.openUri(ctx.session(), menu.globalConfig.discordUrl));
+            action("status", ctx -> ctx.render());
+            action("link", ctx -> {
+                ctx.session().clearDraft(LinkingState.class);
+                ctx.openRoute(MenuRoute.of(ROUTE_LINKING).withParam("regenerate", "false"));
+            });
+            action("unlink", ctx -> {
+                var local = ctx.session().locale();
+                if (!discordLinkService.unlink(ctx.session())) {
+                    local.send("commands-discord-unlink-not-linked", args());
+                } else {
+                    local.send("commands-discord-unlink-success", args());
+                }
+                ctx.render();
+            });
         }
 
         @Override
-        public String routeId() {
-            return ROUTE_MAIN;
-        }
-
-        @Override
-        public MainState createState(Session session, MenuRoute route, MainState currentState) {
-            return currentState == null ? new MainState() : currentState;
-        }
-
-        @Override
-        public Class<MainState> stateType() {
-            return MainState.class;
-        }
-
-        @Override
-        public MenuScreen render(MenuRenderContext<MainState> context) {
+        public MenuScreen render(MenuRenderContext<NoState> context) {
             Session session = context.session();
             var local = context.locale();
             var status = discordLinkService.status(session);
@@ -67,24 +58,17 @@ final class DiscordFlows {
                     ))
                     : local.t("discord-menu-status-not-linked", args());
 
-            List<List<MenuButton>> rows = new ArrayList<>();
-            rows.add(List.of(
-                    MenuButton.of(local.t("discord-menu-open"), ACTION_OPEN),
-                    MenuButton.of(local.t("discord-menu-status"), ACTION_STATUS)
-            ));
-
+            var grid = new MenuGrid()
+                    .row(
+                            MenuButton.of(local.t("discord-menu-open"), "open"),
+                            MenuButton.of(local.t("discord-menu-status"), "status")
+                    );
             if (!status.linked()) {
-                rows.add(List.of(MenuButton.of(local.t("discord-menu-link"), ACTION_LINK)));
+                grid.row(MenuButton.of(local.t("discord-menu-link"), "link"));
             } else {
-                rows.add(List.of(MenuButton.of(local.t("discord-menu-unlink"), ACTION_UNLINK)));
+                grid.row(MenuButton.of(local.t("discord-menu-unlink"), "unlink"));
             }
-
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack()) {
-                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
-            rows.add(navigation);
+            grid.defaultNavigation(session, local);
 
             return MenuScreen.normal(
                     local.t("discord-menu-title"),
@@ -92,49 +76,39 @@ final class DiscordFlows {
                             "status", statusText,
                             "discordUrl", menu.globalConfig.discordUrl
                     )),
-                    rows
+                    grid.build()
             );
-        }
-
-        @Override
-        public void onAction(MenuRenderContext<MainState> context, String actionId) {
-            Session session = context.session();
-            switch (actionId) {
-                case ACTION_OPEN -> session.menuService.openUri(session, menu.globalConfig.discordUrl);
-                case ACTION_STATUS -> context.render();
-                case ACTION_LINK -> {
-                    session.clearDraft(LinkingState.class);
-                    context.openRoute(MenuRoute.of(ROUTE_LINKING).withParam("regenerate", "false"));
-                }
-                case ACTION_UNLINK -> {
-                    var local = session.locale();
-                    if (!discordLinkService.unlink(session)) {
-                        local.send("commands-discord-unlink-not-linked", args());
-                    } else {
-                        local.send("commands-discord-unlink-success", args());
-                    }
-                    context.render();
-                }
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                default -> {
-                }
-            }
         }
     }
 
-    static final class LinkingFlow implements RoutedMenuFlow<LinkingState> {
+    static final class LinkingFlow extends BaseMenuFlow<LinkingState> {
         private final DiscordMenu menu;
         private final DiscordLinkService discordLinkService;
 
         LinkingFlow(DiscordMenu menu, DiscordLinkService discordLinkService) {
+            super(ROUTE_LINKING, LinkingState.class);
             this.menu = menu;
             this.discordLinkService = discordLinkService;
-        }
 
-        @Override
-        public String routeId() {
-            return ROUTE_LINKING;
+            action("open", ctx -> ctx.session().menuService.openUri(ctx.session(), menu.globalConfig.discordUrl));
+            action("copy", ctx -> {
+                var result = ctx.state().result;
+                if (result != null && result.success()) {
+                    ctx.session().menuService.copyToClipboard(ctx.session(), result.code());
+                }
+            });
+            action("refresh", ctx -> {
+                ctx.session().clearDraft(LinkingState.class);
+                ctx.openRoute(MenuRoute.of(ROUTE_LINKING).withParam("regenerate", "false"));
+            });
+            action("regenerate", ctx -> {
+                ctx.session().clearDraft(LinkingState.class);
+                ctx.openRoute(MenuRoute.of(ROUTE_LINKING).withParam("regenerate", "true"));
+            });
+            action("status", ctx -> {
+                ctx.close();
+                ctx.openRoute(MenuRoute.of(ROUTE_MAIN));
+            });
         }
 
         @Override
@@ -150,25 +124,15 @@ final class DiscordFlows {
         }
 
         @Override
-        public Class<LinkingState> stateType() {
-            return LinkingState.class;
-        }
-
-        @Override
         public MenuScreen render(MenuRenderContext<LinkingState> context) {
             Session session = context.session();
             var local = context.locale();
             var result = context.state().result;
 
             if (result == null || !result.success()) {
-                List<List<MenuButton>> rows = new ArrayList<>();
-                rows.add(List.of(MenuButton.of(local.t("discord-link-menu-status"), ACTION_STATUS)));
-                List<MenuButton> nav = new ArrayList<>();
-                if (session.canGoBack()) {
-                    nav.add(MenuButton.of(local.t("back"), ACTION_BACK));
-                }
-                nav.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
-                rows.add(nav);
+                var grid = new MenuGrid()
+                        .row(MenuButton.of(local.t("discord-link-menu-status"), "status"))
+                        .defaultNavigation(session, local);
                 return MenuScreen.followUp(
                         local.t("discord-link-menu-title"),
                         local.t("discord-link-menu-content", args(
@@ -176,27 +140,21 @@ final class DiscordFlows {
                                 "expireMinutes", 0,
                                 "discordUrl", menu.globalConfig.discordUrl
                         )),
-                        rows
+                        grid.build()
                 );
             }
 
-            List<List<MenuButton>> rows = new ArrayList<>();
-            rows.add(List.of(
-                    MenuButton.of(local.t("discord-menu-open"), ACTION_OPEN),
-                    MenuButton.of(local.t("discord-link-menu-copy"), ACTION_COPY)
-            ));
-            rows.add(List.of(
-                    MenuButton.of(local.t("discord-link-menu-refresh"), ACTION_REFRESH),
-                    MenuButton.of(local.t("discord-link-menu-regenerate"), ACTION_REGENERATE),
-                    MenuButton.of(local.t("discord-link-menu-status"), ACTION_STATUS)
-            ));
-
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack()) {
-                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
-            rows.add(navigation);
+            var grid = new MenuGrid()
+                    .row(
+                            MenuButton.of(local.t("discord-menu-open"), "open"),
+                            MenuButton.of(local.t("discord-link-menu-copy"), "copy")
+                    )
+                    .row(
+                            MenuButton.of(local.t("discord-link-menu-refresh"), "refresh"),
+                            MenuButton.of(local.t("discord-link-menu-regenerate"), "regenerate"),
+                            MenuButton.of(local.t("discord-link-menu-status"), "status")
+                    )
+                    .defaultNavigation(session, local);
 
             return MenuScreen.followUp(
                     local.t("discord-link-menu-title"),
@@ -205,42 +163,9 @@ final class DiscordFlows {
                             "expireMinutes", result.remainingMinutes(System.currentTimeMillis()),
                             "discordUrl", menu.globalConfig.discordUrl
                     )),
-                    rows
+                    grid.build()
             );
         }
-
-        @Override
-        public void onAction(MenuRenderContext<LinkingState> context, String actionId) {
-            Session session = context.session();
-            var result = context.state().result;
-            switch (actionId) {
-                case ACTION_OPEN -> session.menuService.openUri(session, menu.globalConfig.discordUrl);
-                case ACTION_COPY -> {
-                    if (result != null && result.success()) {
-                        session.menuService.copyToClipboard(session, result.code());
-                    }
-                }
-                case ACTION_REFRESH -> {
-                    session.clearDraft(LinkingState.class);
-                    context.openRoute(MenuRoute.of(ROUTE_LINKING).withParam("regenerate", "false"));
-                }
-                case ACTION_REGENERATE -> {
-                    session.clearDraft(LinkingState.class);
-                    context.openRoute(MenuRoute.of(ROUTE_LINKING).withParam("regenerate", "true"));
-                }
-                case ACTION_STATUS -> {
-                    context.close();
-                    context.openRoute(MenuRoute.of(ROUTE_MAIN));
-                }
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                default -> {
-                }
-            }
-        }
-    }
-
-    static final class MainState {
     }
 
     static final class LinkingState {

--- a/src/main/java/org/xcore/plugin/ui/menu/EventDraftFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/EventDraftFlows.java
@@ -11,12 +11,14 @@ import org.xcore.plugin.model.PlayerData;
 import org.xcore.plugin.service.EventEditorService;
 import org.xcore.plugin.service.MapService;
 import org.xcore.plugin.session.Session;
+import org.xcore.plugin.ui.flow.BaseMenuFlow;
 import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuGrid;
 import org.xcore.plugin.ui.flow.MenuPrompt;
+import org.xcore.plugin.ui.flow.MenuPromptContext;
 import org.xcore.plugin.ui.flow.MenuRenderContext;
 import org.xcore.plugin.ui.flow.MenuScreen;
 import org.xcore.plugin.ui.route.MenuRoute;
-import org.xcore.plugin.ui.route.RoutedMenuFlow;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,22 +31,6 @@ final class EventDraftFlows {
     static final String ROUTE_EDIT = "event.edit";
     static final String ROUTE_MAP_SELECTION = "event.map-selection";
 
-    private static final String ACTION_EDIT_NAME = "edit-name";
-    private static final String ACTION_EDIT_NAME_RESET = "edit-name-reset";
-    private static final String ACTION_EDIT_DESCRIPTION = "edit-description";
-    private static final String ACTION_EDIT_MAP = "edit-map";
-    private static final String ACTION_TOGGLE_TEMPORARY = "toggle-temporary";
-    private static final String ACTION_EDIT_PLANNED_START = "edit-planned-start";
-    private static final String ACTION_EDIT_PLANNED_END = "edit-planned-end";
-    private static final String ACTION_SAVE = "save";
-    private static final String ACTION_CANCEL_EDIT = "cancel-edit";
-    private static final String ACTION_TOGGLE_MAJOR = "toggle-major";
-    private static final String ACTION_PREVIOUS = "previous";
-    private static final String ACTION_NEXT = "next";
-    private static final String ACTION_BACK = "back";
-    private static final String ACTION_CLOSE = "close";
-    private static final String ACTION_MAP_PREFIX = "map:";
-
     private static final String PROMPT_CREATE_NAME = "event-create-name";
     private static final String PROMPT_EDIT_NAME = "event-edit-name";
     private static final String PROMPT_EDIT_DESCRIPTION = "event-edit-description";
@@ -54,28 +40,30 @@ final class EventDraftFlows {
     private EventDraftFlows() {
     }
 
-    static final class CreateStartFlow implements RoutedMenuFlow<CreateStartState> {
+    static final class CreateStartFlow extends BaseMenuFlow<CreateStartState> {
         private final EventMenu menu;
         private final EventEditorService eventEditorService;
 
         CreateStartFlow(EventMenu menu, EventEditorService eventEditorService) {
+            super(ROUTE_CREATE_START, CreateStartState.class);
             this.menu = menu;
             this.eventEditorService = eventEditorService;
-        }
 
-        @Override
-        public String routeId() {
-            return ROUTE_CREATE_START;
+            onPrompt(PROMPT_CREATE_NAME, ctx -> {
+                Session session = ctx.renderContext().session();
+                EventData draft = session.getDraft(EventData.class);
+                eventEditorService.updateName(draft, ctx.text());
+                menu.edit(menu.getUuid(session));
+            }, ctx -> {
+                Session session = ctx.session();
+                eventEditorService.cancelDraft(session);
+                menu.main(menu.getUuid(session));
+            });
         }
 
         @Override
         public CreateStartState createState(Session session, MenuRoute route, CreateStartState currentState) {
             return currentState == null ? new CreateStartState() : currentState;
-        }
-
-        @Override
-        public Class<CreateStartState> stateType() {
-            return CreateStartState.class;
         }
 
         @Override
@@ -95,53 +83,105 @@ final class EventDraftFlows {
             ));
             return placeholderScreen();
         }
-
-        @Override
-        public void onPromptSubmit(MenuRenderContext<CreateStartState> context, String promptId, String text) {
-            if (!PROMPT_CREATE_NAME.equals(promptId)) {
-                return;
-            }
-
-            Session session = context.session();
-            EventData draft = session.getDraft(EventData.class);
-            eventEditorService.updateName(draft, text);
-            menu.edit(menu.getUuid(session));
-        }
-
-        @Override
-        public void onPromptCancel(MenuRenderContext<CreateStartState> context, String promptId) {
-            if (!PROMPT_CREATE_NAME.equals(promptId)) {
-                return;
-            }
-
-            Session session = context.session();
-            eventEditorService.cancelDraft(session);
-            menu.main(menu.getUuid(session));
-        }
     }
 
-    static final class EditFlow implements RoutedMenuFlow<EditState> {
+    static final class EditFlow extends BaseMenuFlow<EditState> {
         private final EventMenu menu;
         private final EventEditorService eventEditorService;
 
         EditFlow(EventMenu menu, EventEditorService eventEditorService) {
+            super(ROUTE_EDIT, EditState.class);
             this.menu = menu;
             this.eventEditorService = eventEditorService;
-        }
 
-        @Override
-        public String routeId() {
-            return ROUTE_EDIT;
+            action("edit-name", ctx -> {
+                Session session = ctx.session();
+                EventData draft = session.getDraft(EventData.class);
+                ctx.openPrompt(new MenuPrompt(
+                        PROMPT_EDIT_NAME,
+                        session.locale().t("event-menu-edit-name-title"),
+                        "",
+                        24,
+                        draft.name,
+                        false
+                ));
+            });
+            action("edit-name-reset", ctx -> {
+                eventEditorService.resetName(ctx.session().getDraft(EventData.class));
+                ctx.render();
+            });
+            action("edit-description", ctx -> {
+                Session session = ctx.session();
+                EventData draft = session.getDraft(EventData.class);
+                ctx.openPrompt(new MenuPrompt(
+                        PROMPT_EDIT_DESCRIPTION,
+                        session.locale().t("event-menu-edit-description-title"),
+                        "",
+                        1000,
+                        draft.description,
+                        false
+                ));
+            });
+            action("edit-map", ctx -> ctx.openRoute(MenuRoute.of(ROUTE_MAP_SELECTION).withParam("page", "1")));
+            action("toggle-temporary", ctx -> {
+                eventEditorService.toggleTemporary(ctx.session().getDraft(EventData.class));
+                ctx.render();
+            });
+            action("edit-planned-start", ctx -> {
+                ctx.openPrompt(new MenuPrompt(
+                        PROMPT_EDIT_PLANNED_START,
+                        ctx.locale().t("event-menu-edit-planned-start-title"),
+                        "",
+                        64,
+                        "",
+                        false
+                ));
+            });
+            action("edit-planned-end", ctx -> {
+                ctx.openPrompt(new MenuPrompt(
+                        PROMPT_EDIT_PLANNED_END,
+                        ctx.locale().t("event-menu-edit-planned-end-title"),
+                        "",
+                        10,
+                        "",
+                        false
+                ));
+            });
+            action("save", ctx -> {
+                if (eventEditorService.saveDraft(ctx.session())) {
+                    menu.events(menu.getUuid(ctx.session()), 1);
+                }
+            });
+            action("cancel-edit", ctx -> {
+                eventEditorService.cancelDraft(ctx.session());
+                menu.main(menu.getUuid(ctx.session()));
+            });
+            action("toggle-major", ctx -> {
+                eventEditorService.toggleMajor(ctx.session().getDraft(EventData.class));
+                ctx.render();
+            });
+
+            onPrompt(PROMPT_EDIT_NAME, ctx -> {
+                eventEditorService.updateName(ctx.renderContext().session().getDraft(EventData.class), ctx.text());
+                ctx.renderContext().render();
+            }, ctx -> ctx.render());
+            onPrompt(PROMPT_EDIT_DESCRIPTION, ctx -> {
+                eventEditorService.updateDescription(ctx.renderContext().session().getDraft(EventData.class), ctx.text());
+                ctx.renderContext().render();
+            }, ctx -> ctx.render());
+            onPrompt(PROMPT_EDIT_PLANNED_START, ctx -> {
+                eventEditorService.updatePlannedStartTime(ctx.renderContext().session().getDraft(EventData.class), ctx.text());
+                ctx.renderContext().render();
+            }, ctx -> ctx.render());
+            onPrompt(PROMPT_EDIT_PLANNED_END, ctx -> {
+                eventEditorService.updatePlannedEndTime(ctx.renderContext().session().getDraft(EventData.class), ctx.text());
+                ctx.renderContext().render();
+            }, ctx -> ctx.render());
         }
 
         @Override
         public EditState createState(Session session, MenuRoute route, EditState currentState) {
             return currentState == null ? new EditState() : currentState;
-        }
-
-        @Override
-        public Class<EditState> stateType() {
-            return EditState.class;
         }
 
         @Override
@@ -154,29 +194,29 @@ final class EventDraftFlows {
             String yes = session.locale().t("yes");
             String no = session.locale().t("no");
 
-            List<List<MenuButton>> rows = new ArrayList<>();
-            rows.add(List.of(
-                    MenuButton.of(session.locale().t("event-menu-edit-name"), ACTION_EDIT_NAME),
-                    MenuButton.of(session.locale().t("event-menu-edit-name-reset"), ACTION_EDIT_NAME_RESET),
-                    MenuButton.of(session.locale().t("event-menu-edit-description"), ACTION_EDIT_DESCRIPTION)
-            ));
-            rows.add(List.of(
-                    MenuButton.of(session.locale().t("event-menu-edit-map"), ACTION_EDIT_MAP),
-                    MenuButton.of(session.locale().t(draft.isTemporary ? "event-menu-edit-temporary-active" : "event-menu-edit-temporary-inactive"), ACTION_TOGGLE_TEMPORARY)
-            ));
-            rows.add(List.of(
-                    MenuButton.of(session.locale().t("event-menu-edit-planned-start"), ACTION_EDIT_PLANNED_START),
-                    MenuButton.of(session.locale().t("event-menu-edit-planned-end"), ACTION_EDIT_PLANNED_END)
-            ));
-            rows.add(List.of(
-                    MenuButton.of("[green]" + session.locale().t("save"), ACTION_SAVE),
-                    MenuButton.of("[red]" + session.locale().t("cancel"), ACTION_CANCEL_EDIT)
-            ));
+            var grid = new MenuGrid();
+            grid.row(
+                    MenuButton.of(session.locale().t("event-menu-edit-name"), "edit-name"),
+                    MenuButton.of(session.locale().t("event-menu-edit-name-reset"), "edit-name-reset"),
+                    MenuButton.of(session.locale().t("event-menu-edit-description"), "edit-description")
+            );
+            grid.row(
+                    MenuButton.of(session.locale().t("event-menu-edit-map"), "edit-map"),
+                    MenuButton.of(session.locale().t(draft.isTemporary ? "event-menu-edit-temporary-active" : "event-menu-edit-temporary-inactive"), "toggle-temporary")
+            );
+            grid.row(
+                    MenuButton.of(session.locale().t("event-menu-edit-planned-start"), "edit-planned-start"),
+                    MenuButton.of(session.locale().t("event-menu-edit-planned-end"), "edit-planned-end")
+            );
+            grid.row(
+                    MenuButton.of("[green]" + session.locale().t("save"), "save"),
+                    MenuButton.of("[red]" + session.locale().t("cancel"), "cancel-edit")
+            );
             if (session.player.admin) {
-                rows.add(List.of(MenuButton.of(
+                grid.row(MenuButton.of(
                         session.locale().t(draft.isMajor ? "event-menu-edit-major-active" : "event-menu-edit-major-inactive"),
-                        ACTION_TOGGLE_MAJOR
-                )));
+                        "toggle-major"
+                ));
             }
 
             return MenuScreen.normal(
@@ -191,118 +231,52 @@ final class EventDraftFlows {
                             "plannedStartTime", menu.formatTime(draft.plannedStartTime, session),
                             "plannedEndTime", menu.formatTime(draft.plannedEndTime, session)
                     )),
-                    rows
+                    grid.build()
             );
-        }
-
-        @Override
-        public void onAction(MenuRenderContext<EditState> context, String actionId) {
-            Session session = context.session();
-            EventData draft = session.getDraft(EventData.class);
-            String uuid = menu.getUuid(session);
-
-            switch (actionId) {
-                case ACTION_EDIT_NAME -> context.openPrompt(new MenuPrompt(
-                        PROMPT_EDIT_NAME,
-                        session.locale().t("event-menu-edit-name-title"),
-                        "",
-                        24,
-                        draft.name,
-                        false
-                ));
-                case ACTION_EDIT_NAME_RESET -> {
-                    eventEditorService.resetName(draft);
-                    context.render();
-                }
-                case ACTION_EDIT_DESCRIPTION -> context.openPrompt(new MenuPrompt(
-                        PROMPT_EDIT_DESCRIPTION,
-                        session.locale().t("event-menu-edit-description-title"),
-                        "",
-                        1000,
-                        draft.description,
-                        false
-                ));
-                case ACTION_EDIT_MAP -> context.openRoute(MenuRoute.of(ROUTE_MAP_SELECTION).withParam("page", "1"));
-                case ACTION_TOGGLE_TEMPORARY -> {
-                    eventEditorService.toggleTemporary(draft);
-                    context.render();
-                }
-                case ACTION_EDIT_PLANNED_START -> context.openPrompt(new MenuPrompt(
-                        PROMPT_EDIT_PLANNED_START,
-                        session.locale().t("event-menu-edit-planned-start-title"),
-                        "",
-                        64,
-                        "",
-                        false
-                ));
-                case ACTION_EDIT_PLANNED_END -> context.openPrompt(new MenuPrompt(
-                        PROMPT_EDIT_PLANNED_END,
-                        session.locale().t("event-menu-edit-planned-end-title"),
-                        "",
-                        10,
-                        "",
-                        false
-                ));
-                case ACTION_SAVE -> {
-                    if (eventEditorService.saveDraft(session)) {
-                        menu.events(uuid, 1);
-                    }
-                }
-                case ACTION_CANCEL_EDIT -> {
-                    eventEditorService.cancelDraft(session);
-                    menu.main(uuid);
-                }
-                case ACTION_TOGGLE_MAJOR -> {
-                    eventEditorService.toggleMajor(draft);
-                    context.render();
-                }
-                default -> {
-                }
-            }
-        }
-
-        @Override
-        public void onPromptSubmit(MenuRenderContext<EditState> context, String promptId, String text) {
-            Session session = context.session();
-            EventData draft = session.getDraft(EventData.class);
-
-            switch (promptId) {
-                case PROMPT_EDIT_NAME -> eventEditorService.updateName(draft, text);
-                case PROMPT_EDIT_DESCRIPTION -> eventEditorService.updateDescription(draft, text);
-                case PROMPT_EDIT_PLANNED_START -> eventEditorService.updatePlannedStartTime(draft, text);
-                case PROMPT_EDIT_PLANNED_END -> eventEditorService.updatePlannedEndTime(draft, text);
-                default -> {
-                    return;
-                }
-            }
-
-            context.render();
-        }
-
-        @Override
-        public void onPromptCancel(MenuRenderContext<EditState> context, String promptId) {
-            switch (promptId) {
-                case PROMPT_EDIT_NAME, PROMPT_EDIT_DESCRIPTION, PROMPT_EDIT_PLANNED_START, PROMPT_EDIT_PLANNED_END -> context.render();
-                default -> {
-                }
-            }
         }
     }
 
-    static final class MapSelectionFlow implements RoutedMenuFlow<MapSelectionState> {
+    static final class MapSelectionFlow extends BaseMenuFlow<MapSelectionState> {
         private final EventMenu menu;
         private final EventEditorService eventEditorService;
         private final MapService mapService;
 
         MapSelectionFlow(EventMenu menu, EventEditorService eventEditorService, MapService mapService) {
+            super(ROUTE_MAP_SELECTION, MapSelectionState.class);
             this.menu = menu;
             this.eventEditorService = eventEditorService;
             this.mapService = mapService;
-        }
 
-        @Override
-        public String routeId() {
-            return ROUTE_MAP_SELECTION;
+            action("prev", ctx -> {
+                int currentPage = Math.max(1, ctx.state().page);
+                ctx.session().menuService.renderRoute(ctx.session(),
+                        MenuRoute.of(ROUTE_MAP_SELECTION).withParam("page", String.valueOf(currentPage - 1)));
+            });
+            action("next", ctx -> {
+                int currentPage = Math.max(1, ctx.state().page);
+                ctx.session().menuService.renderRoute(ctx.session(),
+                        MenuRoute.of(ROUTE_MAP_SELECTION).withParam("page", String.valueOf(currentPage + 1)));
+            });
+            actionPrefix("map:", (ctx, indexStr) -> {
+                int index;
+                try {
+                    index = Integer.parseInt(indexStr);
+                } catch (NumberFormatException ignored) {
+                    return;
+                }
+                Session session = ctx.session();
+                int currentPage = Math.max(1, ctx.state().page);
+                List<Map> pagedMaps = SeqStream.of(mapService.getAvailableMaps())
+                        .gather(CustomGatherers.page(menu.globalConfig.mapsPerPage, currentPage))
+                        .flatMap(List::stream)
+                        .toList();
+                if (index < 0 || index >= pagedMaps.size()) {
+                    return;
+                }
+                Map map = pagedMaps.get(index);
+                eventEditorService.selectMapForDraft(session, map.plainName(), map.file.name(), map.author(), Vars.state.rules.mode().name());
+                menu.edit(menu.getUuid(session));
+            });
         }
 
         @Override
@@ -310,11 +284,6 @@ final class EventDraftFlows {
             MapSelectionState state = currentState == null ? new MapSelectionState() : currentState;
             state.page = route.intParam("page", 1);
             return state;
-        }
-
-        @Override
-        public Class<MapSelectionState> stateType() {
-            return MapSelectionState.class;
         }
 
         @Override
@@ -329,76 +298,31 @@ final class EventDraftFlows {
                     .flatMap(List::stream)
                     .toList();
 
-            List<List<MenuButton>> rows = new ArrayList<>();
+            var grid = new MenuGrid();
 
             List<MenuButton> paginationRow = new ArrayList<>();
             if (validPage > 1) {
-                paginationRow.add(MenuButton.of(session.locale().t("previous"), ACTION_PREVIOUS));
+                paginationRow.add(MenuButton.of(session.locale().t("previous"), "prev"));
             }
             if (validPage < pagination.totalPages()) {
-                paginationRow.add(MenuButton.of(session.locale().t("next"), ACTION_NEXT));
+                paginationRow.add(MenuButton.of(session.locale().t("next"), "next"));
             }
             if (!paginationRow.isEmpty()) {
-                rows.add(paginationRow);
+                grid.row(paginationRow.toArray(new MenuButton[0]));
             }
 
             for (int i = 0; i < pagedMaps.size(); i++) {
                 Map map = pagedMaps.get(i);
-                rows.add(List.of(MenuButton.of(map.name(), ACTION_MAP_PREFIX + i)));
+                grid.row(MenuButton.of(map.name(), "map:" + i));
             }
 
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack()) {
-                navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
-            rows.add(navigation);
+            grid.defaultNavigation(session, session.locale());
 
             return MenuScreen.normal(
                     session.locale().t("event-menu-maps-title"),
                     session.locale().t("event-menu-maps-content", args("page", validPage, "total", pagination.totalPages())),
-                    rows
+                    grid.build()
             );
-        }
-
-        @Override
-        public void onAction(MenuRenderContext<MapSelectionState> context, String actionId) {
-            Session session = context.session();
-            String uuid = menu.getUuid(session);
-            int currentPage = Math.max(1, context.state().page);
-
-            switch (actionId) {
-                case ACTION_PREVIOUS -> session.menuService.renderRoute(session,
-                        MenuRoute.of(ROUTE_MAP_SELECTION).withParam("page", String.valueOf(currentPage - 1)));
-                case ACTION_NEXT -> session.menuService.renderRoute(session,
-                        MenuRoute.of(ROUTE_MAP_SELECTION).withParam("page", String.valueOf(currentPage + 1)));
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                default -> {
-                    if (!actionId.startsWith(ACTION_MAP_PREFIX)) {
-                        return;
-                    }
-
-                    int index;
-                    try {
-                        index = Integer.parseInt(actionId.substring(ACTION_MAP_PREFIX.length()));
-                    } catch (NumberFormatException ignored) {
-                        return;
-                    }
-
-                    List<Map> pagedMaps = SeqStream.of(mapService.getAvailableMaps())
-                            .gather(CustomGatherers.page(menu.globalConfig.mapsPerPage, currentPage))
-                            .flatMap(List::stream)
-                            .toList();
-                    if (index < 0 || index >= pagedMaps.size()) {
-                        return;
-                    }
-
-                    Map map = pagedMaps.get(index);
-                    eventEditorService.selectMapForDraft(session, map.plainName(), map.file.name(), map.author(), Vars.state.rules.mode().name());
-                    menu.edit(uuid);
-                }
-            }
         }
     }
 

--- a/src/main/java/org/xcore/plugin/ui/menu/EventFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/EventFlows.java
@@ -8,11 +8,12 @@ import org.xcore.plugin.model.PlayerData;
 import org.xcore.plugin.service.EventService;
 import org.xcore.plugin.service.EventViewService;
 import org.xcore.plugin.session.Session;
+import org.xcore.plugin.ui.flow.BaseMenuFlow;
 import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuGrid;
 import org.xcore.plugin.ui.flow.MenuRenderContext;
 import org.xcore.plugin.ui.flow.MenuScreen;
 import org.xcore.plugin.ui.route.MenuRoute;
-import org.xcore.plugin.ui.route.RoutedMenuFlow;
 import org.xcore.plugin.vote.VoteEvent;
 import org.xcore.plugin.vote.VoteService;
 
@@ -27,44 +28,32 @@ final class EventFlows {
     static final String ROUTE_EVENTS = "event.events";
     static final String ROUTE_EVENT = "event.details";
 
-    private static final String ACTION_CREATE_START = "create-start";
-    private static final String ACTION_EVENTS = "events";
-    private static final String ACTION_THIS_EVENT = "this-event";
-    private static final String ACTION_VOTE_STOP = "vote-stop";
-    private static final String ACTION_STOP = "stop";
-    private static final String ACTION_LIKE = "like";
-    private static final String ACTION_DISLIKE = "dislike";
-    private static final String ACTION_VOTE = "vote";
-    private static final String ACTION_ADMIN_VOTE = "admin-vote";
-    private static final String ACTION_EDIT = "edit";
-    private static final String ACTION_EVENT_MAP = "event-map";
-    private static final String ACTION_PREVIOUS = "previous";
-    private static final String ACTION_NEXT = "next";
-    private static final String ACTION_BACK = "back";
-    private static final String ACTION_CLOSE = "close";
-    private static final String ACTION_MAIN = "main";
-    private static final String ACTION_STATUS_PREFIX = "status:";
-    private static final String ACTION_EVENT_PREFIX = "event:";
-
     private EventFlows() {
     }
 
-    static final class MainFlow implements RoutedMenuFlow<MainState> {
+    static final class MainFlow extends BaseMenuFlow<MainState> {
         private final EventMenu menu;
         private final EventViewService eventViewService;
         private final VoteService voteService;
         private final EventService eventService;
 
         MainFlow(EventMenu menu, EventViewService eventViewService, VoteService voteService, EventService eventService) {
+            super(ROUTE_MAIN, MainState.class);
             this.menu = menu;
             this.eventViewService = eventViewService;
             this.voteService = voteService;
             this.eventService = eventService;
-        }
 
-        @Override
-        public String routeId() {
-            return ROUTE_MAIN;
+            action("create-start", ctx -> menu.createStart(menu.getUuid(ctx.session()), null));
+            action("events", ctx -> ctx.openRoute(MenuRoute.of(ROUTE_EVENTS).withParam("page", "1")));
+            action("this-event", ctx -> {
+                EventData active = eventViewService.activeEvent();
+                if (active != null && active.id != null) {
+                    ctx.openRoute(MenuRoute.of(ROUTE_EVENT).withParam("eventId", active.id.toHexString()));
+                }
+            });
+            action("vote-stop", ctx -> voteService.endVote());
+            action("stop", ctx -> eventService.finishActiveEvent());
         }
 
         @Override
@@ -73,89 +62,73 @@ final class EventFlows {
         }
 
         @Override
-        public Class<MainState> stateType() {
-            return MainState.class;
-        }
-
-        @Override
         public MenuScreen render(MenuRenderContext<MainState> context) {
             Session session = context.session();
             var local = context.locale();
             EventData active = eventViewService.activeEvent();
 
-            List<List<MenuButton>> rows = new ArrayList<>();
-            rows.add(List.of(
-                    MenuButton.of(local.t("event-menu-create-start"), ACTION_CREATE_START),
-                    MenuButton.of(local.t("event-menu-events"), ACTION_EVENTS)
-            ));
+            var grid = new MenuGrid();
+            grid.row(
+                    MenuButton.of(local.t("event-menu-create-start"), "create-start"),
+                    MenuButton.of(local.t("event-menu-events"), "events")
+            );
 
-            if (active != null) {
-                rows.add(List.of(MenuButton.of(local.t("event-menu-this-event"), ACTION_THIS_EVENT)));
-            }
+            grid.rowIf(active != null, MenuButton.of(local.t("event-menu-this-event"), "this-event"));
 
             if (session.player.admin) {
                 List<MenuButton> adminRow = new ArrayList<>();
                 if (voteService.getCurrentSession() instanceof VoteEvent) {
-                    adminRow.add(MenuButton.of(local.t("event-menu-vote-stop"), ACTION_VOTE_STOP));
+                    adminRow.add(MenuButton.of(local.t("event-menu-vote-stop"), "vote-stop"));
                 }
                 if (active != null && active.isActive) {
-                    adminRow.add(MenuButton.of(local.t("event-menu-stop"), ACTION_STOP));
+                    adminRow.add(MenuButton.of(local.t("event-menu-stop"), "stop"));
                 }
                 if (!adminRow.isEmpty()) {
-                    rows.add(adminRow);
+                    grid.row(adminRow.toArray(new MenuButton[0]));
                 }
             }
 
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack()) {
-                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
-            rows.add(navigation);
+            grid.defaultNavigation(session, local);
 
             return MenuScreen.normal(
                     local.t("event-menu-main-title"),
                     local.t("event-menu-main-content"),
-                    rows
+                    grid.build()
             );
-        }
-
-        @Override
-        public void onAction(MenuRenderContext<MainState> context, String actionId) {
-            Session session = context.session();
-            String uuid = menu.getUuid(session);
-            EventData active = eventViewService.activeEvent();
-
-            switch (actionId) {
-                case ACTION_CREATE_START -> menu.createStart(uuid, null);
-                case ACTION_EVENTS -> context.openRoute(MenuRoute.of(ROUTE_EVENTS).withParam("page", "1"));
-                case ACTION_THIS_EVENT -> {
-                    if (active != null && active.id != null) {
-                        context.openRoute(MenuRoute.of(ROUTE_EVENT).withParam("eventId", active.id.toHexString()));
-                    }
-                }
-                case ACTION_VOTE_STOP -> voteService.endVote();
-                case ACTION_STOP -> eventService.finishActiveEvent();
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                default -> {
-                }
-            }
         }
     }
 
-    static final class EventsFlow implements RoutedMenuFlow<EventsState> {
+    static final class EventsFlow extends BaseMenuFlow<EventsState> {
         private final EventMenu menu;
         private final EventViewService eventViewService;
 
         EventsFlow(EventMenu menu, EventViewService eventViewService) {
+            super(ROUTE_EVENTS, EventsState.class);
             this.menu = menu;
             this.eventViewService = eventViewService;
-        }
 
-        @Override
-        public String routeId() {
-            return ROUTE_EVENTS;
+            action("prev", ctx -> {
+                int currentPage = Math.max(1, ctx.state().page);
+                ctx.session().menuService.renderRoute(ctx.session(),
+                        MenuRoute.of(ROUTE_EVENTS).withParam("page", String.valueOf(currentPage - 1)));
+            });
+            action("next", ctx -> {
+                int currentPage = Math.max(1, ctx.state().page);
+                ctx.session().menuService.renderRoute(ctx.session(),
+                        MenuRoute.of(ROUTE_EVENTS).withParam("page", String.valueOf(currentPage + 1)));
+            });
+            action("main", ctx -> menu.main(menu.getUuid(ctx.session())));
+            actionPrefix("status:", (ctx, key) -> {
+                ctx.session().setNextStatus(key);
+                ctx.session().menuService.renderRoute(ctx.session(),
+                        MenuRoute.of(ROUTE_EVENTS).withParam("page", "1"));
+            });
+            actionPrefix("event:", (ctx, eventId) -> {
+                EventData event = eventViewService.findById(new ObjectId(eventId));
+                if (event != null) {
+                    ctx.openRoute(MenuRoute.of(ROUTE_EVENT).withParam("eventId", eventId));
+                }
+            });
         }
 
         @Override
@@ -163,11 +136,6 @@ final class EventFlows {
             EventsState state = currentState == null ? new EventsState() : currentState;
             state.page = route.intParam("page", 1);
             return state;
-        }
-
-        @Override
-        public Class<EventsState> stateType() {
-            return EventsState.class;
         }
 
         @Override
@@ -188,99 +156,98 @@ final class EventFlows {
                 ));
             }
 
-            List<List<MenuButton>> rows = new ArrayList<>();
+            var grid = new MenuGrid();
 
-            rows.add(List.of(MenuButton.of(
+            grid.row(MenuButton.of(
                     session.locale().t("finished-" + session.sortStatus.getOrDefault("finished", StatusEnum.Neutral).name().toLowerCase()),
-                    ACTION_STATUS_PREFIX + "finished")));
-            rows.add(List.of(MenuButton.of(
+                    "status:finished"));
+            grid.row(MenuButton.of(
                     session.locale().t("major-" + session.sortStatus.getOrDefault("major", StatusEnum.Neutral).name().toLowerCase()),
-                    ACTION_STATUS_PREFIX + "major")));
-            rows.add(List.of(MenuButton.of(
+                    "status:major"));
+            grid.row(MenuButton.of(
                     session.locale().t("active-" + session.sortStatus.getOrDefault("active", StatusEnum.Neutral).name().toLowerCase()),
-                    ACTION_STATUS_PREFIX + "active")));
+                    "status:active"));
 
             List<MenuButton> paginationRow = new ArrayList<>();
             if (eventPage.hasPrevious()) {
-                paginationRow.add(MenuButton.of(session.locale().t("previous"), ACTION_PREVIOUS));
+                paginationRow.add(MenuButton.of(session.locale().t("previous"), "prev"));
             }
             if (eventPage.hasNext()) {
-                paginationRow.add(MenuButton.of(session.locale().t("next"), ACTION_NEXT));
+                paginationRow.add(MenuButton.of(session.locale().t("next"), "next"));
             }
             if (!paginationRow.isEmpty()) {
-                rows.add(paginationRow);
+                grid.row(paginationRow.toArray(new MenuButton[0]));
             }
 
             for (EventData e : eventPage.events()) {
                 String text = e.isActive ? session.locale().t("event-menu-events-selected", args("name", e.name)) : e.name;
-                rows.add(List.of(MenuButton.of(text, ACTION_EVENT_PREFIX + e.id.toHexString())));
+                grid.row(MenuButton.of(text, "event:" + e.id.toHexString()));
             }
 
-            rows.add(List.of(MenuButton.of(session.locale().t("event-menu-main"), ACTION_MAIN)));
-
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack()) {
-                navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
-            rows.add(navigation);
+            grid.row(MenuButton.of(session.locale().t("event-menu-main"), "main"));
+            grid.defaultNavigation(session, session.locale());
 
             return MenuScreen.normal(
                     session.locale().t("event-menu-events-title"),
                     menuContent,
-                    rows
+                    grid.build()
             );
-        }
-
-        @Override
-        public void onAction(MenuRenderContext<EventsState> context, String actionId) {
-            Session session = context.session();
-            String uuid = menu.getUuid(session);
-            int currentPage = Math.max(1, context.state().page);
-
-            switch (actionId) {
-                case ACTION_PREVIOUS -> session.menuService.renderRoute(session,
-                        MenuRoute.of(ROUTE_EVENTS).withParam("page", String.valueOf(currentPage - 1)));
-                case ACTION_NEXT -> session.menuService.renderRoute(session,
-                        MenuRoute.of(ROUTE_EVENTS).withParam("page", String.valueOf(currentPage + 1)));
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                case ACTION_MAIN -> {
-                    menu.main(uuid);
-                }
-                default -> {
-                    if (actionId.startsWith(ACTION_STATUS_PREFIX)) {
-                        String statusKey = actionId.substring(ACTION_STATUS_PREFIX.length());
-                        session.setNextStatus(statusKey);
-                        session.menuService.renderRoute(session, MenuRoute.of(ROUTE_EVENTS).withParam("page", "1"));
-                    } else if (actionId.startsWith(ACTION_EVENT_PREFIX)) {
-                        String eventId = actionId.substring(ACTION_EVENT_PREFIX.length());
-                        EventData event = eventViewService.findById(new ObjectId(eventId));
-                        if (event != null) {
-                            context.openRoute(MenuRoute.of(ROUTE_EVENT).withParam("eventId", eventId));
-                        }
-                    }
-                }
-            }
         }
     }
 
-    static final class EventFlow implements RoutedMenuFlow<EventState> {
+    static final class EventFlow extends BaseMenuFlow<EventState> {
         private final EventMenu menu;
         private final EventViewService eventViewService;
         private final VoteService voteService;
         private final EventService eventService;
 
         EventFlow(EventMenu menu, EventViewService eventViewService, VoteService voteService, EventService eventService) {
+            super(ROUTE_EVENT, EventState.class);
             this.menu = menu;
             this.eventViewService = eventViewService;
             this.voteService = voteService;
             this.eventService = eventService;
-        }
 
-        @Override
-        public String routeId() {
-            return ROUTE_EVENT;
+            action("like", ctx -> {
+                EventViewService.EventDetails details = resolveEventDetails(eventViewService, ctx.state().eventId);
+                if (details != null && details.event() != null) {
+                    eventService.handleReputation(ctx.session().player, true, details.event());
+                    ctx.render();
+                }
+            });
+            action("dislike", ctx -> {
+                EventViewService.EventDetails details = resolveEventDetails(eventViewService, ctx.state().eventId);
+                if (details != null && details.event() != null) {
+                    eventService.handleReputation(ctx.session().player, false, details.event());
+                    ctx.render();
+                }
+            });
+            action("vote", ctx -> {
+                EventViewService.EventDetails details = resolveEventDetails(eventViewService, ctx.state().eventId);
+                if (details != null && details.event() != null) {
+                    eventService.startVoteSession(ctx.session().player, details.event(), false);
+                }
+            });
+            action("admin-vote", ctx -> {
+                EventViewService.EventDetails details = resolveEventDetails(eventViewService, ctx.state().eventId);
+                if (details != null && details.event() != null) {
+                    eventService.startVoteSession(ctx.session().player, details.event(), true);
+                }
+            });
+            action("edit", ctx -> {
+                EventViewService.EventDetails details = resolveEventDetails(eventViewService, ctx.state().eventId);
+                if (details != null && details.event() != null) {
+                    ctx.session().setDraft(EventData.class, details.event());
+                    menu.edit(menu.getUuid(ctx.session()));
+                }
+            });
+            action("events", ctx -> ctx.openRoute(MenuRoute.of(ROUTE_EVENTS).withParam("page", "1")));
+            action("event-map", ctx -> {
+                EventViewService.EventDetails details = resolveEventDetails(eventViewService, ctx.state().eventId);
+                if (details != null && details.map() != null && details.map().id != null) {
+                    ctx.openRoute(MenuRoute.of("map.details").withParam("mapId", details.map().id.toHexString()));
+                }
+            });
         }
 
         @Override
@@ -289,11 +256,6 @@ final class EventFlows {
             String eventId = route.param("eventId");
             state.eventId = eventId == null ? "" : eventId;
             return state;
-        }
-
-        @Override
-        public Class<EventState> stateType() {
-            return EventState.class;
         }
 
         @Override
@@ -311,41 +273,37 @@ final class EventFlows {
             String yes = session.locale().t("yes");
             String no = session.locale().t("no");
 
-            List<List<MenuButton>> rows = new ArrayList<>();
             Boolean currentVote = session.data.eventVotes.get(event.id.toString());
             String likeTxt = Boolean.TRUE.equals(currentVote) ? session.locale().t("map-vote-like-selected") : session.locale().t("map-vote-like");
             String dislikeTxt = Boolean.FALSE.equals(currentVote) ? session.locale().t("map-vote-dislike-selected") : session.locale().t("map-vote-dislike");
-            rows.add(List.of(
-                    MenuButton.of(likeTxt, ACTION_LIKE),
-                    MenuButton.of(dislikeTxt, ACTION_DISLIKE)
-            ));
+
+            var grid = new MenuGrid();
+            grid.row(
+                    MenuButton.of(likeTxt, "like"),
+                    MenuButton.of(dislikeTxt, "dislike")
+            );
 
             if (!voteService.isVoting()) {
                 List<MenuButton> voteRow = new ArrayList<>();
-                voteRow.add(MenuButton.of(session.locale().t("event-vote"), ACTION_VOTE));
+                voteRow.add(MenuButton.of(session.locale().t("event-vote"), "vote"));
                 if (session.player.admin) {
-                    voteRow.add(MenuButton.of(session.locale().t("event-avote"), ACTION_ADMIN_VOTE));
+                    voteRow.add(MenuButton.of(session.locale().t("event-avote"), "admin-vote"));
                 }
-                rows.add(voteRow);
+                grid.row(voteRow.toArray(new MenuButton[0]));
             }
 
             boolean isOwner = session.data.id != null && session.data.id.equals(event.author);
             if (!event.isFinished && !event.isActive && (!event.isMajor || session.player.admin) && (isOwner || session.player.admin)) {
-                rows.add(List.of(MenuButton.of(session.locale().t("event-menu-edit"), ACTION_EDIT)));
+                grid.row(MenuButton.of(session.locale().t("event-menu-edit"), "edit"));
             }
 
-            rows.add(List.of(MenuButton.of(session.locale().t("event-menu-events"), ACTION_EVENTS)));
+            grid.row(MenuButton.of(session.locale().t("event-menu-events"), "events"));
 
             if (mapData != null) {
-                rows.add(List.of(MenuButton.of(session.locale().t("event-menu-event-map"), ACTION_EVENT_MAP)));
+                grid.row(MenuButton.of(session.locale().t("event-menu-event-map"), "event-map"));
             }
 
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack()) {
-                navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
-            rows.add(navigation);
+            grid.defaultNavigation(session, session.locale());
 
             return MenuScreen.normal(
                     session.locale().t("event-menu-event-title"),
@@ -364,54 +322,22 @@ final class EventFlows {
                             "like", event.like,
                             "dislike", event.dislike
                     )),
-                    rows
+                    grid.build()
             );
         }
 
         @Override
         public void onAction(MenuRenderContext<EventState> context, String actionId) {
-            Session session = context.session();
             EventViewService.EventDetails details = resolveEventDetails(eventViewService, context.state().eventId);
             if (details == null || details.event() == null) {
-                switch (actionId) {
-                    case ACTION_BACK -> context.goBack();
-                    case ACTION_CLOSE -> context.close();
-                    default -> {
-                    }
+                if ("back".equals(actionId)) {
+                    context.goBack();
+                } else if ("close".equals(actionId)) {
+                    context.close();
                 }
                 return;
             }
-
-            EventData event = details.event();
-            MapData mapData = details.map();
-            String uuid = menu.getUuid(session);
-
-            switch (actionId) {
-                case ACTION_LIKE -> {
-                    eventService.handleReputation(session.player, true, event);
-                    context.render();
-                }
-                case ACTION_DISLIKE -> {
-                    eventService.handleReputation(session.player, false, event);
-                    context.render();
-                }
-                case ACTION_VOTE -> eventService.startVoteSession(session.player, event, false);
-                case ACTION_ADMIN_VOTE -> eventService.startVoteSession(session.player, event, true);
-                case ACTION_EDIT -> {
-                    session.setDraft(EventData.class, event);
-                    menu.edit(uuid);
-                }
-                case ACTION_EVENTS -> context.openRoute(MenuRoute.of(ROUTE_EVENTS).withParam("page", "1"));
-                case ACTION_EVENT_MAP -> {
-                    if (mapData != null && mapData.id != null) {
-                        context.openRoute(MenuRoute.of("map.details").withParam("mapId", mapData.id.toHexString()));
-                    }
-                }
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                default -> {
-                }
-            }
+            super.onAction(context, actionId);
         }
     }
 
@@ -425,16 +351,12 @@ final class EventFlows {
     }
 
     static MenuScreen eventNotFoundScreen(Session session) {
-        List<MenuButton> navigation = new ArrayList<>();
-        if (session.canGoBack()) {
-            navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
-        }
-        navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
-
+        var grid = new MenuGrid();
+        grid.defaultNavigation(session, session.locale());
         return MenuScreen.normal(
                 session.locale().t("event-menu-event-title"),
                 session.locale().t("error-internal"),
-                List.of(navigation)
+                grid.build()
         );
     }
 

--- a/src/main/java/org/xcore/plugin/ui/menu/HelpFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/HelpFlows.java
@@ -3,13 +3,14 @@ package org.xcore.plugin.ui.menu;
 import org.xcore.plugin.cloud.XCoreSender;
 import org.xcore.plugin.common.CustomGatherers;
 import org.xcore.plugin.session.Session;
+import org.xcore.plugin.ui.flow.BaseMenuFlow;
 import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuGrid;
 import org.xcore.plugin.ui.flow.MenuRenderContext;
 import org.xcore.plugin.ui.flow.MenuScreen;
+import org.xcore.plugin.ui.flow.NoState;
 import org.xcore.plugin.ui.route.MenuRoute;
-import org.xcore.plugin.ui.route.RoutedMenuFlow;
 
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
@@ -20,41 +21,38 @@ final class HelpFlows {
     static final String ROUTE_LIST = "help.list";
     static final String ROUTE_DETAILS = "help.details";
 
-    private static final String ACTION_PREVIOUS = "previous";
-    private static final String ACTION_NEXT = "next";
-    private static final String ACTION_BACK = "back";
-    private static final String ACTION_CLOSE = "close";
-    private static final String CMD_PREFIX = "cmd:";
-
     private static final int MAX_DESC_LEN = 40;
 
     private HelpFlows() {
     }
 
-    static final class HelpListFlow implements RoutedMenuFlow<HelpListState> {
+    static final class HelpListFlow extends BaseMenuFlow<NoState> {
         private final HelpMenu menu;
 
         HelpListFlow(HelpMenu menu) {
+            super(ROUTE_LIST, NoState.class);
             this.menu = menu;
+
+            action("previous", ctx -> {
+                int currentPage = ctx.route().intParam("page", 1);
+                ctx.session().menuService.renderRoute(ctx.session(),
+                        MenuRoute.of(ROUTE_LIST).withParam("page", String.valueOf(currentPage - 1)));
+            });
+            action("next", ctx -> {
+                int currentPage = ctx.route().intParam("page", 1);
+                ctx.session().menuService.renderRoute(ctx.session(),
+                        MenuRoute.of(ROUTE_LIST).withParam("page", String.valueOf(currentPage + 1)));
+            });
+            actionPrefix("cmd:", (ctx, cmdName) -> {
+                int currentPage = ctx.route().intParam("page", 1);
+                ctx.openRoute(MenuRoute.of(ROUTE_DETAILS)
+                        .withParam("cmd", cmdName)
+                        .withParam("returnPage", String.valueOf(currentPage)));
+            });
         }
 
         @Override
-        public String routeId() {
-            return ROUTE_LIST;
-        }
-
-        @Override
-        public HelpListState createState(Session session, MenuRoute route, HelpListState currentState) {
-            return currentState == null ? new HelpListState() : currentState;
-        }
-
-        @Override
-        public Class<HelpListState> stateType() {
-            return HelpListState.class;
-        }
-
-        @Override
-        public MenuScreen render(MenuRenderContext<HelpListState> context) {
+        public MenuScreen render(MenuRenderContext<NoState> context) {
             Session session = context.session();
             XCoreSender sender = session.sender;
             if (sender == null) {
@@ -76,18 +74,8 @@ final class HelpFlows {
             List<HelpMenu.UnifiedCommand> pageSlice = allCommands.subList(skip, Math.min(skip + menu.globalConfig.commandsPerPage, allCommands.size()));
 
             var local = context.locale();
-            List<List<MenuButton>> rows = new ArrayList<>();
-
-            List<MenuButton> paginationRow = new ArrayList<>();
-            if (currentPage > 1) {
-                paginationRow.add(MenuButton.of(local.t("previous"), ACTION_PREVIOUS));
-            }
-            if (currentPage < pagination.totalPages()) {
-                paginationRow.add(MenuButton.of(local.t("next"), ACTION_NEXT));
-            }
-            if (!paginationRow.isEmpty()) {
-                rows.add(paginationRow);
-            }
+            var grid = new MenuGrid()
+                    .pagination(currentPage, pagination.totalPages(), "previous", "next", local);
 
             for (HelpMenu.UnifiedCommand cmd : pageSlice) {
                 String desc = menu.resolveDescription(session, cmd);
@@ -95,71 +83,29 @@ final class HelpFlows {
                         "command", menu.formatCommandLabel(session, cmd),
                         "description", menu.truncate(desc, MAX_DESC_LEN)
                 ));
-                rows.add(List.of(MenuButton.of(btnText, CMD_PREFIX + cmd.name())));
+                grid.row(MenuButton.of(btnText, "cmd:" + cmd.name()));
             }
 
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack()) {
-                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
-            rows.add(navigation);
+            grid.defaultNavigation(session, local);
 
             return MenuScreen.normal(
                     local.t("help-menu-title"),
                     local.t("help-menu-content", args("page", currentPage, "total", pagination.totalPages())),
-                    rows
+                    grid.build()
             );
-        }
-
-        @Override
-        public void onAction(MenuRenderContext<HelpListState> context, String actionId) {
-            Session session = context.session();
-            int currentPage = context.route().intParam("page", 1);
-
-            switch (actionId) {
-                case ACTION_PREVIOUS -> session.menuService.renderRoute(session,
-                        MenuRoute.of(ROUTE_LIST).withParam("page", String.valueOf(currentPage - 1)));
-                case ACTION_NEXT -> session.menuService.renderRoute(session,
-                        MenuRoute.of(ROUTE_LIST).withParam("page", String.valueOf(currentPage + 1)));
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                default -> {
-                    if (actionId.startsWith(CMD_PREFIX)) {
-                        String cmdName = actionId.substring(CMD_PREFIX.length());
-                        context.openRoute(MenuRoute.of(ROUTE_DETAILS)
-                                .withParam("cmd", cmdName)
-                                .withParam("returnPage", String.valueOf(currentPage)));
-                    }
-                }
-            }
         }
     }
 
-    static final class HelpDetailsFlow implements RoutedMenuFlow<HelpDetailsState> {
+    static final class HelpDetailsFlow extends BaseMenuFlow<NoState> {
         private final HelpMenu menu;
 
         HelpDetailsFlow(HelpMenu menu) {
+            super(ROUTE_DETAILS, NoState.class);
             this.menu = menu;
         }
 
         @Override
-        public String routeId() {
-            return ROUTE_DETAILS;
-        }
-
-        @Override
-        public HelpDetailsState createState(Session session, MenuRoute route, HelpDetailsState currentState) {
-            return currentState == null ? new HelpDetailsState() : currentState;
-        }
-
-        @Override
-        public Class<HelpDetailsState> stateType() {
-            return HelpDetailsState.class;
-        }
-
-        @Override
-        public MenuScreen render(MenuRenderContext<HelpDetailsState> context) {
+        public MenuScreen render(MenuRenderContext<NoState> context) {
             Session session = context.session();
             XCoreSender sender = session.sender;
             String cmdName = context.route().param("cmd");
@@ -178,7 +124,7 @@ final class HelpFlows {
                 return MenuScreen.normal(
                         session.locale().t("help-menu-title"),
                         session.locale().t("error-command-not-found"),
-                        List.of(List.of(MenuButton.of(session.locale().t("back"), ACTION_BACK)))
+                        List.of(List.of(MenuButton.of(session.locale().t("back"), "back")))
                 );
             }
 
@@ -186,39 +132,19 @@ final class HelpFlows {
             String content = menu.buildCommandContent(session, cmd);
             var local = context.locale();
 
-            List<List<MenuButton>> rows = new ArrayList<>();
-            rows.add(List.of(MenuButton.of(local.t("help-back"), ACTION_BACK)));
+            var grid = new MenuGrid()
+                    .row(MenuButton.of(local.t("help-back"), "back"))
+                    .defaultNavigation(session, local);
 
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack()) {
-                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
-            rows.add(navigation);
-
-            return MenuScreen.normal(title, content, rows);
+            return MenuScreen.normal(title, content, grid.build());
         }
-
-        @Override
-        public void onAction(MenuRenderContext<HelpDetailsState> context, String actionId) {
-            switch (actionId) {
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-            }
-        }
-    }
-
-    static final class HelpListState {
-    }
-
-    static final class HelpDetailsState {
     }
 
     private static MenuScreen errorScreen(Session session) {
         return MenuScreen.normal(
                 session.locale().t("help-menu-title"),
                 "",
-                List.of(List.of(MenuButton.of(session.locale().t("close"), ACTION_CLOSE)))
+                List.of(List.of(MenuButton.of(session.locale().t("close"), "close")))
         );
     }
 }

--- a/src/main/java/org/xcore/plugin/ui/menu/InformationMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/InformationMenu.java
@@ -9,15 +9,14 @@ import org.xcore.plugin.config.Config;
 import org.xcore.plugin.config.GlobalConfig;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.MenuService;
+import org.xcore.plugin.ui.flow.BaseMenuFlow;
 import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuGrid;
 import org.xcore.plugin.ui.flow.MenuRenderContext;
 import org.xcore.plugin.ui.flow.MenuScreen;
-import org.xcore.plugin.ui.MenuService;
+import org.xcore.plugin.ui.flow.NoState;
 import org.xcore.plugin.ui.route.MenuRoute;
-import org.xcore.plugin.ui.route.RoutedMenuFlow;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static com.ospx.flubundle.Bundle.args;
 
@@ -25,19 +24,6 @@ import static com.ospx.flubundle.Bundle.args;
 public class InformationMenu extends Menu {
     private static final String ROUTE_MAIN = "information.main";
     private static final String ROUTE_INFORMATION = "information.info";
-    private static final String ACTION_INFORMATION = "information";
-    private static final String ACTION_HELP = "help";
-    private static final String ACTION_MAPS = "maps";
-    private static final String ACTION_PLAYERS = "players";
-    private static final String ACTION_EVENT_MAIN = "event-main";
-    private static final String ACTION_EVENT_LIST = "event-list";
-    private static final String ACTION_DISCORD = "discord";
-    private static final String ACTION_GITHUB = "github";
-    private static final String ACTION_DONATELLO = "donatello";
-    private static final String ACTION_WEBLATE = "weblate";
-    private static final String ACTION_DISCORD_RED_VS_BLUE = "discord-red-vs-blue";
-    private static final String ACTION_BACK = "back";
-    private static final String ACTION_CLOSE = "close";
 
     private final BuildInfo buildInfo;
     private final MenuService menuService;
@@ -46,7 +32,6 @@ public class InformationMenu extends Menu {
     private final Provider<EventMenu> event;
     private final Provider<HelpMenu> help;
     private final Provider<PlayerMenu> player;
-
 
     @Inject
     public InformationMenu(Config config, GlobalConfig globalConfig, SessionService sessionService,
@@ -83,75 +68,44 @@ public class InformationMenu extends Menu {
         session.menuService.renderRoute(session, MenuRoute.of(ROUTE_INFORMATION));
     }
 
-    private final class MainFlow implements RoutedMenuFlow<MainState> {
-        @Override
-        public String routeId() {
-            return ROUTE_MAIN;
+    private final class MainFlow extends BaseMenuFlow<NoState> {
+        MainFlow() {
+            super(ROUTE_MAIN, NoState.class);
+            action("information", ctx -> ctx.openRoute(MenuRoute.of(ROUTE_INFORMATION)));
+            action("help", ctx -> openRoutedFromMain(ctx, () -> help.get().help(getUuid(ctx.session()), 1)));
+            action("maps", ctx -> openRoutedFromMain(ctx, () -> map.get().maps(getUuid(ctx.session()), 1)));
+            action("players", ctx -> openRoutedFromMain(ctx, () -> player.get().players(getUuid(ctx.session()), 1)));
+            action("event-main", ctx -> openRoutedFromMain(ctx, () -> event.get().main(getUuid(ctx.session()))));
+            action("event-list", ctx -> openRoutedFromMain(ctx, () -> event.get().events(getUuid(ctx.session()), 1)));
         }
 
         @Override
-        public MainState createState(Session session, MenuRoute route, MainState currentState) {
-            return currentState == null ? new MainState() : currentState;
-        }
-
-        @Override
-        public Class<MainState> stateType() {
-            return MainState.class;
-        }
-
-        @Override
-        public MenuScreen render(MenuRenderContext<MainState> context) {
+        public MenuScreen render(MenuRenderContext<NoState> context) {
             var local = context.locale();
-            List<List<MenuButton>> rows = new ArrayList<>();
-            rows.add(List.of(
-                    MenuButton.of(local.t("commands-info"), ACTION_INFORMATION),
-                    MenuButton.of(local.t("help-menu"), ACTION_HELP)
-            ));
-            rows.add(List.of(
-                    MenuButton.of(local.t("map-maps"), ACTION_MAPS),
-                    MenuButton.of(local.t("player-menu-players"), ACTION_PLAYERS)
-            ));
-
+            var grid = new MenuGrid()
+                    .row(
+                            MenuButton.of(local.t("commands-info"), "information"),
+                            MenuButton.of(local.t("help-menu"), "help")
+                    )
+                    .row(
+                            MenuButton.of(local.t("map-maps"), "maps"),
+                            MenuButton.of(local.t("player-menu-players"), "players")
+                    );
             if (config.isEvent()) {
-                rows.add(List.of(
-                        MenuButton.of(local.t("event-menu-main"), ACTION_EVENT_MAIN),
-                        MenuButton.of(local.t("event-events"), ACTION_EVENT_LIST)
-                ));
+                grid.row(
+                        MenuButton.of(local.t("event-menu-main"), "event-main"),
+                        MenuButton.of(local.t("event-events"), "event-list")
+                );
             }
-
-            List<MenuButton> navigation = new ArrayList<>();
-            if (context.session().canGoBack()) {
-                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
-            rows.add(navigation);
-
+            grid.defaultNavigation(context.session(), local);
             return MenuScreen.normal(
                     local.t("menu-main-title"),
                     local.t("menu-main-content"),
-                    rows
+                    grid.build()
             );
         }
 
-        @Override
-        public void onAction(MenuRenderContext<MainState> context, String actionId) {
-            Session session = context.session();
-            String uuid = getUuid(session);
-            switch (actionId) {
-                case ACTION_INFORMATION -> context.openRoute(MenuRoute.of(ROUTE_INFORMATION));
-                case ACTION_HELP -> openRoutedFromMain(context, () -> help.get().help(uuid, 1));
-                case ACTION_MAPS -> openRoutedFromMain(context, () -> map.get().maps(uuid, 1));
-                case ACTION_PLAYERS -> openRoutedFromMain(context, () -> player.get().players(uuid, 1));
-                case ACTION_EVENT_MAIN -> openRoutedFromMain(context, () -> event.get().main(uuid));
-                case ACTION_EVENT_LIST -> openRoutedFromMain(context, () -> event.get().events(uuid, 1));
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                default -> {
-                }
-            }
-        }
-
-        private void openRoutedFromMain(MenuRenderContext<MainState> context, Runnable action) {
+        private void openRoutedFromMain(MenuRenderContext<NoState> context, Runnable action) {
             Session session = context.session();
             if (context.route() != null) {
                 session.pushRouteHistory(context.route());
@@ -160,75 +114,39 @@ public class InformationMenu extends Menu {
         }
     }
 
-    private final class InformationFlow implements RoutedMenuFlow<InformationState> {
-        @Override
-        public String routeId() {
-            return ROUTE_INFORMATION;
+    private final class InformationFlow extends BaseMenuFlow<NoState> {
+        InformationFlow() {
+            super(ROUTE_INFORMATION, NoState.class);
+            action("discord", ctx -> openUrl(ctx.session(), globalConfig.discordUrl));
+            action("github", ctx -> openUrl(ctx.session(), globalConfig.githubUrl));
+            action("donatello", ctx -> openUrl(ctx.session(), globalConfig.donatelloUrl));
+            action("weblate", ctx -> openUrl(ctx.session(), globalConfig.weblateUrl));
+            action("discord-red-vs-blue", ctx -> openUrl(ctx.session(), globalConfig.discordRedVSBlueUrl));
         }
 
         @Override
-        public InformationState createState(Session session, MenuRoute route, InformationState currentState) {
-            return currentState == null ? new InformationState() : currentState;
-        }
-
-        @Override
-        public Class<InformationState> stateType() {
-            return InformationState.class;
-        }
-
-        @Override
-        public MenuScreen render(MenuRenderContext<InformationState> context) {
-            Session session = context.session();
+        public MenuScreen render(MenuRenderContext<NoState> context) {
             var local = context.locale();
-            List<List<MenuButton>> rows = new ArrayList<>();
-            rows.add(List.of(
-                    MenuButton.of(local.t("discord"), ACTION_DISCORD),
-                    MenuButton.of(local.t("github"), ACTION_GITHUB)
-            ));
-            rows.add(List.of(
-                    MenuButton.of(local.t("donatello"), ACTION_DONATELLO),
-                    MenuButton.of(local.t("weblate"), ACTION_WEBLATE)
-            ));
-            rows.add(List.of(MenuButton.of(local.t("discord-red-vs-blue"), ACTION_DISCORD_RED_VS_BLUE)));
-
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack()) {
-                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
-            rows.add(navigation);
-
+            var grid = new MenuGrid()
+                    .row(
+                            MenuButton.of(local.t("discord"), "discord"),
+                            MenuButton.of(local.t("github"), "github")
+                    )
+                    .row(
+                            MenuButton.of(local.t("donatello"), "donatello"),
+                            MenuButton.of(local.t("weblate"), "weblate")
+                    )
+                    .row(MenuButton.of(local.t("discord-red-vs-blue"), "discord-red-vs-blue"))
+                    .defaultNavigation(context.session(), local);
             return MenuScreen.followUp(
                     local.t("commands-info-title", args("server-name", config.server)),
                     local.t("commands-info-text", args("version", buildInfo.getVersion())),
-                    rows
+                    grid.build()
             );
-        }
-
-        @Override
-        public void onAction(MenuRenderContext<InformationState> context, String actionId) {
-            Session session = context.session();
-            switch (actionId) {
-                case ACTION_DISCORD -> openUrl(session, globalConfig.discordUrl);
-                case ACTION_GITHUB -> openUrl(session, globalConfig.githubUrl);
-                case ACTION_DONATELLO -> openUrl(session, globalConfig.donatelloUrl);
-                case ACTION_WEBLATE -> openUrl(session, globalConfig.weblateUrl);
-                case ACTION_DISCORD_RED_VS_BLUE -> openUrl(session, globalConfig.discordRedVSBlueUrl);
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                default -> {
-                }
-            }
         }
 
         private void openUrl(Session session, String url) {
             session.menuService.openUri(session, url);
         }
-    }
-
-    public static final class InformationState {
-    }
-
-    public static final class MainState {
     }
 }

--- a/src/main/java/org/xcore/plugin/ui/menu/MapFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/MapFlows.java
@@ -12,11 +12,12 @@ import org.xcore.plugin.model.MapData;
 import org.xcore.plugin.model.enums.Feature;
 import org.xcore.plugin.service.MapService;
 import org.xcore.plugin.session.Session;
+import org.xcore.plugin.ui.flow.BaseMenuFlow;
 import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuGrid;
 import org.xcore.plugin.ui.flow.MenuRenderContext;
 import org.xcore.plugin.ui.flow.MenuScreen;
 import org.xcore.plugin.ui.route.MenuRoute;
-import org.xcore.plugin.ui.route.RoutedMenuFlow;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,45 +30,57 @@ final class MapFlows {
     static final String ROUTE_MAP = "map.details";
     static final String ROUTE_MAPS = "map.maps";
 
-    private static final String ACTION_LIKE = "like";
-    private static final String ACTION_DISLIKE = "dislike";
-    private static final String ACTION_RTV = "rtv";
-    private static final String ACTION_ADMIN_RTV = "admin-rtv";
-    private static final String ACTION_MAPS = "maps";
-    private static final String ACTION_CREATE_START = "create-start";
-    private static final String ACTION_PREVIOUS = "previous";
-    private static final String ACTION_NEXT = "next";
-    private static final String ACTION_BACK = "back";
-    private static final String ACTION_CLOSE = "close";
-    private static final String ACTION_MAP_PREFIX = "map-";
-
     private MapFlows() {
     }
 
-    static final class MapsFlow implements RoutedMenuFlow<MapsState> {
+    static final class MapsFlow extends BaseMenuFlow<MapsState> {
         private final MapMenu menu;
         private final MapDataRepository mapDataRepository;
         private final MapService mapService;
 
         MapsFlow(MapMenu menu, MapDataRepository mapDataRepository, MapService mapService) {
+            super(ROUTE_MAPS, MapsState.class);
             this.menu = menu;
             this.mapDataRepository = mapDataRepository;
             this.mapService = mapService;
-        }
 
-        @Override
-        public String routeId() {
-            return ROUTE_MAPS;
+            action("previous", ctx -> {
+                Session session = ctx.session();
+                int page = ctx.route().intParam("page", 1);
+                session.menuService.renderRoute(session,
+                        MenuRoute.of(ROUTE_MAPS).withParam("page", String.valueOf(page - 1)));
+            });
+            action("next", ctx -> {
+                Session session = ctx.session();
+                int page = ctx.route().intParam("page", 1);
+                session.menuService.renderRoute(session,
+                        MenuRoute.of(ROUTE_MAPS).withParam("page", String.valueOf(page + 1)));
+            });
+            actionPrefix("map:", (ctx, indexStr) -> {
+                int index = Integer.parseInt(indexStr);
+                Session session = ctx.session();
+                int page = ctx.route().intParam("page", 1);
+                Seq<Map> availableMaps = mapService.getAvailableMaps();
+                var pagination = CustomGatherers.calculatePagination(availableMaps.size, menu.globalConfig.mapsPerPage);
+                int validPage = pagination.clampPage(page);
+                String gameMode = state.rules.mode().name();
+                List<Map> pageMaps = SeqStream.of(availableMaps)
+                        .gather(CustomGatherers.page(menu.globalConfig.mapsPerPage, validPage))
+                        .flatMap(List::stream)
+                        .toList();
+                if (index >= 0 && index < pageMaps.size()) {
+                    Map map = pageMaps.get(index);
+                    MapData data = mapDataRepository.findOrCreate(map.plainName(), map.file.name(), map.author(), gameMode);
+                    if (data != null && data.id != null) {
+                        ctx.openRoute(MenuRoute.of(ROUTE_MAP).withParam("mapId", data.id.toHexString()));
+                    }
+                }
+            });
         }
 
         @Override
         public MapsState createState(Session session, MenuRoute route, MapsState currentState) {
             return currentState == null ? new MapsState() : currentState;
-        }
-
-        @Override
-        public Class<MapsState> stateType() {
-            return MapsState.class;
         }
 
         @Override
@@ -82,7 +95,7 @@ final class MapFlows {
                 return MenuScreen.normal(
                         session.locale().t("commands-maps-title"),
                         "",
-                        List.of(List.of(MenuButton.of(session.locale().t("close"), ACTION_CLOSE)))
+                        new MenuGrid().row(MenuButton.of(session.locale().t("close"), "close")).build()
                 );
             }
 
@@ -93,90 +106,82 @@ final class MapFlows {
                     .toList();
 
             var local = context.locale();
-            List<List<MenuButton>> rows = new ArrayList<>();
+            var grid = new MenuGrid();
 
             List<MenuButton> paginationRow = new ArrayList<>();
             if (validPage > 1) {
-                paginationRow.add(MenuButton.of(local.t("previous"), ACTION_PREVIOUS));
+                paginationRow.add(MenuButton.of(local.t("previous"), "previous"));
             }
             if (validPage < pagination.totalPages()) {
-                paginationRow.add(MenuButton.of(local.t("next"), ACTION_NEXT));
+                paginationRow.add(MenuButton.of(local.t("next"), "next"));
             }
             if (!paginationRow.isEmpty()) {
-                rows.add(paginationRow);
+                grid.row(paginationRow.toArray(new MenuButton[0]));
             }
 
             for (int i = 0; i < pageMaps.size(); i++) {
                 Map map = pageMaps.get(i);
-                rows.add(List.of(MenuButton.of(map.name(), ACTION_MAP_PREFIX + i)));
+                grid.row(MenuButton.of(map.name(), "map:" + i));
             }
 
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack()) {
-                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
-            rows.add(navigation);
+            grid.defaultNavigation(session, local);
 
             return MenuScreen.normal(
                     local.t("commands-maps-title"),
                     local.t("commands-maps-content", args("page", validPage, "total", pagination.totalPages())),
-                    rows
+                    grid.build()
             );
-        }
-
-        @Override
-        public void onAction(MenuRenderContext<MapsState> context, String actionId) {
-            Session session = context.session();
-            int page = context.route().intParam("page", 1);
-
-            switch (actionId) {
-                case ACTION_PREVIOUS -> session.menuService.renderRoute(session,
-                        MenuRoute.of(ROUTE_MAPS).withParam("page", String.valueOf(page - 1)));
-                case ACTION_NEXT -> session.menuService.renderRoute(session,
-                        MenuRoute.of(ROUTE_MAPS).withParam("page", String.valueOf(page + 1)));
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                default -> {
-                    if (actionId.startsWith(ACTION_MAP_PREFIX)) {
-                        int index = Integer.parseInt(actionId.substring(ACTION_MAP_PREFIX.length()));
-                        Seq<Map> availableMaps = mapService.getAvailableMaps();
-                        var pagination = CustomGatherers.calculatePagination(availableMaps.size, menu.globalConfig.mapsPerPage);
-                        int validPage = pagination.clampPage(page);
-                        String gameMode = state.rules.mode().name();
-                        List<Map> pageMaps = SeqStream.of(availableMaps)
-                                .gather(CustomGatherers.page(menu.globalConfig.mapsPerPage, validPage))
-                                .flatMap(List::stream)
-                                .toList();
-                        if (index >= 0 && index < pageMaps.size()) {
-                            Map map = pageMaps.get(index);
-                            MapData data = mapDataRepository.findOrCreate(map.plainName(), map.file.name(), map.author(), gameMode);
-                            if (data != null && data.id != null) {
-                                context.openRoute(MenuRoute.of(ROUTE_MAP).withParam("mapId", data.id.toHexString()));
-                            }
-                        }
-                    }
-                }
-            }
         }
     }
 
-    static final class MapFlow implements RoutedMenuFlow<MapState> {
+    static final class MapFlow extends BaseMenuFlow<MapState> {
         private final MapMenu menu;
         private final Config config;
         private final EventDataRepository eventDataRepository;
         private final MapService mapService;
 
         MapFlow(MapMenu menu, Config config, EventDataRepository eventDataRepository, MapService mapService) {
+            super(ROUTE_MAP, MapState.class);
             this.menu = menu;
             this.config = config;
             this.eventDataRepository = eventDataRepository;
             this.mapService = mapService;
-        }
 
-        @Override
-        public String routeId() {
-            return ROUTE_MAP;
+            action("like", ctx -> {
+                MapData mapData = menu.resolveMap(ctx.state().mapId);
+                if (mapData != null) {
+                    mapService.handleReputation(ctx.session().player, true, mapData);
+                    ctx.render();
+                }
+            });
+            action("dislike", ctx -> {
+                MapData mapData = menu.resolveMap(ctx.state().mapId);
+                if (mapData != null) {
+                    mapService.handleReputation(ctx.session().player, false, mapData);
+                    ctx.render();
+                }
+            });
+            action("rtv", ctx -> {
+                MapData mapData = menu.resolveMap(ctx.state().mapId);
+                if (mapData != null) {
+                    Map mindustryMap = mapService.findPersistedMap(mapData);
+                    mapService.startRtvSession(ctx.session().player, mindustryMap, true, false);
+                }
+            });
+            action("admin-rtv", ctx -> {
+                MapData mapData = menu.resolveMap(ctx.state().mapId);
+                if (mapData != null) {
+                    Map mindustryMap = mapService.findPersistedMap(mapData);
+                    mapService.startRtvSession(ctx.session().player, mindustryMap, true, true);
+                }
+            });
+            action("maps", ctx -> ctx.openRoute(MenuRoute.of(ROUTE_MAPS).withParam("page", "1")));
+            action("create-start", ctx -> {
+                MapData mapData = menu.resolveMap(ctx.state().mapId);
+                if (mapData != null) {
+                    menu.eventMenu.get().createStart(menu.getUuid(ctx.session()), mapData);
+                }
+            });
         }
 
         @Override
@@ -185,11 +190,6 @@ final class MapFlows {
             String mapId = route.param("mapId");
             state.mapId = mapId == null ? "" : mapId;
             return state;
-        }
-
-        @Override
-        public Class<MapState> stateType() {
-            return MapState.class;
         }
 
         @Override
@@ -211,35 +211,30 @@ final class MapFlows {
             String likeTxt = Boolean.TRUE.equals(currentVote) ? session.locale().t("map-vote-like-selected") : session.locale().t("map-vote-like");
             String dislikeTxt = Boolean.FALSE.equals(currentVote) ? session.locale().t("map-vote-dislike-selected") : session.locale().t("map-vote-dislike");
 
-            List<List<MenuButton>> rows = new ArrayList<>();
-            rows.add(List.of(
-                    MenuButton.of(likeTxt, ACTION_LIKE),
-                    MenuButton.of(dislikeTxt, ACTION_DISLIKE)
-            ));
+            var grid = new MenuGrid();
+            grid.row(
+                    MenuButton.of(likeTxt, "like"),
+                    MenuButton.of(dislikeTxt, "dislike")
+            );
 
             EventData activeEvent = eventDataRepository.findActive().orElse(null);
             boolean rtvEnabled = !config.isFeatureDisabled(Feature.RTV);
             if (rtvEnabled && (!config.isEvent() || (activeEvent == null || !activeEvent.isActive) || activeEvent.map.equals(mapData.id))) {
                 List<MenuButton> rtvRow = new ArrayList<>();
-                rtvRow.add(MenuButton.of(session.locale().t("map-rtv"), ACTION_RTV));
+                rtvRow.add(MenuButton.of(session.locale().t("map-rtv"), "rtv"));
                 if (session.player.admin) {
-                    rtvRow.add(MenuButton.of(session.locale().t("map-artv"), ACTION_ADMIN_RTV));
+                    rtvRow.add(MenuButton.of(session.locale().t("map-artv"), "admin-rtv"));
                 }
-                rows.add(rtvRow);
+                grid.row(rtvRow.toArray(new MenuButton[0]));
             }
 
-            rows.add(List.of(MenuButton.of(session.locale().t("map-maps"), ACTION_MAPS)));
+            grid.row(MenuButton.of(session.locale().t("map-maps"), "maps"));
 
             if (config.isEvent()) {
-                rows.add(List.of(MenuButton.of(session.locale().t("event-menu-create-start-map"), ACTION_CREATE_START)));
+                grid.row(MenuButton.of(session.locale().t("event-menu-create-start-map"), "create-start"));
             }
 
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack()) {
-                navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
-            rows.add(navigation);
+            grid.defaultNavigation(session, session.locale());
 
             return MenuScreen.normal(
                     session.locale().t("commands-map-title"),
@@ -253,44 +248,8 @@ final class MapFlows {
                             "like", mapData.like, "dislike", mapData.dislike,
                             "min", mapData.minimumGameTime / 60000, "avg", mapData.averageGameTime / 60000, "max", mapData.maximumGameTime / 60000
                     )),
-                    rows
+                    grid.build()
             );
-        }
-
-        @Override
-        public void onAction(MenuRenderContext<MapState> context, String actionId) {
-            Session session = context.session();
-            MapData mapData = menu.resolveMap(context.state().mapId);
-            if (mapData == null) {
-                switch (actionId) {
-                    case ACTION_BACK -> context.goBack();
-                    case ACTION_CLOSE -> context.close();
-                    default -> {
-                    }
-                }
-                return;
-            }
-
-            Map mindustryMap = mapService.findPersistedMap(mapData);
-            String uuid = menu.getUuid(session);
-            switch (actionId) {
-                case ACTION_LIKE -> {
-                    mapService.handleReputation(session.player, true, mapData);
-                    context.render();
-                }
-                case ACTION_DISLIKE -> {
-                    mapService.handleReputation(session.player, false, mapData);
-                    context.render();
-                }
-                case ACTION_RTV -> mapService.startRtvSession(session.player, mindustryMap, true, false);
-                case ACTION_ADMIN_RTV -> mapService.startRtvSession(session.player, mindustryMap, true, true);
-                case ACTION_MAPS -> context.openRoute(MenuRoute.of(ROUTE_MAPS).withParam("page", "1"));
-                case ACTION_CREATE_START -> menu.eventMenu.get().createStart(uuid, mapData);
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                default -> {
-                }
-            }
         }
     }
 

--- a/src/main/java/org/xcore/plugin/ui/menu/MessageFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/MessageFlows.java
@@ -7,15 +7,13 @@ import org.xcore.plugin.model.PrivateMessage;
 import org.xcore.plugin.service.PrivateMessageService;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.flow.BaseMenuFlow;
 import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuGrid;
 import org.xcore.plugin.ui.flow.MenuPrompt;
 import org.xcore.plugin.ui.flow.MenuRenderContext;
 import org.xcore.plugin.ui.flow.MenuScreen;
 import org.xcore.plugin.ui.route.MenuRoute;
-import org.xcore.plugin.ui.route.RoutedMenuFlow;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static com.ospx.flubundle.Bundle.args;
 
@@ -25,18 +23,6 @@ final class MessageFlows {
     static final String ROUTE_BLOCKED = "message.blocked";
     static final String ROUTE_DETAILS = "message.details";
 
-    private static final String ACTION_PREVIOUS = "previous";
-    private static final String ACTION_NEXT = "next";
-    private static final String ACTION_COMPOSE = "compose";
-    private static final String ACTION_BLOCKED = "blocked";
-    private static final String ACTION_BACK = "back";
-    private static final String ACTION_CLOSE = "close";
-    private static final String ACTION_MESSAGE_PREFIX = "message:";
-    private static final String ACTION_UNBLOCK_PREFIX = "unblock:";
-    private static final String ACTION_REPLY = "reply";
-    private static final String ACTION_DELETE = "delete";
-    private static final String ACTION_TOGGLE_BLOCK = "toggle-block";
-
     private static final String PROMPT_REPLY = "private-message-reply";
     private static final String PROMPT_COMPOSE_TARGET = "private-message-compose-target";
     private static final String PROMPT_COMPOSE_BODY = "private-message-compose-body";
@@ -44,18 +30,36 @@ final class MessageFlows {
     private MessageFlows() {
     }
 
-    static final class InboxFlow implements RoutedMenuFlow<InboxState> {
+    static final class InboxFlow extends BaseMenuFlow<InboxState> {
         private final MessageMenu menu;
         private final PrivateMessageService privateMessageService;
 
         InboxFlow(MessageMenu menu, PrivateMessageService privateMessageService) {
+            super(ROUTE_INBOX, InboxState.class);
             this.menu = menu;
             this.privateMessageService = privateMessageService;
-        }
 
-        @Override
-        public String routeId() {
-            return ROUTE_INBOX;
+            action("previous", ctx -> {
+                Session session = ctx.session();
+                int currentPage = Math.max(1, ctx.state().page);
+                session.menuService.renderRoute(session,
+                        MenuRoute.of(ROUTE_INBOX).withParam("page", String.valueOf(currentPage - 1)));
+            });
+            action("next", ctx -> {
+                Session session = ctx.session();
+                int currentPage = Math.max(1, ctx.state().page);
+                session.menuService.renderRoute(session,
+                        MenuRoute.of(ROUTE_INBOX).withParam("page", String.valueOf(currentPage + 1)));
+            });
+            action("compose", ctx -> promptCompose(menu, privateMessageService, menu.getUuid(ctx.session()), ctx::render));
+            action("blocked", ctx -> ctx.openRoute(MenuRoute.of(ROUTE_BLOCKED).withParam("page", "1")));
+            actionPrefix("message:", (ctx, messageIdHex) -> {
+                ObjectId messageId = new ObjectId(messageIdHex);
+                int currentPage = Math.max(1, ctx.state().page);
+                ctx.openRoute(MenuRoute.of(ROUTE_DETAILS)
+                        .withParam("messageId", messageId.toHexString())
+                        .withParam("returnPage", String.valueOf(currentPage)));
+            });
         }
 
         @Override
@@ -63,11 +67,6 @@ final class MessageFlows {
             InboxState state = currentState == null ? new InboxState() : currentState;
             state.page = route.intParam("page", 1);
             return state;
-        }
-
-        @Override
-        public Class<InboxState> stateType() {
-            return InboxState.class;
         }
 
         @Override
@@ -80,19 +79,18 @@ final class MessageFlows {
             var pagination = CustomGatherers.calculatePagination(total, menu.globalConfig.privateMessagesPerPage);
             int validPage = pagination.totalPages() <= 0 ? 1 : pagination.clampPage(requestedPage);
             context.state().page = validPage;
-            List<PrivateMessage> messages = privateMessageService.inbox(session.data.uuid, validPage);
+            java.util.List<PrivateMessage> messages = privateMessageService.inbox(session.data.uuid, validPage);
 
-            List<List<MenuButton>> rows = new ArrayList<>();
-
-            List<MenuButton> pagingRow = new ArrayList<>();
+            var grid = new MenuGrid();
+            var pagingRow = new java.util.ArrayList<MenuButton>();
             if (validPage > 1) {
-                pagingRow.add(MenuButton.of(session.locale().t("previous"), ACTION_PREVIOUS));
+                pagingRow.add(MenuButton.of(session.locale().t("previous"), "previous"));
             }
             if (validPage < Math.max(1, pagination.totalPages())) {
-                pagingRow.add(MenuButton.of(session.locale().t("next"), ACTION_NEXT));
+                pagingRow.add(MenuButton.of(session.locale().t("next"), "next"));
             }
             if (!pagingRow.isEmpty()) {
-                rows.add(pagingRow);
+                grid.row(pagingRow.toArray(new MenuButton[0]));
             }
 
             for (PrivateMessage message : messages) {
@@ -105,20 +103,15 @@ final class MessageFlows {
                                 "time", menu.formatTime(message.createdModelTime, session)
                         )
                 );
-                rows.add(List.of(MenuButton.of(text, ACTION_MESSAGE_PREFIX + message.id.toHexString())));
+                grid.row(MenuButton.of(text, "message:" + message.id.toHexString()));
             }
 
-            rows.add(List.of(
-                    MenuButton.of(session.locale().t("private-message-compose"), ACTION_COMPOSE),
-                    MenuButton.of(session.locale().t("private-message-blocked"), ACTION_BLOCKED)
-            ));
+            grid.row(
+                    MenuButton.of(session.locale().t("private-message-compose"), "compose"),
+                    MenuButton.of(session.locale().t("private-message-blocked"), "blocked")
+            );
 
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack()) {
-                navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
-            rows.add(navigation);
+            grid.defaultNavigation(session, session.locale());
 
             return MenuScreen.normal(
                     session.locale().t("private-message-menu-title"),
@@ -127,49 +120,75 @@ final class MessageFlows {
                             "total", Math.max(1, pagination.totalPages()),
                             "unread", privateMessageService.countUnread(session.data.uuid)
                     )),
-                    rows
+                    grid.build()
             );
-        }
-
-        @Override
-        public void onAction(MenuRenderContext<InboxState> context, String actionId) {
-            Session session = context.session();
-            String uuid = menu.getUuid(session);
-            int currentPage = Math.max(1, context.state().page);
-
-            switch (actionId) {
-                case ACTION_PREVIOUS -> session.menuService.renderRoute(session,
-                        MenuRoute.of(ROUTE_INBOX).withParam("page", String.valueOf(currentPage - 1)));
-                case ACTION_NEXT -> session.menuService.renderRoute(session,
-                        MenuRoute.of(ROUTE_INBOX).withParam("page", String.valueOf(currentPage + 1)));
-                case ACTION_COMPOSE -> promptCompose(menu, privateMessageService, uuid, context::render);
-                case ACTION_BLOCKED -> context.openRoute(MenuRoute.of(ROUTE_BLOCKED).withParam("page", "1"));
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                default -> {
-                    if (actionId.startsWith(ACTION_MESSAGE_PREFIX)) {
-                        ObjectId messageId = new ObjectId(actionId.substring(ACTION_MESSAGE_PREFIX.length()));
-                        context.openRoute(MenuRoute.of(ROUTE_DETAILS)
-                                .withParam("messageId", messageId.toHexString())
-                                .withParam("returnPage", String.valueOf(currentPage)));
-                    }
-                }
-            }
         }
     }
 
-    static final class DetailsFlow implements RoutedMenuFlow<DetailsState> {
+    static final class DetailsFlow extends BaseMenuFlow<DetailsState> {
         private final MessageMenu menu;
         private final PrivateMessageService privateMessageService;
 
         DetailsFlow(MessageMenu menu, PrivateMessageService privateMessageService) {
+            super(ROUTE_DETAILS, DetailsState.class);
             this.menu = menu;
             this.privateMessageService = privateMessageService;
-        }
 
-        @Override
-        public String routeId() {
-            return ROUTE_DETAILS;
+            action("reply", ctx -> {
+                DetailsView view = resolveDetailsView(ctx.session(), ctx.state(), privateMessageService);
+                if (view != null) {
+                    ctx.openPrompt(new MenuPrompt(
+                            PROMPT_REPLY,
+                            ctx.session().locale().t("private-message-reply-title"),
+                            ctx.session().locale().t("private-message-reply-message", args("pid", view.message.fromPid)),
+                            menu.globalConfig.privateMessageMaxLength,
+                            "",
+                            false
+                    ));
+                }
+            });
+            action("delete", ctx -> {
+                Session session = ctx.session();
+                DetailsView view = resolveDetailsView(session, ctx.state(), privateMessageService);
+                if (view == null) {
+                    if (ctx.session().hasRouteHistory()) {
+                        ctx.goBack();
+                    } else {
+                        menu.inbox(menu.getUuid(session), ctx.state().returnPage);
+                    }
+                    return;
+                }
+                privateMessageService.softDelete(view.message.id, session.data.uuid);
+                if (session.hasRouteHistory()) {
+                    ctx.goBack();
+                } else {
+                    menu.inbox(menu.getUuid(session), ctx.state().returnPage);
+                }
+            });
+            action("toggle-block", ctx -> {
+                Session session = ctx.session();
+                DetailsView view = resolveDetailsView(session, ctx.state(), privateMessageService);
+                if (view != null) {
+                    if (view.blocked) {
+                        privateMessageService.unblock(session, view.message.fromPid);
+                    } else {
+                        privateMessageService.block(session, view.message.fromPid);
+                    }
+                    ctx.render();
+                }
+            });
+
+            onPrompt(PROMPT_REPLY,
+                    ctx -> {
+                        Session session = ctx.renderContext().session();
+                        DetailsView view = resolveDetailsView(session, ctx.renderContext().state(), privateMessageService);
+                        if (view != null) {
+                            privateMessageService.send(session, view.message.fromPid, ctx.text());
+                        }
+                        ctx.renderContext().render();
+                    },
+                    ctx -> ctx.render()
+            );
         }
 
         @Override
@@ -181,11 +200,6 @@ final class MessageFlows {
         }
 
         @Override
-        public Class<DetailsState> stateType() {
-            return DetailsState.class;
-        }
-
-        @Override
         public MenuScreen render(MenuRenderContext<DetailsState> context) {
             Session session = context.session();
             DetailsView view = resolveDetailsView(session, context.state(), privateMessageService);
@@ -193,22 +207,16 @@ final class MessageFlows {
                 return notFoundScreen(session);
             }
 
-            List<List<MenuButton>> rows = new ArrayList<>();
-            rows.add(List.of(
-                    MenuButton.of(session.locale().t("reply"), ACTION_REPLY),
-                    MenuButton.of(session.locale().t("delete"), ACTION_DELETE)
-            ));
-            rows.add(List.of(MenuButton.of(
+            var grid = new MenuGrid();
+            grid.row(
+                    MenuButton.of(session.locale().t("reply"), "reply"),
+                    MenuButton.of(session.locale().t("delete"), "delete")
+            );
+            grid.row(MenuButton.of(
                     session.locale().t(view.blocked ? "private-message-unblock" : "private-message-block"),
-                    ACTION_TOGGLE_BLOCK
-            )));
-
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack()) {
-                navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
-            rows.add(navigation);
+                    "toggle-block"
+            ));
+            grid.defaultNavigation(session, session.locale());
 
             return MenuScreen.normal(
                     session.locale().t("private-message-details-title"),
@@ -219,92 +227,37 @@ final class MessageFlows {
                             "message", view.message.message,
                             "status", session.locale().t(view.markedRead || view.message.readAt > 0 ? "private-message-status-read" : "private-message-status-unread")
                     )),
-                    rows
+                    grid.build()
             );
-        }
-
-        @Override
-        public void onAction(MenuRenderContext<DetailsState> context, String actionId) {
-            Session session = context.session();
-            DetailsView view = resolveDetailsView(session, context.state(), privateMessageService);
-            if (view == null) {
-                if (ACTION_BACK.equals(actionId)) {
-                    context.goBack();
-                } else if (ACTION_CLOSE.equals(actionId)) {
-                    context.close();
-                }
-                return;
-            }
-
-            switch (actionId) {
-                case ACTION_REPLY -> context.openPrompt(new MenuPrompt(
-                        PROMPT_REPLY,
-                        session.locale().t("private-message-reply-title"),
-                        session.locale().t("private-message-reply-message", args("pid", view.message.fromPid)),
-                        menu.globalConfig.privateMessageMaxLength,
-                        "",
-                        false
-                ));
-                case ACTION_DELETE -> {
-                    privateMessageService.softDelete(view.message.id, session.data.uuid);
-                    if (session.hasRouteHistory()) {
-                        context.goBack();
-                    } else {
-                        menu.inbox(menu.getUuid(session), context.state().returnPage);
-                    }
-                }
-                case ACTION_TOGGLE_BLOCK -> {
-                    if (view.blocked) {
-                        privateMessageService.unblock(session, view.message.fromPid);
-                    } else {
-                        privateMessageService.block(session, view.message.fromPid);
-                    }
-                    context.render();
-                }
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                default -> {
-                }
-            }
-        }
-
-        @Override
-        public void onPromptSubmit(MenuRenderContext<DetailsState> context, String promptId, String text) {
-            if (!PROMPT_REPLY.equals(promptId)) {
-                return;
-            }
-
-            Session session = context.session();
-            DetailsView view = resolveDetailsView(session, context.state(), privateMessageService);
-            if (view == null) {
-                context.render();
-                return;
-            }
-
-            privateMessageService.send(session, view.message.fromPid, text);
-            context.render();
-        }
-
-        @Override
-        public void onPromptCancel(MenuRenderContext<DetailsState> context, String promptId) {
-            if (PROMPT_REPLY.equals(promptId)) {
-                context.render();
-            }
         }
     }
 
-    static final class BlockedFlow implements RoutedMenuFlow<BlockedState> {
+    static final class BlockedFlow extends BaseMenuFlow<BlockedState> {
         private final MessageMenu menu;
         private final PrivateMessageService privateMessageService;
 
         BlockedFlow(MessageMenu menu, PrivateMessageService privateMessageService) {
+            super(ROUTE_BLOCKED, BlockedState.class);
             this.menu = menu;
             this.privateMessageService = privateMessageService;
-        }
 
-        @Override
-        public String routeId() {
-            return ROUTE_BLOCKED;
+            action("previous", ctx -> {
+                Session session = ctx.session();
+                int currentPage = Math.max(1, ctx.state().page);
+                session.menuService.renderRoute(session,
+                        MenuRoute.of(ROUTE_BLOCKED).withParam("page", String.valueOf(currentPage - 1)));
+            });
+            action("next", ctx -> {
+                Session session = ctx.session();
+                int currentPage = Math.max(1, ctx.state().page);
+                session.menuService.renderRoute(session,
+                        MenuRoute.of(ROUTE_BLOCKED).withParam("page", String.valueOf(currentPage + 1)));
+            });
+            actionPrefix("unblock:", (ctx, pidStr) -> {
+                int pid = Integer.parseInt(pidStr);
+                privateMessageService.unblock(ctx.session(), pid);
+                ctx.render();
+            });
         }
 
         @Override
@@ -315,49 +268,38 @@ final class MessageFlows {
         }
 
         @Override
-        public Class<BlockedState> stateType() {
-            return BlockedState.class;
-        }
-
-        @Override
         public MenuScreen render(MenuRenderContext<BlockedState> context) {
             Session session = context.session();
             int requestedPage = Math.max(1, context.state().page);
 
-            List<PlayerData> blockedPlayers = privateMessageService.listBlocked(session);
+            java.util.List<PlayerData> blockedPlayers = privateMessageService.listBlocked(session);
             var pagination = CustomGatherers.calculatePagination(blockedPlayers.size(), menu.globalConfig.privateMessagesPerPage);
             int validPage = pagination.totalPages() <= 0 ? 1 : pagination.clampPage(requestedPage);
             context.state().page = validPage;
             int start = (validPage - 1) * menu.globalConfig.privateMessagesPerPage;
             int end = Math.min(start + menu.globalConfig.privateMessagesPerPage, blockedPlayers.size());
-            List<PlayerData> pageItems = start >= blockedPlayers.size() ? List.of() : blockedPlayers.subList(start, end);
+            java.util.List<PlayerData> pageItems = start >= blockedPlayers.size() ? java.util.List.of() : blockedPlayers.subList(start, end);
 
-            List<List<MenuButton>> rows = new ArrayList<>();
-
-            List<MenuButton> pagingRow = new ArrayList<>();
+            var grid = new MenuGrid();
+            var pagingRow = new java.util.ArrayList<MenuButton>();
             if (validPage > 1) {
-                pagingRow.add(MenuButton.of(session.locale().t("previous"), ACTION_PREVIOUS));
+                pagingRow.add(MenuButton.of(session.locale().t("previous"), "previous"));
             }
             if (validPage < Math.max(1, pagination.totalPages())) {
-                pagingRow.add(MenuButton.of(session.locale().t("next"), ACTION_NEXT));
+                pagingRow.add(MenuButton.of(session.locale().t("next"), "next"));
             }
             if (!pagingRow.isEmpty()) {
-                rows.add(pagingRow);
+                grid.row(pagingRow.toArray(new MenuButton[0]));
             }
 
             for (PlayerData playerData : pageItems) {
-                rows.add(List.of(MenuButton.of(
+                grid.row(MenuButton.of(
                         session.locale().t("private-message-blocked-entry", args("target", playerData.nickname, "pid", playerData.pid)),
-                        ACTION_UNBLOCK_PREFIX + playerData.pid
-                )));
+                        "unblock:" + playerData.pid
+                ));
             }
 
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack()) {
-                navigation.add(MenuButton.of(session.locale().t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(session.locale().t("close"), ACTION_CLOSE));
-            rows.add(navigation);
+            grid.defaultNavigation(session, session.locale());
 
             return MenuScreen.normal(
                     session.locale().t("private-message-blocked-title"),
@@ -366,30 +308,8 @@ final class MessageFlows {
                             "total", Math.max(1, pagination.totalPages()),
                             "count", blockedPlayers.size()
                     )),
-                    rows
+                    grid.build()
             );
-        }
-
-        @Override
-        public void onAction(MenuRenderContext<BlockedState> context, String actionId) {
-            Session session = context.session();
-            int currentPage = Math.max(1, context.state().page);
-
-            switch (actionId) {
-                case ACTION_PREVIOUS -> session.menuService.renderRoute(session,
-                        MenuRoute.of(ROUTE_BLOCKED).withParam("page", String.valueOf(currentPage - 1)));
-                case ACTION_NEXT -> session.menuService.renderRoute(session,
-                        MenuRoute.of(ROUTE_BLOCKED).withParam("page", String.valueOf(currentPage + 1)));
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                default -> {
-                    if (actionId.startsWith(ACTION_UNBLOCK_PREFIX)) {
-                        int pid = Integer.parseInt(actionId.substring(ACTION_UNBLOCK_PREFIX.length()));
-                        privateMessageService.unblock(session, pid);
-                        context.render();
-                    }
-                }
-            }
         }
     }
 
@@ -423,10 +343,10 @@ final class MessageFlows {
     }
 
     private static void handleComposeTarget(MessageMenu menu,
-                                            PrivateMessageService privateMessageService,
-                                            String uuid,
-                                            Runnable onBack,
-                                            String pidText) {
+                                             PrivateMessageService privateMessageService,
+                                             String uuid,
+                                             Runnable onBack,
+                                             String pidText) {
         Session session = menu.sessionService.get(uuid);
         if (session == null || session.data == null) return;
 
@@ -456,13 +376,12 @@ final class MessageFlows {
         if (message == null) {
             return "";
         }
-
         return message.length() <= 40 ? message : message.substring(0, 37) + "...";
     }
 
     private static DetailsView resolveDetailsView(Session session,
-                                                  DetailsState state,
-                                                  PrivateMessageService privateMessageService) {
+                                                    DetailsState state,
+                                                    PrivateMessageService privateMessageService) {
         if (session == null || session.data == null || state == null || state.messageId == null) {
             return null;
         }
@@ -488,10 +407,10 @@ final class MessageFlows {
         return MenuScreen.normal(
                 session.locale().t("private-message-details-title"),
                 session.locale().t("error-private-message-not-found"),
-                List.of(List.of(
-                        MenuButton.of(session.locale().t("back"), ACTION_BACK),
-                        MenuButton.of(session.locale().t("close"), ACTION_CLOSE)
-                ))
+                new MenuGrid().row(
+                        MenuButton.of(session.locale().t("back"), "back"),
+                        MenuButton.of(session.locale().t("close"), "close")
+                ).build()
         );
     }
 

--- a/src/main/java/org/xcore/plugin/ui/menu/PlayerProfileFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/PlayerProfileFlows.java
@@ -10,11 +10,12 @@ import org.xcore.plugin.model.PlayerStatsOverview;
 import org.xcore.plugin.service.PlayerDisplayService;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
+import org.xcore.plugin.ui.flow.BaseMenuFlow;
 import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuGrid;
 import org.xcore.plugin.ui.flow.MenuRenderContext;
 import org.xcore.plugin.ui.flow.MenuScreen;
 import org.xcore.plugin.ui.route.MenuRoute;
-import org.xcore.plugin.ui.route.RoutedMenuFlow;
 
 import java.text.NumberFormat;
 import java.util.ArrayList;
@@ -29,34 +30,24 @@ final class PlayerProfileFlows {
     static final String ROUTE_PLAYER = "player.profile";
     static final String ROUTE_PLAYERS = "player.players";
 
-    private static final String ACTION_BACK = "back";
-    private static final String ACTION_CLOSE = "close";
-    private static final String ACTION_SETTINGS = "settings";
-    private static final String ACTION_AUDIT_HISTORY = "audit-history";
-    private static final String ACTION_AUDIT_ACTIONS = "audit-actions";
-    private static final String ACTION_PLAYERS = "players";
-    private static final String ACTION_ADMIN_FILTER = "admin-filter";
-    private static final String ACTION_PREV = "prev";
-    private static final String ACTION_NEXT = "next";
-    private static final String ACTION_SELECT_PREFIX = "select-";
-
     private PlayerProfileFlows() {
     }
 
-    static final class PlayerFlow implements RoutedMenuFlow<PlayerState> {
+    static final class PlayerFlow extends BaseMenuFlow<PlayerState> {
         private final PlayerMenu menu;
         private final GameDataRepository gameDataRepository;
         private final AuditHistoryMenu auditHistoryMenu;
 
         PlayerFlow(PlayerMenu menu, GameDataRepository gameDataRepository, AuditHistoryMenu auditHistoryMenu) {
+            super(ROUTE_PLAYER, PlayerState.class);
             this.menu = menu;
             this.gameDataRepository = gameDataRepository;
             this.auditHistoryMenu = auditHistoryMenu;
-        }
 
-        @Override
-        public String routeId() {
-            return ROUTE_PLAYER;
+            action("settings", ctx -> ctx.openRoute(MenuRoute.of(PlayerSettingsFlows.ROUTE_SETTINGS).withParam("targetUuid", ctx.state().targetUuid)));
+            action("audit-history", ctx -> auditHistoryMenu.history(ctx.session().data.uuid, resolveTargetData(ctx)));
+            action("audit-actions", ctx -> auditHistoryMenu.actions(ctx.session().data.uuid, resolveTargetData(ctx)));
+            action("players", ctx -> ctx.openRoute(MenuRoute.of(ROUTE_PLAYERS).withParam("page", "1")));
         }
 
         @Override
@@ -66,11 +57,6 @@ final class PlayerProfileFlows {
                 return currentState;
             }
             return new PlayerState(targetUuid);
-        }
-
-        @Override
-        public Class<PlayerState> stateType() {
-            return PlayerState.class;
         }
 
         @Override
@@ -101,26 +87,20 @@ final class PlayerProfileFlows {
             var overallStats = statsOverview.overall();
             NumberFormat numberFormat = NumberFormat.getIntegerInstance(local.getLocale());
 
-            List<List<MenuButton>> rows = new ArrayList<>();
+            var grid = new MenuGrid();
             List<MenuButton> actions = new ArrayList<>();
             if (isOwner || session.player.admin) {
-                actions.add(MenuButton.of(local.t("player-menu-settings"), ACTION_SETTINGS));
+                actions.add(MenuButton.of(local.t("player-menu-settings"), "settings"));
             }
             if (session.player.admin) {
-                actions.add(MenuButton.of(local.t("audit-menu-open"), ACTION_AUDIT_HISTORY));
-                actions.add(MenuButton.of(local.t("audit-menu-actions-open"), ACTION_AUDIT_ACTIONS));
+                actions.add(MenuButton.of(local.t("audit-menu-open"), "audit-history"));
+                actions.add(MenuButton.of(local.t("audit-menu-actions-open"), "audit-actions"));
             }
             if (!actions.isEmpty()) {
-                rows.add(actions);
+                grid.row(actions.toArray(new MenuButton[0]));
             }
-            rows.add(List.of(MenuButton.of(local.t("player-menu-players"), ACTION_PLAYERS)));
-
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack()) {
-                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
-            rows.add(navigation);
+            grid.row(MenuButton.of(local.t("player-menu-players"), "players"));
+            grid.defaultNavigation(session, local);
 
             return MenuScreen.normal(
                     local.t("player-menu-player-title"),
@@ -151,44 +131,55 @@ final class PlayerProfileFlows {
                             "admin", targetData.admin ? local.t("yes") : local.t("no"),
                             "hexedPoints", numberFormat.format(targetData.hexedPoints)
                     )),
-                    rows
+                    grid.build()
             );
         }
 
-        @Override
-        public void onAction(MenuRenderContext<PlayerState> context, String actionId) {
-            Session session = context.session();
-            PlayerState state = context.state();
-            PlayerData targetData = session.playerDataRepository.findByUuid(state.targetUuid);
-            if (targetData == null) {
-                return;
-            }
-
-            switch (actionId) {
-                case ACTION_SETTINGS -> context.openRoute(MenuRoute.of(PlayerSettingsFlows.ROUTE_SETTINGS).withParam("targetUuid", state.targetUuid));
-                case ACTION_AUDIT_HISTORY -> auditHistoryMenu.history(session.data.uuid, targetData);
-                case ACTION_AUDIT_ACTIONS -> auditHistoryMenu.actions(session.data.uuid, targetData);
-                case ACTION_PLAYERS -> context.openRoute(MenuRoute.of(ROUTE_PLAYERS).withParam("page", "1"));
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-            }
+        private PlayerData resolveTargetData(MenuRenderContext<PlayerState> context) {
+            return context.session().playerDataRepository.findByUuid(context.state().targetUuid);
         }
     }
 
-    static final class PlayersFlow implements RoutedMenuFlow<PlayersState> {
+    static final class PlayersFlow extends BaseMenuFlow<PlayersState> {
         private final PlayerMenu menu;
         private final SessionService sessionService;
         private final PlayerDisplayService playerDisplayService;
 
         PlayersFlow(PlayerMenu menu, SessionService sessionService, PlayerDisplayService playerDisplayService) {
+            super(ROUTE_PLAYERS, PlayersState.class);
             this.menu = menu;
             this.sessionService = sessionService;
             this.playerDisplayService = playerDisplayService;
-        }
 
-        @Override
-        public String routeId() {
-            return ROUTE_PLAYERS;
+            action("admin-filter", ctx -> {
+                ctx.session().setNextStatus("admin");
+                ctx.state().page = 1;
+                ctx.render();
+            });
+            action("prev", ctx -> {
+                ctx.state().page = Math.max(1, ctx.state().page - 1);
+                ctx.render();
+            });
+            action("next", ctx -> {
+                ctx.state().page = ctx.state().page + 1;
+                ctx.render();
+            });
+            actionPrefix("select:", (ctx, indexStr) -> {
+                int index = Integer.parseInt(indexStr);
+                List<Session> onlinePlayers = getFilteredOnlinePlayers(ctx.session(), sessionService, playerDisplayService);
+                int perPage = menu.globalConfig.eventsPerPage;
+                var pagination = CustomGatherers.calculatePagination(onlinePlayers.size(), perPage);
+                int validPage = pagination.totalPages() <= 0 ? 1 : pagination.clampPage(ctx.state().page);
+                int skip = (validPage - 1) * perPage;
+                List<Session> players = onlinePlayers.stream()
+                        .skip(skip)
+                        .limit(perPage)
+                        .toList();
+                if (index >= 0 && index < players.size()) {
+                    Session onlinePlayer = players.get(index);
+                    ctx.openRoute(MenuRoute.of(ROUTE_PLAYER).withParam("targetUuid", onlinePlayer.data.uuid));
+                }
+            });
         }
 
         @Override
@@ -198,11 +189,6 @@ final class PlayerProfileFlows {
                 return currentState;
             }
             return new PlayersState(page);
-        }
-
-        @Override
-        public Class<PlayersState> stateType() {
-            return PlayersState.class;
         }
 
         @Override
@@ -233,7 +219,7 @@ final class PlayerProfileFlows {
                 ));
             }
 
-            List<List<MenuButton>> rows = new ArrayList<>();
+            var grid = new MenuGrid();
 
             StatusEnum adminStatus = session.sortStatus.getOrDefault("admin", StatusEnum.Neutral);
             String adminLabel;
@@ -244,17 +230,17 @@ final class PlayerProfileFlows {
             } else {
                 adminLabel = local.t("admin-neutral");
             }
-            rows.add(List.of(MenuButton.of(adminLabel, ACTION_ADMIN_FILTER)));
+            grid.row(MenuButton.of(adminLabel, "admin-filter"));
 
             List<MenuButton> paginationRow = new ArrayList<>();
             if (validPage > 1) {
-                paginationRow.add(MenuButton.of(local.t("previous"), ACTION_PREV));
+                paginationRow.add(MenuButton.of(local.t("previous"), "prev"));
             }
             if (validPage < totalPages) {
-                paginationRow.add(MenuButton.of(local.t("next"), ACTION_NEXT));
+                paginationRow.add(MenuButton.of(local.t("next"), "next"));
             }
             if (!paginationRow.isEmpty()) {
-                rows.add(paginationRow);
+                grid.row(paginationRow.toArray(new MenuButton[0]));
             }
 
             for (int i = 0; i < players.size(); i++) {
@@ -263,63 +249,16 @@ final class PlayerProfileFlows {
                         "nickname", playerDisplayService.resolveBaseName(onlinePlayer.data, onlinePlayer.player),
                         "pid", onlinePlayer.data.pid
                 ));
-                rows.add(List.of(MenuButton.of(label, ACTION_SELECT_PREFIX + i)));
+                grid.row(MenuButton.of(label, "select:" + i));
             }
 
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack()) {
-                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
-            rows.add(navigation);
+            grid.defaultNavigation(session, local);
 
             return MenuScreen.normal(
                     local.t("player-menu-players-title"),
                     menuContent,
-                    rows
+                    grid.build()
             );
-        }
-
-        @Override
-        public void onAction(MenuRenderContext<PlayersState> context, String actionId) {
-            Session session = context.session();
-            PlayersState state = context.state();
-
-            switch (actionId) {
-                case ACTION_ADMIN_FILTER -> {
-                    session.setNextStatus("admin");
-                    state.page = 1;
-                    context.render();
-                }
-                case ACTION_PREV -> {
-                    state.page = Math.max(1, state.page - 1);
-                    context.render();
-                }
-                case ACTION_NEXT -> {
-                    state.page = state.page + 1;
-                    context.render();
-                }
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                default -> {
-                    if (actionId.startsWith(ACTION_SELECT_PREFIX)) {
-                        int index = Integer.parseInt(actionId.substring(ACTION_SELECT_PREFIX.length()));
-                        List<Session> onlinePlayers = getFilteredOnlinePlayers(session, sessionService, playerDisplayService);
-                        int perPage = menu.globalConfig.eventsPerPage;
-                        var pagination = CustomGatherers.calculatePagination(onlinePlayers.size(), perPage);
-                        int validPage = pagination.totalPages() <= 0 ? 1 : pagination.clampPage(state.page);
-                        int skip = (validPage - 1) * perPage;
-                        List<Session> players = onlinePlayers.stream()
-                                .skip(skip)
-                                .limit(perPage)
-                                .toList();
-                        if (index >= 0 && index < players.size()) {
-                            Session onlinePlayer = players.get(index);
-                            context.openRoute(MenuRoute.of(ROUTE_PLAYER).withParam("targetUuid", onlinePlayer.data.uuid));
-                        }
-                    }
-                }
-            }
         }
     }
 
@@ -350,7 +289,7 @@ final class PlayerProfileFlows {
         return MenuScreen.normal(
                 local.t(titleKey),
                 local.t(messageKey),
-                List.of(List.of(MenuButton.of(local.t("close"), ACTION_CLOSE)))
+                new MenuGrid().row(MenuButton.of(local.t("close"), "close")).build()
         );
     }
 
@@ -405,8 +344,8 @@ final class PlayerProfileFlows {
     }
 
     private static List<Session> getFilteredOnlinePlayers(Session viewerSession,
-                                                          SessionService sessionService,
-                                                          PlayerDisplayService playerDisplayService) {
+                                                           SessionService sessionService,
+                                                           PlayerDisplayService playerDisplayService) {
         return sessionService.streamCached()
                 .filter(onlineSession -> onlineSession != null && onlineSession.data != null && onlineSession.player != null)
                 .filter(onlineSession -> matchesAdminFilter(viewerSession, onlineSession))

--- a/src/main/java/org/xcore/plugin/ui/menu/PlayerSettingsFlows.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/PlayerSettingsFlows.java
@@ -8,12 +8,13 @@ import org.xcore.plugin.model.PlayerData;
 import org.xcore.plugin.player.Badge;
 import org.xcore.plugin.service.PlayerProfileSettingsService;
 import org.xcore.plugin.session.Session;
+import org.xcore.plugin.ui.flow.BaseMenuFlow;
 import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuGrid;
 import org.xcore.plugin.ui.flow.MenuPrompt;
 import org.xcore.plugin.ui.flow.MenuRenderContext;
 import org.xcore.plugin.ui.flow.MenuScreen;
 import org.xcore.plugin.ui.route.MenuRoute;
-import org.xcore.plugin.ui.route.RoutedMenuFlow;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,39 +32,85 @@ final class PlayerSettingsFlows {
     static final String ROUTE_LANGUAGE_SELECTION = "player.language-selection";
     static final String ROUTE_BADGE_SYMBOL_COLOR = "player.badge-symbol-color";
 
-    private static final String ACTION_TOGGLE_GLOBAL_CHAT = "toggle-global-chat";
-    private static final String ACTION_TOGGLE_DISCORD_RELAY = "toggle-discord-relay";
-    private static final String ACTION_TRANSLATOR_LANGUAGE = "translator-language";
-    private static final String ACTION_BACK = "back";
-    private static final String ACTION_CLOSE = "close";
-    private static final String ACTION_SET_DEFAULT_MODE = "set-default-mode";
-    private static final String ACTION_SET_PLAYER_COLOR_MODE = "set-player-color-mode";
-    private static final String ACTION_SYMBOL_COLOR_MODE = "symbol-color-mode";
-    private static final String ACTION_VIEW_ALL = "view-all";
-    private static final String ACTION_CLEAR = "clear";
-    private static final String ACTION_CUSTOM_NICKNAME = "custom-nickname";
-    private static final String ACTION_CUSTOM_NICKNAME_RESET = "custom-nickname-reset";
-    private static final String ACTION_DESCRIPTION = "description";
-    private static final String ACTION_CHAT_SETTINGS = "chat-settings";
-    private static final String ACTION_BADGES = "badges";
-    private static final String ACTION_LEADERBOARD = "leaderboard";
-    private static final String ACTION_LANGUAGE = "language";
-    private static final String ACTION_SELECT_AUTO = "auto";
-    private static final String ACTION_SELECT_DEFAULT = "default";
-
     private PlayerSettingsFlows() {
     }
 
-    static final class SettingsFlow implements RoutedMenuFlow<SettingsState> {
+    static final class SettingsFlow extends BaseMenuFlow<SettingsState> {
         private final PlayerProfileSettingsService profileSettings;
 
         SettingsFlow(PlayerProfileSettingsService profileSettings) {
+            super(ROUTE_SETTINGS, SettingsState.class);
             this.profileSettings = profileSettings;
-        }
 
-        @Override
-        public String routeId() {
-            return ROUTE_SETTINGS;
+            action("custom-nickname", ctx -> {
+                PlayerData targetData = resolveTargetData(ctx);
+                if (targetData == null) return;
+                ctx.openPrompt(new MenuPrompt(
+                        "custom-nickname",
+                        ctx.locale().t("player-menu-settings-customNickname-title"),
+                        ctx.locale().t("player-menu-settings-customNickname-message"),
+                        256,
+                        targetData.customNickname,
+                        false
+                ));
+            });
+            action("custom-nickname-reset", ctx -> {
+                PlayerData targetData = resolveTargetData(ctx);
+                if (targetData == null) return;
+                profileSettings.updateCustomNickname(targetData, "", true, true);
+                ctx.render();
+            });
+            action("description", ctx -> {
+                PlayerData targetData = resolveTargetData(ctx);
+                if (targetData == null) return;
+                ctx.openPrompt(new MenuPrompt(
+                        "description",
+                        ctx.locale().t("player-menu-settings-description-title"),
+                        "",
+                        1000,
+                        targetData.description,
+                        false
+                ));
+            });
+            action("chat-settings", ctx -> ctx.openRoute(MenuRoute.of(ROUTE_CHAT_SETTINGS).withParam("targetUuid", ctx.state().targetUuid)));
+            action("badges", ctx -> ctx.openRoute(MenuRoute.of(ROUTE_BADGES).withParam("targetUuid", ctx.state().targetUuid)));
+            action("leaderboard", ctx -> {
+                PlayerData targetData = resolveTargetData(ctx);
+                if (targetData == null) return;
+                profileSettings.updateLeaderboard(targetData, !targetData.leaderboard);
+                ctx.render();
+            });
+            action("language", ctx -> ctx.openRoute(MenuRoute.of(ROUTE_LANGUAGE_SELECTION)
+                    .withParam("targetUuid", ctx.state().targetUuid)
+                    .withParam("isTranslator", "false")));
+
+            onPrompt("custom-nickname",
+                    ctx -> {
+                        PlayerData targetData = resolveTargetData(ctx.renderContext());
+                        if (targetData == null) return;
+                        String newNick = ctx.text() == null || ctx.text().trim().isEmpty() ? "" : ctx.text().trim();
+                        if (!newNick.isEmpty()) {
+                            var result = profileSettings.validateCustomNickname(newNick);
+                            if (!result.valid()) {
+                                ctx.renderContext().locale().send(result.errorKey(), args("max", result.maxBytes()));
+                                ctx.renderContext().render();
+                                return;
+                            }
+                        }
+                        profileSettings.updateCustomNickname(targetData, newNick, true, true);
+                        ctx.renderContext().render();
+                    },
+                    ctx -> ctx.render()
+            );
+            onPrompt("description",
+                    ctx -> {
+                        PlayerData targetData = resolveTargetData(ctx.renderContext());
+                        if (targetData == null) return;
+                        profileSettings.updateDescription(targetData, ctx.text());
+                        ctx.renderContext().render();
+                    },
+                    ctx -> ctx.render()
+            );
         }
 
         @Override
@@ -73,11 +120,6 @@ final class PlayerSettingsFlows {
                 return currentState;
             }
             return new SettingsState(targetUuid);
-        }
-
-        @Override
-        public Class<SettingsState> stateType() {
-            return SettingsState.class;
         }
 
         @Override
@@ -107,33 +149,21 @@ final class PlayerSettingsFlows {
             String globalChat = targetData.globalChatVisible ? local.t("yes") : local.t("no");
             String discordRelay = targetData.discordRelayVisible ? local.t("yes") : local.t("no");
 
-            List<List<MenuButton>> rows = new ArrayList<>();
-
-            rows.add(List.of(
-                    MenuButton.of(local.t("player-menu-settings-customNickname"), ACTION_CUSTOM_NICKNAME),
-                    MenuButton.of(local.t("player-menu-settings-customNickname-reset"), ACTION_CUSTOM_NICKNAME_RESET),
-                    MenuButton.of(local.t("player-menu-settings-description"), ACTION_DESCRIPTION)));
-
-            rows.add(List.of(MenuButton.of(
-                    local.t("player-menu-settings-chat"),
-                    ACTION_CHAT_SETTINGS)));
-            rows.add(List.of(MenuButton.of(
-                    local.t("player-menu-settings-badges"),
-                    ACTION_BADGES)));
-            rows.add(List.of(MenuButton.of(
+            var grid = new MenuGrid();
+            grid.row(
+                    MenuButton.of(local.t("player-menu-settings-customNickname"), "custom-nickname"),
+                    MenuButton.of(local.t("player-menu-settings-customNickname-reset"), "custom-nickname-reset"),
+                    MenuButton.of(local.t("player-menu-settings-description"), "description")
+            );
+            grid.row(MenuButton.of(local.t("player-menu-settings-chat"), "chat-settings"));
+            grid.row(MenuButton.of(local.t("player-menu-settings-badges"), "badges"));
+            grid.row(MenuButton.of(
                     local.t(targetData.leaderboard ? "player-leaderboard-active" : "player-leaderboard-inactive"),
-                    ACTION_LEADERBOARD)));
-
-            rows.add(List.of(MenuButton.of(
+                    "leaderboard"));
+            grid.row(MenuButton.of(
                     local.t("settings-language-label", args("lang", local.getLanguageName(targetData.language, "auto"))),
-                    ACTION_LANGUAGE)));
-
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack()) {
-                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
-            rows.add(navigation);
+                    "language"));
+            grid.defaultNavigation(session, local);
 
             return MenuScreen.normal(
                     local.t("player-menu-settings-title"),
@@ -149,102 +179,37 @@ final class PlayerSettingsFlows {
                             "globalChat", globalChat,
                             "discordRelay", discordRelay
                     )),
-                    rows
+                    grid.build()
             );
         }
 
-        @Override
-        public void onAction(MenuRenderContext<SettingsState> context, String actionId) {
-            Session session = context.session();
-            SettingsState state = context.state();
-            PlayerData targetData = session.playerDataRepository.findByUuid(state.targetUuid);
-            if (targetData == null) return;
-
-            Localization local = context.locale();
-
-            switch (actionId) {
-                case ACTION_CUSTOM_NICKNAME -> context.openPrompt(new MenuPrompt(
-                        ACTION_CUSTOM_NICKNAME,
-                        local.t("player-menu-settings-customNickname-title"),
-                        local.t("player-menu-settings-customNickname-message"),
-                        256,
-                        targetData.customNickname,
-                        false
-                ));
-                case ACTION_CUSTOM_NICKNAME_RESET -> {
-                    profileSettings.updateCustomNickname(targetData, "", true, true);
-                    context.render();
-                }
-                case ACTION_DESCRIPTION -> context.openPrompt(new MenuPrompt(
-                        ACTION_DESCRIPTION,
-                        local.t("player-menu-settings-description-title"),
-                        "",
-                        1000,
-                        targetData.description,
-                        false
-                ));
-                case ACTION_CHAT_SETTINGS -> context.openRoute(MenuRoute.of(ROUTE_CHAT_SETTINGS).withParam("targetUuid", state.targetUuid));
-                case ACTION_BADGES -> context.openRoute(MenuRoute.of(ROUTE_BADGES).withParam("targetUuid", state.targetUuid));
-                case ACTION_LEADERBOARD -> {
-                    profileSettings.updateLeaderboard(targetData, !targetData.leaderboard);
-                    context.render();
-                }
-                case ACTION_LANGUAGE -> context.openRoute(MenuRoute.of(ROUTE_LANGUAGE_SELECTION)
-                        .withParam("targetUuid", state.targetUuid)
-                        .withParam("isTranslator", "false"));
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                default -> {
-                }
-            }
-        }
-
-        @Override
-        public void onPromptSubmit(MenuRenderContext<SettingsState> context, String promptId, String text) {
-            Session session = context.session();
-            SettingsState state = context.state();
-            PlayerData targetData = session.playerDataRepository.findByUuid(state.targetUuid);
-            if (targetData == null) return;
-
-            switch (promptId) {
-                case ACTION_CUSTOM_NICKNAME -> {
-                    String newNick = text == null || text.trim().isEmpty() ? "" : text;
-                    if (!newNick.isEmpty()) {
-                        var result = profileSettings.validateCustomNickname(newNick);
-                        if (!result.valid()) {
-                            context.locale().send(result.errorKey(), args("max", result.maxBytes()));
-                            context.render();
-                            return;
-                        }
-                    }
-                    profileSettings.updateCustomNickname(targetData, newNick, true, true);
-                    context.render();
-                }
-                case ACTION_DESCRIPTION -> {
-                    profileSettings.updateDescription(targetData, text);
-                    context.render();
-                }
-                default -> {
-                }
-            }
-        }
-
-        @Override
-        public void onPromptCancel(MenuRenderContext<SettingsState> context, String promptId) {
-            context.render();
+        private PlayerData resolveTargetData(MenuRenderContext<SettingsState> context) {
+            return context.session().playerDataRepository.findByUuid(context.state().targetUuid);
         }
     }
 
-    static final class ChatSettingsFlow implements RoutedMenuFlow<ChatSettingsState> {
+    static final class ChatSettingsFlow extends BaseMenuFlow<ChatSettingsState> {
         private final PlayerProfileSettingsService profileSettings;
 
         ChatSettingsFlow(PlayerProfileSettingsService profileSettings) {
+            super(ROUTE_CHAT_SETTINGS, ChatSettingsState.class);
             this.profileSettings = profileSettings;
-        }
 
-        @Override
-        public String routeId() {
-            return ROUTE_CHAT_SETTINGS;
+            action("toggle-global-chat", ctx -> {
+                PlayerData targetData = resolveTargetData(ctx);
+                if (targetData == null) return;
+                profileSettings.updateGlobalChatVisible(targetData, !targetData.globalChatVisible);
+                ctx.render();
+            });
+            action("toggle-discord-relay", ctx -> {
+                PlayerData targetData = resolveTargetData(ctx);
+                if (targetData == null) return;
+                profileSettings.updateDiscordRelayVisible(targetData, !targetData.discordRelayVisible);
+                ctx.render();
+            });
+            action("translator-language", ctx -> ctx.openRoute(MenuRoute.of(ROUTE_LANGUAGE_SELECTION)
+                    .withParam("targetUuid", ctx.state().targetUuid)
+                    .withParam("isTranslator", "true")));
         }
 
         @Override
@@ -254,11 +219,6 @@ final class PlayerSettingsFlows {
                 return currentState;
             }
             return new ChatSettingsState(targetUuid);
-        }
-
-        @Override
-        public Class<ChatSettingsState> stateType() {
-            return ChatSettingsState.class;
         }
 
         @Override
@@ -279,23 +239,17 @@ final class PlayerSettingsFlows {
 
             Localization local = context.locale();
 
-            List<List<MenuButton>> rows = new ArrayList<>();
-            rows.add(List.of(MenuButton.of(
+            var grid = new MenuGrid();
+            grid.row(MenuButton.of(
                     local.t(targetData.globalChatVisible ? "player-menu-settings-global-chat-on" : "player-menu-settings-global-chat-off"),
-                    ACTION_TOGGLE_GLOBAL_CHAT)));
-            rows.add(List.of(MenuButton.of(
+                    "toggle-global-chat"));
+            grid.row(MenuButton.of(
                     local.t(targetData.discordRelayVisible ? "player-menu-settings-discord-relay-on" : "player-menu-settings-discord-relay-off"),
-                    ACTION_TOGGLE_DISCORD_RELAY)));
-            rows.add(List.of(MenuButton.of(
+                    "toggle-discord-relay"));
+            grid.row(MenuButton.of(
                     local.t("settings-translator-label", args("lang", local.getLanguageName(targetData.translatorLanguage, "off"))),
-                    ACTION_TRANSLATOR_LANGUAGE)));
-
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack()) {
-                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
-            rows.add(navigation);
+                    "translator-language"));
+            grid.defaultNavigation(session, local);
 
             return MenuScreen.normal(
                     local.t("player-menu-settings-chat-title"),
@@ -304,49 +258,46 @@ final class PlayerSettingsFlows {
                             "discordRelay", targetData.discordRelayVisible ? local.t("yes") : local.t("no"),
                             "translatorLanguage", local.getLanguageName(targetData.translatorLanguage, "off")
                     )),
-                    rows
+                    grid.build()
             );
         }
 
-        @Override
-        public void onAction(MenuRenderContext<ChatSettingsState> context, String actionId) {
-            Session session = context.session();
-            ChatSettingsState state = context.state();
-            PlayerData targetData = session.playerDataRepository.findByUuid(state.targetUuid);
-            if (targetData == null) return;
-
-            switch (actionId) {
-                case ACTION_TOGGLE_GLOBAL_CHAT -> {
-                    profileSettings.updateGlobalChatVisible(targetData, !targetData.globalChatVisible);
-                    context.render();
-                }
-                case ACTION_TOGGLE_DISCORD_RELAY -> {
-                    profileSettings.updateDiscordRelayVisible(targetData, !targetData.discordRelayVisible);
-                    context.render();
-                }
-                case ACTION_TRANSLATOR_LANGUAGE -> context.openRoute(MenuRoute.of(ROUTE_LANGUAGE_SELECTION)
-                        .withParam("targetUuid", state.targetUuid)
-                        .withParam("isTranslator", "true"));
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                default -> {
-                }
-            }
+        private PlayerData resolveTargetData(MenuRenderContext<ChatSettingsState> context) {
+            return context.session().playerDataRepository.findByUuid(context.state().targetUuid);
         }
     }
 
-    static final class LanguageSelectionFlow implements RoutedMenuFlow<LanguageSelectionState> {
+    static final class LanguageSelectionFlow extends BaseMenuFlow<LanguageSelectionState> {
         private final Bundle bundle;
         private final PlayerProfileSettingsService profileSettings;
 
         LanguageSelectionFlow(Bundle bundle, PlayerProfileSettingsService profileSettings) {
+            super(ROUTE_LANGUAGE_SELECTION, LanguageSelectionState.class);
             this.bundle = bundle;
             this.profileSettings = profileSettings;
-        }
 
-        @Override
-        public String routeId() {
-            return ROUTE_LANGUAGE_SELECTION;
+            action("auto", ctx -> {
+                PlayerData targetData = resolveTargetData(ctx);
+                if (targetData == null) return;
+                profileSettings.updateLanguage(targetData, "auto");
+                ctx.goBack();
+            });
+            action("default", ctx -> {
+                PlayerData targetData = resolveTargetData(ctx);
+                if (targetData == null) return;
+                profileSettings.updateTranslatorLanguage(targetData, "off");
+                ctx.goBack();
+            });
+            defaultAction((ctx, actionId) -> {
+                PlayerData targetData = resolveTargetData(ctx);
+                if (targetData == null) return;
+                if (ctx.state().isTranslator) {
+                    profileSettings.updateTranslatorLanguage(targetData, actionId);
+                } else {
+                    profileSettings.updateLanguage(targetData, actionId);
+                }
+                ctx.goBack();
+            });
         }
 
         @Override
@@ -357,11 +308,6 @@ final class PlayerSettingsFlows {
                 return currentState;
             }
             return new LanguageSelectionState(targetUuid, isTranslator);
-        }
-
-        @Override
-        public Class<LanguageSelectionState> stateType() {
-            return LanguageSelectionState.class;
         }
 
         @Override
@@ -385,68 +331,46 @@ final class PlayerSettingsFlows {
             Localization local = context.locale();
             Seq<Locale> locales = bundle.getAvailableLocales();
 
-            List<List<MenuButton>> rows = new ArrayList<>();
-
-            String firstActionId = state.isTranslator ? ACTION_SELECT_DEFAULT : ACTION_SELECT_AUTO;
+            var grid = new MenuGrid();
+            String firstActionId = state.isTranslator ? "default" : "auto";
             String firstLabelKey = state.isTranslator ? "default" : "auto";
-            rows.add(List.of(MenuButton.of(local.t(firstLabelKey), firstActionId)));
+            grid.row(MenuButton.of(local.t(firstLabelKey), firstActionId));
 
             for (Locale loc : locales) {
                 String code = "uk".equals(loc.getLanguage()) ? "uk_UA" : loc.getLanguage();
                 String langName = Strings.capitalize(loc.getDisplayLanguage(loc));
-                rows.add(List.of(MenuButton.of(langName, code)));
+                grid.row(MenuButton.of(langName, code));
             }
 
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack()) {
-                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
-            rows.add(navigation);
+            grid.defaultNavigation(session, local);
 
-            return MenuScreen.normal(local.t(titleKey), "", rows);
+            return MenuScreen.normal(local.t(titleKey), "", grid.build());
         }
 
-        @Override
-        public void onAction(MenuRenderContext<LanguageSelectionState> context, String actionId) {
-            Session session = context.session();
-            LanguageSelectionState state = context.state();
-            PlayerData targetData = session.playerDataRepository.findByUuid(state.targetUuid);
-            if (targetData == null) return;
-
-            switch (actionId) {
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                case ACTION_SELECT_AUTO -> {
-                    profileSettings.updateLanguage(targetData, "auto");
-                    context.goBack();
-                }
-                case ACTION_SELECT_DEFAULT -> {
-                    profileSettings.updateTranslatorLanguage(targetData, "off");
-                    context.goBack();
-                }
-                default -> {
-                    if (state.isTranslator) {
-                        profileSettings.updateTranslatorLanguage(targetData, actionId);
-                    } else {
-                        profileSettings.updateLanguage(targetData, actionId);
-                    }
-                    context.goBack();
-                }
-            }
+        private PlayerData resolveTargetData(MenuRenderContext<LanguageSelectionState> context) {
+            return context.session().playerDataRepository.findByUuid(context.state().targetUuid);
         }
     }
 
-    static final class BadgeSymbolColorModeFlow implements RoutedMenuFlow<BadgeSymbolColorModeState> {
+    static final class BadgeSymbolColorModeFlow extends BaseMenuFlow<BadgeSymbolColorModeState> {
         private final PlayerProfileSettingsService profileSettings;
 
         BadgeSymbolColorModeFlow(PlayerProfileSettingsService profileSettings) {
+            super(ROUTE_BADGE_SYMBOL_COLOR, BadgeSymbolColorModeState.class);
             this.profileSettings = profileSettings;
-        }
 
-        @Override
-        public String routeId() {
-            return ROUTE_BADGE_SYMBOL_COLOR;
+            action("set-default-mode", ctx -> {
+                PlayerData targetData = resolveTargetData(ctx);
+                if (targetData == null) return;
+                profileSettings.updateBadgeSymbolColorMode(targetData, "default", true, true);
+                ctx.render();
+            });
+            action("set-player-color-mode", ctx -> {
+                PlayerData targetData = resolveTargetData(ctx);
+                if (targetData == null) return;
+                profileSettings.updateBadgeSymbolColorMode(targetData, "player-color", true, true);
+                ctx.render();
+            });
         }
 
         @Override
@@ -456,11 +380,6 @@ final class PlayerSettingsFlows {
                 return currentState;
             }
             return new BadgeSymbolColorModeState(targetUuid);
-        }
-
-        @Override
-        public Class<BadgeSymbolColorModeState> stateType() {
-            return BadgeSymbolColorModeState.class;
         }
 
         @Override
@@ -481,58 +400,47 @@ final class PlayerSettingsFlows {
 
             Localization local = context.locale();
 
-            List<List<MenuButton>> rows = new ArrayList<>();
-            rows.add(List.of(MenuButton.of(local.t("badge-menu-symbol-color-default"), ACTION_SET_DEFAULT_MODE)));
-            rows.add(List.of(MenuButton.of(local.t("badge-menu-symbol-color-player-color"), ACTION_SET_PLAYER_COLOR_MODE)));
-
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack()) {
-                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
-            rows.add(navigation);
+            var grid = new MenuGrid();
+            grid.row(MenuButton.of(local.t("badge-menu-symbol-color-default"), "set-default-mode"));
+            grid.row(MenuButton.of(local.t("badge-menu-symbol-color-player-color"), "set-player-color-mode"));
+            grid.defaultNavigation(session, local);
 
             return MenuScreen.normal(
                     local.t("badge-menu-symbol-color-title"),
                     local.t("badge-menu-symbol-color-content", args("mode", badgeSymbolColorModeLabel(local, targetData))),
-                    rows
+                    grid.build()
             );
         }
 
-        @Override
-        public void onAction(MenuRenderContext<BadgeSymbolColorModeState> context, String actionId) {
-            Session session = context.session();
-            BadgeSymbolColorModeState state = context.state();
-            PlayerData targetData = session.playerDataRepository.findByUuid(state.targetUuid);
-            if (targetData == null) return;
-
-            switch (actionId) {
-                case ACTION_SET_DEFAULT_MODE -> {
-                    profileSettings.updateBadgeSymbolColorMode(targetData, "default", true, true);
-                    context.render();
-                }
-                case ACTION_SET_PLAYER_COLOR_MODE -> {
-                    profileSettings.updateBadgeSymbolColorMode(targetData, "player-color", true, true);
-                    context.render();
-                }
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                default -> {
-                }
-            }
+        private PlayerData resolveTargetData(MenuRenderContext<BadgeSymbolColorModeState> context) {
+            return context.session().playerDataRepository.findByUuid(context.state().targetUuid);
         }
     }
 
-    static final class BadgesFlow implements RoutedMenuFlow<BadgesState> {
+    static final class BadgesFlow extends BaseMenuFlow<BadgesState> {
         private final PlayerProfileSettingsService profileSettings;
 
         BadgesFlow(PlayerProfileSettingsService profileSettings) {
+            super(ROUTE_BADGES, BadgesState.class);
             this.profileSettings = profileSettings;
-        }
 
-        @Override
-        public String routeId() {
-            return ROUTE_BADGES;
+            action("symbol-color-mode", ctx -> ctx.openRoute(MenuRoute.of(ROUTE_BADGE_SYMBOL_COLOR).withParam("targetUuid", ctx.state().targetUuid)));
+            action("view-all", ctx -> ctx.openRoute(MenuRoute.of(ROUTE_ALL_BADGES).withParam("targetUuid", ctx.state().targetUuid)));
+            action("clear", ctx -> {
+                PlayerData targetData = resolveTargetData(ctx);
+                if (targetData == null) return;
+                profileSettings.updateActiveBadge(targetData, "", true, true);
+                ctx.render();
+            });
+            defaultAction((ctx, actionId) -> {
+                PlayerData targetData = resolveTargetData(ctx);
+                if (targetData == null) return;
+                Badge badge = Badge.byId(actionId);
+                if (badge != null) {
+                    profileSettings.updateActiveBadge(targetData, badge.id(), true, true);
+                    ctx.render();
+                }
+            });
         }
 
         @Override
@@ -542,11 +450,6 @@ final class PlayerSettingsFlows {
                 return currentState;
             }
             return new BadgesState(targetUuid);
-        }
-
-        @Override
-        public Class<BadgesState> stateType() {
-            return BadgesState.class;
         }
 
         @Override
@@ -573,77 +476,57 @@ final class PlayerSettingsFlows {
                     "symbolColorMode", badgeSymbolColorModeLabel(local, targetData)
             ));
 
-            List<List<MenuButton>> rows = new ArrayList<>();
-
+            var grid = new MenuGrid();
             for (Badge badge : badges) {
-                rows.add(List.of(MenuButton.of(
+                grid.row(MenuButton.of(
                         local.t("badge-menu-row", args(
                                 "badge", badgeLabel(local, badge),
                                 "description", local.t(badge.descriptionKey())
                         )),
-                        badge.id())));
+                        badge.id()));
             }
 
-            rows.add(List.of(MenuButton.of(
+            grid.row(MenuButton.of(
                     local.t("badge-menu-symbol-color-button", args("mode", badgeSymbolColorModeLabel(local, targetData))),
-                    ACTION_SYMBOL_COLOR_MODE)));
+                    "symbol-color-mode"));
 
-            List<MenuButton> bottomRow = new ArrayList<>();
-            bottomRow.add(MenuButton.of(local.t("badge-menu-view-all"), ACTION_VIEW_ALL));
-            bottomRow.add(MenuButton.of(local.t("badge-clear-button"), ACTION_CLEAR));
-            rows.add(bottomRow);
+            grid.row(
+                    MenuButton.of(local.t("badge-menu-view-all"), "view-all"),
+                    MenuButton.of(local.t("badge-clear-button"), "clear")
+            );
 
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack()) {
-                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
-            rows.add(navigation);
+            grid.defaultNavigation(session, local);
 
             return MenuScreen.normal(
                     local.t("badge-menu-title"),
                     badges.isEmpty() ? header + "\n" + local.t("badge-menu-empty") : header,
-                    rows
+                    grid.build()
             );
         }
 
-        @Override
-        public void onAction(MenuRenderContext<BadgesState> context, String actionId) {
-            Session session = context.session();
-            BadgesState state = context.state();
-            PlayerData targetData = session.playerDataRepository.findByUuid(state.targetUuid);
-            if (targetData == null) return;
-
-            switch (actionId) {
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                case ACTION_SYMBOL_COLOR_MODE -> context.openRoute(MenuRoute.of(ROUTE_BADGE_SYMBOL_COLOR).withParam("targetUuid", state.targetUuid));
-                case ACTION_VIEW_ALL -> context.openRoute(MenuRoute.of(ROUTE_ALL_BADGES).withParam("targetUuid", state.targetUuid));
-                case ACTION_CLEAR -> {
-                    profileSettings.updateActiveBadge(targetData, "", true, true);
-                    context.render();
-                }
-                default -> {
-                    Badge badge = Badge.byId(actionId);
-                    if (badge != null) {
-                        profileSettings.updateActiveBadge(targetData, badge.id(), true, true);
-                        context.render();
-                    }
-                }
-            }
+        private PlayerData resolveTargetData(MenuRenderContext<BadgesState> context) {
+            return context.session().playerDataRepository.findByUuid(context.state().targetUuid);
         }
     }
 
-    static final class AllBadgesFlow implements RoutedMenuFlow<AllBadgesState> {
+    static final class AllBadgesFlow extends BaseMenuFlow<AllBadgesState> {
         private final PlayerProfileSettingsService profileSettings;
 
         AllBadgesFlow(PlayerProfileSettingsService profileSettings) {
+            super(ROUTE_ALL_BADGES, AllBadgesState.class);
             this.profileSettings = profileSettings;
-        }
 
-        @Override
-        public String routeId() {
-            return ROUTE_ALL_BADGES;
+            defaultAction((ctx, actionId) -> {
+                PlayerData targetData = resolveTargetData(ctx);
+                if (targetData == null) return;
+                Badge badge = Badge.byId(actionId);
+                if (badge != null) {
+                    if (badge.selectable() && !badge.system() && ownsBadge(targetData, badge)) {
+                        profileSettings.updateActiveBadge(targetData, badge.id(), true, true);
+                    }
+                    ctx.render();
+                }
+            });
         }
 
         @Override
@@ -653,11 +536,6 @@ final class PlayerSettingsFlows {
                 return currentState;
             }
             return new AllBadgesState(targetUuid);
-        }
-
-        @Override
-        public Class<AllBadgesState> stateType() {
-            return AllBadgesState.class;
         }
 
         @Override
@@ -677,52 +555,29 @@ final class PlayerSettingsFlows {
             }
 
             Localization local = context.locale();
-            List<List<MenuButton>> rows = new ArrayList<>();
+            var grid = new MenuGrid();
 
             for (Badge badge : Badge.values()) {
-                rows.add(List.of(MenuButton.of(
+                grid.row(MenuButton.of(
                         local.t("badge-menu-all-row", args(
                                 "badge", badgeLabel(local, badge),
                                 "state", badgeState(local, targetData, badge),
                                 "description", local.t(badge.descriptionKey())
                         )),
-                        badge.id())));
+                        badge.id()));
             }
 
-            List<MenuButton> navigation = new ArrayList<>();
-            if (session.canGoBack()) {
-                navigation.add(MenuButton.of(local.t("back"), ACTION_BACK));
-            }
-            navigation.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
-            rows.add(navigation);
+            grid.defaultNavigation(session, local);
 
             return MenuScreen.normal(
                     local.t("badge-menu-all-title"),
                     local.t("badge-menu-all-content"),
-                    rows
+                    grid.build()
             );
         }
 
-        @Override
-        public void onAction(MenuRenderContext<AllBadgesState> context, String actionId) {
-            Session session = context.session();
-            AllBadgesState state = context.state();
-            PlayerData targetData = session.playerDataRepository.findByUuid(state.targetUuid);
-            if (targetData == null) return;
-
-            switch (actionId) {
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                default -> {
-                    Badge badge = Badge.byId(actionId);
-                    if (badge != null) {
-                        if (badge.selectable() && !badge.system() && ownsBadge(targetData, badge)) {
-                            profileSettings.updateActiveBadge(targetData, badge.id(), true, true);
-                        }
-                        context.render();
-                    }
-                }
-            }
+        private PlayerData resolveTargetData(MenuRenderContext<AllBadgesState> context) {
+            return context.session().playerDataRepository.findByUuid(context.state().targetUuid);
         }
     }
 
@@ -799,7 +654,7 @@ final class PlayerSettingsFlows {
         return MenuScreen.normal(
                 local.t(titleKey),
                 local.t(messageKey),
-                List.of(List.of(MenuButton.of(local.t("close"), ACTION_CLOSE)))
+                new MenuGrid().row(MenuButton.of(local.t("close"), "close")).build()
         );
     }
 

--- a/src/main/java/org/xcore/plugin/ui/menu/TopMenu.java
+++ b/src/main/java/org/xcore/plugin/ui/menu/TopMenu.java
@@ -13,11 +13,12 @@ import org.xcore.plugin.service.TopMenuService;
 import org.xcore.plugin.session.Session;
 import org.xcore.plugin.session.SessionService;
 import org.xcore.plugin.ui.MenuService;
+import org.xcore.plugin.ui.flow.BaseMenuFlow;
 import org.xcore.plugin.ui.flow.MenuButton;
+import org.xcore.plugin.ui.flow.MenuGrid;
 import org.xcore.plugin.ui.flow.MenuRenderContext;
 import org.xcore.plugin.ui.flow.MenuScreen;
 import org.xcore.plugin.ui.route.MenuRoute;
-import org.xcore.plugin.ui.route.RoutedMenuFlow;
 
 import java.text.NumberFormat;
 import java.util.ArrayDeque;
@@ -36,11 +37,6 @@ public class TopMenu extends Menu {
     private static final String ROUTE_TOP_LIST = "top.list";
     private static final String ROUTE_TOP_CATEGORIES = "top.categories";
 
-    private static final String ACTION_PREVIOUS = "previous";
-    private static final String ACTION_NEXT = "next";
-    private static final String ACTION_CATEGORY = "category";
-    private static final String ACTION_CLOSE = "close";
-    private static final String ACTION_BACK = "back";
     private static final String ACTION_PROFILE_PREFIX = "profile:";
 
     private final TopMenuService topMenuService;
@@ -110,14 +106,64 @@ public class TopMenu extends Menu {
         }
     }
 
-    private final class TopListFlow implements RoutedMenuFlow<TopMenuState> {
-        @Override
-        public String routeId() {
-            return ROUTE_TOP_LIST;
+    private final class TopListFlow extends BaseMenuFlow<TopMenuState> {
+        TopListFlow() {
+            super(ROUTE_TOP_LIST, TopMenuState.class);
+            action("previous", ctx -> {
+                TopMenuState state = ctx.state();
+                LeaderboardCursor previous = state.backStack.pollLast();
+                LeaderboardCursor previousCursor = previous == FIRST_PAGE_MARKER ? null : previous;
+                state.currentCursor = previousCursor;
+                state.currentPage = Math.max(1, state.currentPage - 1);
+                ctx.render();
+            });
+            action("next", ctx -> {
+                TopMenuState state = ctx.state();
+                state.backStack.addLast(state.currentCursor == null ? FIRST_PAGE_MARKER : state.currentCursor);
+                state.currentCursor = state.nextCursor;
+                state.currentPage = state.currentPage + 1;
+                ctx.render();
+            });
+            action("category", ctx -> {
+                TopMenuState state = ctx.state();
+                Session session = ctx.session();
+                TopCategory savedCategory = state.category;
+                LeaderboardCursor savedCursor = state.currentCursor;
+                int savedPage = state.currentPage;
+                Deque<LeaderboardCursor> savedBackStack = new ArrayDeque<>(state.backStack);
+                LeaderboardCursor savedNextCursor = state.nextCursor;
+                session.pushHistory(() -> {
+                    session.clear();
+                    TopMenuState histState = session.getDraft(TopMenuState.class);
+                    histState.category = savedCategory;
+                    histState.currentCursor = savedCursor;
+                    histState.currentPage = savedPage;
+                    histState.backStack = savedBackStack;
+                    histState.nextCursor = savedNextCursor;
+                    session.menuService.renderRoute(session, MenuRoute.of(ROUTE_TOP_LIST)
+                            .withParam("category", savedCategory.name()));
+                });
+                session.menuService.hideFollowUp(session);
+                session.menuService.renderRoute(session, MenuRoute.of(ROUTE_TOP_CATEGORIES)
+                        .withParam("category", state.category.name()));
+            });
+            actionPrefix("profile:", (ctx, targetUuid) -> {
+                PlayerData target = ctx.session().playerDataRepository.findByUuid(targetUuid);
+                if (target != null) {
+                    if (ctx.route() != null) {
+                        ctx.session().pushRouteHistory(ctx.route());
+                    }
+                    ctx.session().menuService.hideFollowUp(ctx.session());
+                    playerMenu.player(ctx.session().data.uuid, target);
+                }
+            });
         }
 
         @Override
         public TopMenuState createState(Session session, MenuRoute route, TopMenuState currentState) {
+            if (currentState == null) {
+                currentState = new TopMenuState();
+            }
             TopCategory routeCategory = parseCategory(route.param("category"));
             TopCategory resolvedCategory = routeCategory == null ? topMenuService.resolveDefaultCategory() : routeCategory;
             int routePage = route.intParam("page", 1);
@@ -134,11 +180,6 @@ public class TopMenu extends Menu {
         }
 
         @Override
-        public Class<TopMenuState> stateType() {
-            return TopMenuState.class;
-        }
-
-        @Override
         public MenuScreen render(MenuRenderContext<TopMenuState> context) {
             Session session = context.session();
             TopMenuState state = context.state();
@@ -152,34 +193,29 @@ public class TopMenu extends Menu {
             state.nextCursor = topPage.nextCursor();
 
             String categoryName = local.t(resolvedCategory.bundleKey());
-            List<List<MenuButton>> rows = new ArrayList<>();
+            var grid = new MenuGrid();
 
             if (topPage.totalEntries() > 0) {
                 for (int i = 0; i < topPage.players().size(); i++) {
                     PlayerData player = topPage.players().get(i);
                     String buttonText = cursorPlayerButton(session, topPage, resolvedCategory, player, i);
-                    rows.add(List.of(MenuButton.of(buttonText, ACTION_PROFILE_PREFIX + player.uuid)));
+                    grid.row(MenuButton.of(buttonText, ACTION_PROFILE_PREFIX + player.uuid));
                 }
             }
 
             List<MenuButton> navRow = new ArrayList<>();
             if (!state.backStack.isEmpty()) {
-                navRow.add(MenuButton.of(local.t("previous"), ACTION_PREVIOUS));
+                navRow.add(MenuButton.of(local.t("previous"), "previous"));
             }
-            navRow.add(MenuButton.of(local.t("top-menu-category-button", args("category", categoryName)), ACTION_CATEGORY));
+            navRow.add(MenuButton.of(local.t("top-menu-category-button", args("category", categoryName)), "category"));
             if (topPage.hasNext() && state.nextCursor != null) {
-                navRow.add(MenuButton.of(local.t("next"), ACTION_NEXT));
+                navRow.add(MenuButton.of(local.t("next"), "next"));
             }
             if (!navRow.isEmpty()) {
-                rows.add(navRow);
+                grid.row(navRow.toArray(new MenuButton[0]));
             }
 
-            List<MenuButton> bottomNav = new ArrayList<>();
-            if (session.canGoBack()) {
-                bottomNav.add(MenuButton.of(local.t("back"), ACTION_BACK));
-            }
-            bottomNav.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
-            rows.add(bottomNav);
+            grid.defaultNavigation(session, local);
 
             return MenuScreen.followUp(
                     local.t("top-menu-title", args("category", categoryName)),
@@ -192,86 +228,31 @@ public class TopMenu extends Menu {
                                     "category", categoryName,
                                     "selfRankLine", selfRankLine(local, topPage.selfRank())
                             )),
-                    rows
+                    grid.build()
             );
-        }
-
-        @Override
-        public void onAction(MenuRenderContext<TopMenuState> context, String actionId) {
-            TopMenuState state = context.state();
-            Session session = context.session();
-
-            switch (actionId) {
-                case ACTION_PREVIOUS -> {
-                    LeaderboardCursor previous = state.backStack.pollLast();
-                    LeaderboardCursor previousCursor = previous == FIRST_PAGE_MARKER ? null : previous;
-                    state.currentCursor = previousCursor;
-                    state.currentPage = Math.max(1, state.currentPage - 1);
-                    context.render();
-                }
-                case ACTION_NEXT -> {
-                    state.backStack.addLast(state.currentCursor == null ? FIRST_PAGE_MARKER : state.currentCursor);
-                    state.currentCursor = state.nextCursor;
-                    state.currentPage = state.currentPage + 1;
-                    context.render();
-                }
-                case ACTION_CATEGORY -> {
-                    TopCategory savedCategory = state.category;
-                    LeaderboardCursor savedCursor = state.currentCursor;
-                    int savedPage = state.currentPage;
-                    Deque<LeaderboardCursor> savedBackStack = new ArrayDeque<>(state.backStack);
-                    LeaderboardCursor savedNextCursor = state.nextCursor;
-                    // This handoff still needs an immutable snapshot. Route history alone only restores
-                    // the route params, while this callback also preserves cursor/back-stack state even
-                    // if the draft is later reset by opening a different leaderboard route.
-                    session.pushHistory(() -> {
-                        session.clear();
-                        TopMenuState histState = session.getDraft(TopMenuState.class);
-                        histState.category = savedCategory;
-                        histState.currentCursor = savedCursor;
-                        histState.currentPage = savedPage;
-                        histState.backStack = savedBackStack;
-                        histState.nextCursor = savedNextCursor;
-                        session.menuService.renderRoute(session, MenuRoute.of(ROUTE_TOP_LIST)
-                                .withParam("category", savedCategory.name()));
-                    });
-                    session.menuService.hideFollowUp(session);
-                    session.menuService.renderRoute(session, MenuRoute.of(ROUTE_TOP_CATEGORIES)
-                            .withParam("category", state.category.name()));
-                }
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                default -> {
-                    if (actionId.startsWith(ACTION_PROFILE_PREFIX)) {
-                        String targetUuid = actionId.substring(ACTION_PROFILE_PREFIX.length());
-                        PlayerData target = session.playerDataRepository.findByUuid(targetUuid);
-                        if (target != null) {
-                            if (context.route() != null) {
-                                session.pushRouteHistory(context.route());
-                            }
-                            session.menuService.hideFollowUp(session);
-                            playerMenu.player(session.data.uuid, target);
-                        }
-                    }
-                }
-            }
         }
     }
 
-    private final class CategoriesFlow implements RoutedMenuFlow<TopCategoriesState> {
-        @Override
-        public String routeId() {
-            return ROUTE_TOP_CATEGORIES;
+    private final class CategoriesFlow extends BaseMenuFlow<TopCategoriesState> {
+        CategoriesFlow() {
+            super(ROUTE_TOP_CATEGORIES, TopCategoriesState.class);
+            defaultAction((ctx, actionId) -> {
+                try {
+                    TopCategory category = TopCategory.valueOf(actionId);
+                    Session session = ctx.session();
+                    session.clear();
+                    session.clearDraft(TopMenuState.class);
+                    session.menuService.renderRoute(session, MenuRoute.of(ROUTE_TOP_LIST)
+                            .withParam("category", category.name())
+                            .withParam("page", "1"));
+                } catch (IllegalArgumentException ignored) {
+                }
+            });
         }
 
         @Override
         public TopCategoriesState createState(Session session, MenuRoute route, TopCategoriesState currentState) {
             return currentState == null ? new TopCategoriesState() : currentState;
-        }
-
-        @Override
-        public Class<TopCategoriesState> stateType() {
-            return TopCategoriesState.class;
         }
 
         @Override
@@ -286,47 +267,19 @@ public class TopMenu extends Menu {
 
             String categoryName = local.t(currentCategory.bundleKey());
 
-            List<List<MenuButton>> rows = new ArrayList<>();
-            rows.add(List.of(
+            var grid = new MenuGrid();
+            grid.row(
                     MenuButton.of(categoryButton(session, TopCategory.MINI_PVP, currentCategory), TopCategory.MINI_PVP.name()),
                     MenuButton.of(categoryButton(session, TopCategory.PLAYTIME, currentCategory), TopCategory.PLAYTIME.name())
-            ));
-            rows.add(List.of(
-                    MenuButton.of(categoryButton(session, TopCategory.HEXED, currentCategory), TopCategory.HEXED.name())
-            ));
-
-            List<MenuButton> navRow = new ArrayList<>();
-            if (session.canGoBack()) {
-                navRow.add(MenuButton.of(local.t("back"), ACTION_BACK));
-            }
-            navRow.add(MenuButton.of(local.t("close"), ACTION_CLOSE));
-            rows.add(navRow);
+            );
+            grid.row(MenuButton.of(categoryButton(session, TopCategory.HEXED, currentCategory), TopCategory.HEXED.name()));
+            grid.defaultNavigation(session, local);
 
             return MenuScreen.normal(
                     local.t("top-menu-categories-title"),
                     local.t("top-menu-categories-content", args("category", categoryName)),
-                    rows
+                    grid.build()
             );
-        }
-
-        @Override
-        public void onAction(MenuRenderContext<TopCategoriesState> context, String actionId) {
-            Session session = context.session();
-            switch (actionId) {
-                case ACTION_BACK -> context.goBack();
-                case ACTION_CLOSE -> context.close();
-                default -> {
-                    try {
-                        TopCategory category = TopCategory.valueOf(actionId);
-                        session.clear();
-                        session.clearDraft(TopMenuState.class);
-                        session.menuService.renderRoute(session, MenuRoute.of(ROUTE_TOP_LIST)
-                                .withParam("category", category.name())
-                                .withParam("page", "1"));
-                    } catch (IllegalArgumentException ignored) {
-                    }
-                }
-            }
         }
     }
 


### PR DESCRIPTION
## Overview
Refactored the UI Flow architecture to reduce boilerplate, removing massive `switch` statements and `List.of` chains.

## Key Changes
1. **Core:** Introduced `BaseMenuFlow`, `MenuGrid`, and `NoState`.
2. **Routing:** Actions and Prompts are now registered declaratively in Flow constructors via `action()`, `actionPrefix()`, and `onPrompt()`.
3. **UI Building:** `MenuGrid` handles row construction, pagination, and default navigation.
4. **Cleanup:** Removed over 20+ empty state classes and hundreds of lines of `switch/case` boilerplate.

## Testing
- [x] Unit tests passed (612 tests, 0 failed, 17 skipped).
- [x] Verified prefix routing (`select:`, `details:`, `cmd:`, `map:`, `event:`, `status:`) works correctly.
- [x] Verified multi-step prompts (e.g., `BanMenu`, `EventDraftFlows`) execute callbacks correctly.
- [x] Build passes (`./gradlew compileJava`, `./gradlew shadowJar`).

## Files Changed
- **New:** `BaseMenuFlow.java`, `MenuGrid.java`, `NoState.java`, `MenuPromptContext.java`
- **Refactored:** `InformationMenu`, `DiscordFlows`, `HelpFlows`, `AuditHistoryFlows`, `MessageFlows`, `PlayerProfileFlows`, `PlayerSettingsFlows`, `MapFlows`, `TopMenu`, `EventFlows`, `EventDraftFlows`, `BanMenu`