### PR TITLE
Add IP reputation ingress checks

### DIFF
--- a/src/main/java/org/xcore/plugin/command/controller/server/IpReputationServerController.java
+++ b/src/main/java/org/xcore/plugin/command/controller/server/IpReputationServerController.java
@@ -1,0 +1,119 @@
+package org.xcore.plugin.command.controller.server;
+
+import arc.util.Log;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.CommandDescription;
+import org.xcore.plugin.cloud.XCoreSender;
+import org.xcore.plugin.command.controller.CloudServerController;
+import org.xcore.plugin.security.ingress.ipreputation.IpReputationAllowlist;
+import org.xcore.plugin.security.ingress.ipreputation.IpReputationResult;
+import org.xcore.plugin.security.ingress.ipreputation.IpReputationService;
+
+import java.util.Set;
+
+/**
+ * Server console commands for IP reputation diagnostics and allowlist management.
+ * <p>
+ * All commands are server-only and log results to the console.
+ */
+@Singleton
+public class IpReputationServerController implements CloudServerController {
+
+    private final IpReputationService ipReputationService;
+    private final IpReputationAllowlist allowlist;
+
+    @Inject
+    public IpReputationServerController(IpReputationService ipReputationService,
+                                        IpReputationAllowlist allowlist) {
+        this.ipReputationService = ipReputationService;
+        this.allowlist = allowlist;
+    }
+
+    @Command("iprep lookup <ip>")
+    @CommandDescription("Performs a fresh provider lookup for the given IP.")
+    public void lookup(XCoreSender sender,
+                       @Argument(value = "ip", description = "IP address to look up") String ip) {
+        if (ip == null || ip.isBlank()) {
+            Log.err("IP address cannot be blank.");
+            return;
+        }
+
+        IpReputationResult result = ipReputationService.lookup(ip.trim());
+        if (result == null) {
+            Log.err("Lookup failed or IP reputation is disabled.");
+            return;
+        }
+
+        Log.info("IP Reputation for @: proxy=@, hosting=@, mobile=@",
+                result.ip(), result.proxy(), result.hosting(), result.mobile());
+    }
+
+    @Command("iprep check <ip>")
+    @CommandDescription("Checks whether the given IP would be blocked by current policy.")
+    public void check(XCoreSender sender,
+                      @Argument(value = "ip", description = "IP address to check") String ip) {
+        if (ip == null || ip.isBlank()) {
+            Log.err("IP address cannot be blank.");
+            return;
+        }
+
+        boolean blocked = ipReputationService.isBlocked(ip.trim());
+        if (blocked) {
+            Log.info("IP @ would be BLOCKED.", ip.trim());
+        } else {
+            Log.info("IP @ would be ALLOWED.", ip.trim());
+        }
+    }
+
+    @Command("iprep allow add <ip>")
+    @CommandDescription("Adds an IP to the IP reputation allowlist.")
+    public void allowAdd(XCoreSender sender,
+                         @Argument(value = "ip", description = "IP address to allowlist") String ip) {
+        if (ip == null || ip.isBlank()) {
+            Log.err("IP address cannot be blank.");
+            return;
+        }
+
+        String normalized = ip.trim();
+        if (allowlist.add(normalized)) {
+            Log.info("Added @ to the IP reputation allowlist.", normalized);
+        } else {
+            Log.err("Failed to add @ to the allowlist.", normalized);
+        }
+    }
+
+    @Command("iprep allow remove <ip>")
+    @CommandDescription("Removes an IP from the IP reputation allowlist.")
+    public void allowRemove(XCoreSender sender,
+                            @Argument(value = "ip", description = "IP address to remove from allowlist") String ip) {
+        if (ip == null || ip.isBlank()) {
+            Log.err("IP address cannot be blank.");
+            return;
+        }
+
+        String normalized = ip.trim();
+        if (allowlist.remove(normalized)) {
+            Log.info("Removed @ from the IP reputation allowlist.", normalized);
+        } else {
+            Log.err("Failed to remove @ from the allowlist.", normalized);
+        }
+    }
+
+    @Command("iprep allow list")
+    @CommandDescription("Lists all IPs on the IP reputation allowlist.")
+    public void allowList(XCoreSender sender) {
+        Set<String> entries = allowlist.list();
+        if (entries.isEmpty()) {
+            Log.info("IP reputation allowlist is empty.");
+            return;
+        }
+
+        Log.info("IP reputation allowlist (@ entries):", entries.size());
+        for (String entry : entries) {
+            Log.info("  - @", entry);
+        }
+    }
+}

--- a/src/main/java/org/xcore/plugin/command/controller/server/IpReputationServerController.java
+++ b/src/main/java/org/xcore/plugin/command/controller/server/IpReputationServerController.java
@@ -25,6 +25,9 @@ public class IpReputationServerController implements CloudServerController {
     private final IpReputationService ipReputationService;
     private final IpReputationAllowlist allowlist;
 
+    /**
+     * Creates an IpReputationServerController and stores the provided service and allowlist for use by its command handlers.
+     */
     @Inject
     public IpReputationServerController(IpReputationService ipReputationService,
                                         IpReputationAllowlist allowlist) {
@@ -32,6 +35,11 @@ public class IpReputationServerController implements CloudServerController {
         this.allowlist = allowlist;
     }
 
+    /**
+     * Perform a fresh provider reputation lookup for the specified IP and log the resulting reputation fields.
+     *
+     * @param ip the IP address to look up; leading and trailing whitespace is ignored
+     */
     @Command("iprep lookup <ip>")
     @CommandDescription("Performs a fresh provider lookup for the given IP.")
     public void lookup(XCoreSender sender,
@@ -51,6 +59,12 @@ public class IpReputationServerController implements CloudServerController {
                 result.ip(), result.proxy(), result.hosting(), result.mobile());
     }
 
+    /**
+     * Determines whether a given IP would be blocked by the current IP-reputation policy.
+     *
+     * @param sender the command sender invoking this check
+     * @param ip the IP address to evaluate; must not be null or blank
+     */
     @Command("iprep check <ip>")
     @CommandDescription("Checks whether the given IP would be blocked by current policy.")
     public void check(XCoreSender sender,
@@ -68,6 +82,13 @@ public class IpReputationServerController implements CloudServerController {
         }
     }
 
+    /**
+     * Adds the given IP address to the IP reputation allowlist.
+     *
+     * If `ip` is null or blank the method logs an error and returns without modifying the allowlist.
+     *
+     * @param ip the IP address to add; leading and trailing whitespace are trimmed before insertion
+     */
     @Command("iprep allow add <ip>")
     @CommandDescription("Adds an IP to the IP reputation allowlist.")
     public void allowAdd(XCoreSender sender,
@@ -85,6 +106,11 @@ public class IpReputationServerController implements CloudServerController {
         }
     }
 
+    /**
+     * Removes the given IP address from the IP reputation allowlist.
+     *
+     * @param ip the IP address (or CIDR) to remove from the allowlist; leading and trailing whitespace will be ignored
+     */
     @Command("iprep allow remove <ip>")
     @CommandDescription("Removes an IP from the IP reputation allowlist.")
     public void allowRemove(XCoreSender sender,
@@ -102,6 +128,12 @@ public class IpReputationServerController implements CloudServerController {
         }
     }
 
+    /**
+     * Prints all IPs currently stored in the IP reputation allowlist to the server console.
+     *
+     * If the allowlist is empty, logs a message indicating that; otherwise logs the total
+     * number of entries followed by each entry on its own line.
+     */
     @Command("iprep allow list")
     @CommandDescription("Lists all IPs on the IP reputation allowlist.")
     public void allowList(XCoreSender sender) {

--- a/src/main/java/org/xcore/plugin/config/Config.java
+++ b/src/main/java/org/xcore/plugin/config/Config.java
@@ -56,6 +56,7 @@ public class Config {
     public boolean isEventHubMap = false;
     public String eventHubMapID = "";
     public TranslationConfig translation = new TranslationConfig();
+    public IpReputationConfig ipReputation = new IpReputationConfig();
 
     public void normalize() {
         if (disabledCommands == null) {
@@ -70,7 +71,12 @@ public class Config {
             translation = new TranslationConfig();
         }
 
+        if (ipReputation == null) {
+            ipReputation = new IpReputationConfig();
+        }
+
         translation.normalize();
+        ipReputation.normalize();
     }
 
     public static class TranslationConfig {
@@ -146,6 +152,21 @@ public class Config {
 
             if (maxOutputChars <= 0) {
                 maxOutputChars = 1200;
+            }
+        }
+    }
+
+    public static class IpReputationConfig {
+        public boolean enabled = false;
+        public boolean blockProxy = true;
+        public boolean blockVpn = true;
+        public boolean blockTor = true;
+        public boolean blockHosting = false;
+        public int cacheTtlSeconds = 3600;
+
+        public void normalize() {
+            if (cacheTtlSeconds <= 0) {
+                cacheTtlSeconds = 3600;
             }
         }
     }

--- a/src/main/java/org/xcore/plugin/config/Config.java
+++ b/src/main/java/org/xcore/plugin/config/Config.java
@@ -58,6 +58,15 @@ public class Config {
     public TranslationConfig translation = new TranslationConfig();
     public IpReputationConfig ipReputation = new IpReputationConfig();
 
+    /**
+     * Ensures configuration sub-objects and collections are initialized and normalized.
+     *
+     * If any of the mutable sub-fields are null, replaces them with default instances and
+     * then invokes their normalize methods to enforce sane defaults. Specifically initializes
+     * {@code disabledCommands}, {@code disabledFeatures}, {@code translation}, and
+     * {@code ipReputation} when null and calls {@code translation.normalize()} and
+     * {@code ipReputation.normalize()}.
+     */
     public void normalize() {
         if (disabledCommands == null) {
             disabledCommands = new HashSet<>();
@@ -145,6 +154,11 @@ public class Config {
         public int maxOutputChars = 1200;
         public boolean stripControlCharacters = true;
 
+        /**
+         * Ensures the translation policy's maximum input and output character limits are positive, applying defaults when they are not.
+         *
+         * If `maxInputChars` is less than or equal to zero, it is set to 500. If `maxOutputChars` is less than or equal to zero, it is set to 1200.
+         */
         public void normalize() {
             if (maxInputChars <= 0) {
                 maxInputChars = 500;
@@ -164,6 +178,11 @@ public class Config {
         public boolean blockHosting = false;
         public int cacheTtlSeconds = 3600;
 
+        /**
+         * Ensure configuration fields have valid values and apply defaults where necessary.
+         *
+         * <p>Sets {@code cacheTtlSeconds} to 3600 if its value is less than or equal to zero.</p>
+         */
         public void normalize() {
             if (cacheTtlSeconds <= 0) {
                 cacheTtlSeconds = 3600;

--- a/src/main/java/org/xcore/plugin/config/GlobalConfig.java
+++ b/src/main/java/org/xcore/plugin/config/GlobalConfig.java
@@ -41,6 +41,7 @@ public class GlobalConfig {
     public boolean isDataBaseReadOnly = false;
     public boolean isDataBaseMigration = false;
     public Map<String, TranslationProviderConfig> translationProviders = defaultTranslationProviders();
+    public IpReputationProviderConfig ipReputationProvider = new IpReputationProviderConfig();
 
     public void normalize() {
         if (translationProviders == null || translationProviders.isEmpty()) {
@@ -54,6 +55,12 @@ public class GlobalConfig {
             normalized.normalize();
             return normalized;
         });
+
+        if (ipReputationProvider == null) {
+            ipReputationProvider = new IpReputationProviderConfig();
+        }
+
+        ipReputationProvider.normalize();
     }
 
     public void postInit(Fi globalConfigFile) {
@@ -135,6 +142,31 @@ public class GlobalConfig {
 
             if (supportedLanguages == null) {
                 supportedLanguages = new LinkedHashSet<>();
+            }
+        }
+    }
+
+    public static class IpReputationProviderConfig {
+        public String baseUrl = "http://ip-api.com/json";
+        public int timeoutSeconds = 10;
+        public int maxRetries = 2;
+        public int rateLimitPerMinute = 45;
+
+        public void normalize() {
+            if (baseUrl == null || baseUrl.isBlank()) {
+                baseUrl = "http://ip-api.com/json";
+            }
+
+            if (timeoutSeconds <= 0) {
+                timeoutSeconds = 10;
+            }
+
+            if (maxRetries < 0) {
+                maxRetries = 2;
+            }
+
+            if (rateLimitPerMinute <= 0) {
+                rateLimitPerMinute = 45;
             }
         }
     }

--- a/src/main/java/org/xcore/plugin/config/GlobalConfig.java
+++ b/src/main/java/org/xcore/plugin/config/GlobalConfig.java
@@ -43,6 +43,12 @@ public class GlobalConfig {
     public Map<String, TranslationProviderConfig> translationProviders = defaultTranslationProviders();
     public IpReputationProviderConfig ipReputationProvider = new IpReputationProviderConfig();
 
+    /**
+     * Normalizes and populates missing global configuration for translation and IP reputation providers.
+     *
+     * Ensures the translation provider map is present (using defaults when absent), normalizes every
+     * TranslationProviderConfig entry, ensures an IpReputationProviderConfig exists, and normalizes it.
+     */
     public void normalize() {
         if (translationProviders == null || translationProviders.isEmpty()) {
             translationProviders = defaultTranslationProviders();
@@ -63,6 +69,15 @@ public class GlobalConfig {
         ipReputationProvider.normalize();
     }
 
+    /**
+     * Validates required global configuration fields after normalizing the configuration and aborts startup if any are missing.
+     *
+     * Ensures `mongoConnectionString` and `databaseName` are present and non-blank; when validation fails, a formatted error is logged
+     * referencing the provided configuration file and an IllegalStateException is thrown.
+     *
+     * @param globalConfigFile the configuration file used in error messages
+     * @throws IllegalStateException if one or more required fields are missing or blank
+     */
     public void postInit(Fi globalConfigFile) {
         normalize();
 
@@ -115,6 +130,18 @@ public class GlobalConfig {
         public double temperature = 0.0;
         public Set<String> supportedLanguages = new LinkedHashSet<>();
 
+        /**
+         * Ensure configuration fields have sensible defaults and normalized values.
+         *
+         * Applies defaults and normalization to the instance's fields when they are missing or invalid:
+         * - `type` → `"google"` if blank or null
+         * - `baseUrl` → `"https://api.openai.com/v1"` if blank or null
+         * - `model` → `"gpt-5.4"` if blank or null
+         * - `apiMode` → trimmed and lowercased when non-blank
+         * - `timeoutSeconds` → `15` if less than or equal to zero
+         * - `maxRetries` → `1` if negative
+         * - `supportedLanguages` → new empty `LinkedHashSet` if null
+         */
         public void normalize() {
             if (type == null || type.isBlank()) {
                 type = "google";
@@ -152,6 +179,17 @@ public class GlobalConfig {
         public int maxRetries = 2;
         public int rateLimitPerMinute = 45;
 
+        /**
+         * Ensures configuration fields have valid values, replacing missing or invalid entries with defaults.
+         *
+         * <p>Defaults applied:
+         * <ul>
+         *   <li>{@code baseUrl} → {@code "http://ip-api.com/json"} when null or blank</li>
+         *   <li>{@code timeoutSeconds} → {@code 10} when ≤ 0</li>
+         *   <li>{@code maxRetries} → {@code 2} when < 0</li>
+         *   <li>{@code rateLimitPerMinute} → {@code 45} when ≤ 0</li>
+         * </ul>
+         */
         public void normalize() {
             if (baseUrl == null || baseUrl.isBlank()) {
                 baseUrl = "http://ip-api.com/json";

--- a/src/main/java/org/xcore/plugin/security/ingress/checks/IpReputationCheck.java
+++ b/src/main/java/org/xcore/plugin/security/ingress/checks/IpReputationCheck.java
@@ -1,0 +1,71 @@
+package org.xcore.plugin.security.ingress.checks;
+
+import com.ospx.flubundle.Bundle;
+import jakarta.inject.Singleton;
+import mindustry.net.NetConnection;
+import mindustry.net.Packets;
+import org.xcore.plugin.config.GlobalConfig;
+import org.xcore.plugin.localization.Localization;
+import org.xcore.plugin.security.ingress.AccessResult;
+import org.xcore.plugin.security.ingress.IngressCheck;
+import org.xcore.plugin.security.ingress.ipreputation.IpReputationService;
+
+import static com.ospx.flubundle.Bundle.args;
+
+/**
+ * Checks whether the connecting IP address has a bad reputation
+ * (proxy / VPN / TOR) using the configured IP reputation service.
+ * <p>
+ * Priority 10: Slow check that may consult cache or external provider,
+ * runs in parallel with other slow checks.
+ * <p>
+ * Fail-open: any internal error during evaluation results in Allowed.
+ */
+@Singleton
+public class IpReputationCheck implements IngressCheck {
+
+    private final IpReputationService ipReputationService;
+    private final Bundle bundle;
+    private final GlobalConfig globalConfig;
+
+    public IpReputationCheck(IpReputationService ipReputationService, Bundle bundle, GlobalConfig globalConfig) {
+        this.ipReputationService = ipReputationService;
+        this.bundle = bundle;
+        this.globalConfig = globalConfig;
+    }
+
+    @Override
+    public AccessResult check(NetConnection con, Packets.ConnectPacket packet) {
+        String ip = con.address;
+        if (ip == null || ip.isBlank()) {
+            return AccessResult.Allowed.INSTANCE;
+        }
+
+        String normalized = ip.trim();
+
+        try {
+            if (ipReputationService.isBlocked(normalized)) {
+                Localization local = new Localization(bundle, bundle.resolveLocale(packet.locale));
+                String reason = local.format("ip-reputation-denied", args(
+                        "discordUrl", globalConfig.discordUrl
+                ));
+                return new AccessResult.Denied(reason, false, 0);
+            }
+        } catch (Exception e) {
+            // Fail open on any internal error from the reputation service.
+            return AccessResult.Allowed.INSTANCE;
+        }
+
+        return AccessResult.Allowed.INSTANCE;
+    }
+
+    @Override
+    public int priority() {
+        return 10;
+    }
+
+    @Override
+    public String name() {
+        return "IpReputationCheck";
+    }
+}

--- a/src/main/java/org/xcore/plugin/security/ingress/checks/IpReputationCheck.java
+++ b/src/main/java/org/xcore/plugin/security/ingress/checks/IpReputationCheck.java
@@ -29,12 +29,31 @@ public class IpReputationCheck implements IngressCheck {
     private final Bundle bundle;
     private final GlobalConfig globalConfig;
 
+    /**
+     * Constructs an IpReputationCheck that evaluates connection IPs against an IP reputation service.
+     *
+     * @param ipReputationService service used to determine whether an IP is blocked (e.g., proxy/VPN/TOR)
+     * @param bundle               localization bundle used to format denial messages
+     * @param globalConfig         configuration providing values included in denial messages (notably `discordUrl`)
+     */
     public IpReputationCheck(IpReputationService ipReputationService, Bundle bundle, GlobalConfig globalConfig) {
         this.ipReputationService = ipReputationService;
         this.bundle = bundle;
         this.globalConfig = globalConfig;
     }
 
+    /**
+     * Checks the connection's IP against the reputation service and denies access when the IP is blocked.
+     *
+     * If the connection address is null or blank the check allows. When the IP is blocked this returns
+     * an AccessResult.Denied containing a localized denial reason (locale resolved from the connect
+     * packet). If an error occurs while querying the reputation service the method fails open and
+     * returns an allow result.
+     *
+     * @param con    the network connection whose IP address will be evaluated
+     * @param packet the connect packet whose locale is used to localize the denial reason
+     * @return       an AccessResult.Denied with a localized reason when the IP is blocked, `AccessResult.Allowed.INSTANCE` otherwise
+     */
     @Override
     public AccessResult check(NetConnection con, Packets.ConnectPacket packet) {
         String ip = con.address;
@@ -60,11 +79,21 @@ public class IpReputationCheck implements IngressCheck {
         return AccessResult.Allowed.INSTANCE;
     }
 
+    /**
+     * Execution priority of this ingress check.
+     *
+     * @return `10` indicating the check's execution order relative to others; lower values run earlier.
+     */
     @Override
     public int priority() {
         return 10;
     }
 
+    /**
+     * Identifies this ingress check implementation.
+     *
+     * @return the name of the check, "IpReputationCheck"
+     */
     @Override
     public String name() {
         return "IpReputationCheck";

--- a/src/main/java/org/xcore/plugin/security/ingress/checks/IpReputationCheck.java
+++ b/src/main/java/org/xcore/plugin/security/ingress/checks/IpReputationCheck.java
@@ -5,6 +5,7 @@ import jakarta.inject.Singleton;
 import mindustry.net.NetConnection;
 import mindustry.net.Packets;
 import org.xcore.plugin.config.GlobalConfig;
+import org.xcore.plugin.common.PLog;
 import org.xcore.plugin.localization.Localization;
 import org.xcore.plugin.security.ingress.AccessResult;
 import org.xcore.plugin.security.ingress.IngressCheck;
@@ -52,7 +53,7 @@ public class IpReputationCheck implements IngressCheck {
                 return new AccessResult.Denied(reason, false, 0);
             }
         } catch (Exception e) {
-            // Fail open on any internal error from the reputation service.
+            PLog.errTag("IpReputationCheck", "Reputation service failed open", e);
             return AccessResult.Allowed.INSTANCE;
         }
 

--- a/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpApiProvider.java
+++ b/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpApiProvider.java
@@ -39,18 +39,41 @@ public class IpApiProvider implements IpReputationProvider {
     private final HttpClient client;
     private final Deque<Long> requestTimestamps = new ArrayDeque<>();
 
+    /**
+     * Creates a new IpApiProvider using values from the provided global configuration.
+     *
+     * The provider will use an HttpClient configured with a connect timeout derived from
+     * globalConfig.ipReputationProvider.timeoutSeconds.
+     *
+     * @param globalConfig global configuration containing ip reputation provider settings
+     */
     public IpApiProvider(GlobalConfig globalConfig) {
         this(globalConfig, HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(globalConfig.ipReputationProvider.timeoutSeconds))
                 .build());
     }
 
-    // Package-private for testing
+    /**
+     * Package-private constructor used for testing; initializes the provider with the given configuration and HTTP client.
+     *
+     * @param globalConfig supplies the {@code ipReputationProvider} settings (base URL, timeouts, retries, rate limits)
+     * @param client       the {@link HttpClient} to use for HTTP requests (injected, typically a test client)
+     */
     IpApiProvider(GlobalConfig globalConfig, HttpClient client) {
         this.providerConfig = globalConfig.ipReputationProvider;
         this.client = client;
     }
 
+    /**
+     * Performs an IP reputation lookup for the given IP and returns the parsed result or `null` when unavailable.
+     *
+     * The method trims the input, enforces a local per-minute rate limit, retries transient failures with
+     * exponential backoff up to the configured retry count, and returns `null` on invalid input, interruption,
+     * rate limiting, non-successful responses, parsing errors, or when all attempts fail.
+     *
+     * @param ip the IP address to lookup; leading and trailing whitespace will be ignored
+     * @return the resolved {@code IpReputationResult} for the IP, or {@code null} if the lookup cannot be completed
+     */
     @Override
     public IpReputationResult lookup(String ip) {
         if (ip == null || ip.isBlank()) {
@@ -90,6 +113,15 @@ public class IpApiProvider implements IpReputationProvider {
         return null;
     }
 
+    /**
+     * Performs an HTTP GET to the given URL and parses the JSON response into an IpReputationResult.
+     *
+     * @param url the full request URL (including the target IP) to query
+     * @return the parsed IpReputationResult from the response body, or `null` if the response JSON
+     *         does not indicate a successful lookup or cannot be parsed
+     * @throws IOException if the HTTP response status is not in the 2xx range or an I/O error occurs
+     * @throws InterruptedException if the thread is interrupted while sending the HTTP request
+     */
     private IpReputationResult executeLookup(String url) throws IOException, InterruptedException {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(url))
@@ -108,6 +140,12 @@ public class IpApiProvider implements IpReputationProvider {
         return parseResponse(response.body());
     }
 
+    /**
+     * Parses the JSON response from ip-api.com and produces an IpReputationResult when the response indicates success.
+     *
+     * @param body the raw JSON response body from ip-api.com
+     * @return an IpReputationResult populated from the response when `status` equals "success", or `null` if the response is missing/invalid, the status is not "success", or parsing fails
+     */
     private IpReputationResult parseResponse(String body) {
         try {
             JsonObject json = GSON.fromJson(body, JsonObject.class);
@@ -133,6 +171,15 @@ public class IpApiProvider implements IpReputationProvider {
         }
     }
 
+    /**
+     * Builds the full request URL for the configured provider by appending the given IP.
+     *
+     * Normalizes the configured base URL by removing a trailing '/' if present, then appends
+     * '/' followed by the provided IP.
+     *
+     * @param ip the IP address to append to the provider base URL
+     * @return the normalized base URL with the IP appended (e.g. "https://api.example.com/1.2.3.4")
+     */
     private String buildUrl(String ip) {
         String base = providerConfig.baseUrl;
         // Normalize: strip trailing slash, then append /{ip}
@@ -142,6 +189,13 @@ public class IpApiProvider implements IpReputationProvider {
         return base + "/" + ip;
     }
 
+    /**
+     * Sleep for an exponential backoff delay based on the attempt number, capped at 2000 ms.
+     *
+     * If the thread is interrupted while sleeping, the interrupt status is restored before returning.
+     *
+     * @param attempt 1-based attempt number used to compute the delay (delay = 200ms * 2^(attempt-1), capped at 2000ms)
+     */
     private void backoff(int attempt) {
         try {
             // Simple exponential backoff: 200ms, 400ms, 800ms...
@@ -152,6 +206,14 @@ public class IpApiProvider implements IpReputationProvider {
         }
     }
 
+    /**
+     * Acquires a local rate-limit slot if the number of requests in the recent window is below the configured per-minute limit.
+     *
+     * Evicts timestamps older than RATE_LIMIT_WINDOW_MILLIS from the internal timestamp deque, compares the remaining count
+     * against providerConfig.rateLimitPerMinute, and if allowed records the current time.
+     *
+     * @return `true` if a request slot was acquired and the current timestamp was recorded, `false` if the per-minute limit has been reached.
+     */
     private boolean tryAcquireRequestSlot() {
         synchronized (requestTimestamps) {
             long now = System.currentTimeMillis();
@@ -170,6 +232,13 @@ public class IpApiProvider implements IpReputationProvider {
         }
     }
 
+    /**
+     * Produce a short SHA-256 fingerprint token for an IP address suitable for logging.
+     *
+     * @param ip the IP address string to hash
+     * @return `sha256:` followed by the first 8 hex characters of the SHA-256 digest of {@code ip}
+     * @throws IllegalStateException if the SHA-256 MessageDigest is unavailable
+     */
     private String hashIp(String ip) {
         try {
             byte[] digest = MessageDigest.getInstance("SHA-256")

--- a/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpApiProvider.java
+++ b/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpApiProvider.java
@@ -16,6 +16,8 @@ import java.net.http.HttpResponse;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HexFormat;
 
 /**
@@ -31,9 +33,11 @@ import java.util.HexFormat;
 public class IpApiProvider implements IpReputationProvider {
 
     private static final Gson GSON = new Gson();
+    private static final long RATE_LIMIT_WINDOW_MILLIS = 60_000L;
 
     private final GlobalConfig.IpReputationProviderConfig providerConfig;
     private final HttpClient client;
+    private final Deque<Long> requestTimestamps = new ArrayDeque<>();
 
     public IpApiProvider(GlobalConfig globalConfig) {
         this(globalConfig, HttpClient.newBuilder()
@@ -59,6 +63,12 @@ public class IpApiProvider implements IpReputationProvider {
 
         int maxAttempts = Math.max(1, providerConfig.maxRetries + 1);
         for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            if (!tryAcquireRequestSlot()) {
+                PLog.warnTag("IpApiProvider", "Skipping lookup for @ because local rate limit @/min was reached",
+                        ipToken, providerConfig.rateLimitPerMinute);
+                return null;
+            }
+
             try {
                 return executeLookup(url);
             } catch (InterruptedException e) {
@@ -139,6 +149,24 @@ public class IpApiProvider implements IpReputationProvider {
             Thread.sleep(Math.min(delayMs, 2000L));
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+        }
+    }
+
+    private boolean tryAcquireRequestSlot() {
+        synchronized (requestTimestamps) {
+            long now = System.currentTimeMillis();
+            long cutoff = now - RATE_LIMIT_WINDOW_MILLIS;
+
+            while (!requestTimestamps.isEmpty() && requestTimestamps.peekFirst() <= cutoff) {
+                requestTimestamps.removeFirst();
+            }
+
+            if (requestTimestamps.size() >= providerConfig.rateLimitPerMinute) {
+                return false;
+            }
+
+            requestTimestamps.addLast(now);
+            return true;
         }
     }
 

--- a/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpApiProvider.java
+++ b/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpApiProvider.java
@@ -8,11 +8,15 @@ import org.xcore.plugin.common.PLog;
 import org.xcore.plugin.config.GlobalConfig;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
+import java.util.HexFormat;
 
 /**
  * IP reputation provider backed by ip-api.com.
@@ -50,6 +54,7 @@ public class IpApiProvider implements IpReputationProvider {
         }
 
         String normalized = ip.trim();
+        String ipToken = hashIp(normalized);
         String url = buildUrl(normalized);
 
         int maxAttempts = Math.max(1, providerConfig.maxRetries + 1);
@@ -58,16 +63,16 @@ public class IpApiProvider implements IpReputationProvider {
                 return executeLookup(url);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                PLog.warnTag("IpApiProvider", "Lookup interrupted for @", normalized);
+                PLog.warnTag("IpApiProvider", "Lookup interrupted for @", ipToken);
                 return null;
             } catch (IOException | RuntimeException e) {
                 if (attempt < maxAttempts) {
                     PLog.warnTag("IpApiProvider", "Lookup failed for @ (attempt @/@), retrying: @",
-                            normalized, attempt, maxAttempts, e.getMessage());
+                            ipToken, attempt, maxAttempts, e.getMessage());
                     backoff(attempt);
                 } else {
                     PLog.warnTag("IpApiProvider", "Lookup failed for @ after @ attempts: @",
-                            normalized, maxAttempts, e.getMessage());
+                            ipToken, maxAttempts, e.getMessage());
                 }
             }
         }
@@ -134,6 +139,16 @@ public class IpApiProvider implements IpReputationProvider {
             Thread.sleep(Math.min(delayMs, 2000L));
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+        }
+    }
+
+    private String hashIp(String ip) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(ip.getBytes(StandardCharsets.UTF_8));
+            return "sha256:" + HexFormat.of().formatHex(digest, 0, 8);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
         }
     }
 }

--- a/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpApiProvider.java
+++ b/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpApiProvider.java
@@ -1,0 +1,139 @@
+package org.xcore.plugin.security.ingress.ipreputation;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import jakarta.inject.Singleton;
+import org.xcore.plugin.common.PLog;
+import org.xcore.plugin.config.GlobalConfig;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+/**
+ * IP reputation provider backed by ip-api.com.
+ * <p>
+ * Transport concerns (HTTP, JSON parsing, retries) are internal to this class.
+ * The public surface ({@link IpReputationProvider}) is transport-agnostic.
+ * <p>
+ * Fail-open: any lookup failure returns {@code null} so the caller does not
+ * block ingress on provider errors.
+ */
+@Singleton
+public class IpApiProvider implements IpReputationProvider {
+
+    private static final Gson GSON = new Gson();
+
+    private final GlobalConfig.IpReputationProviderConfig providerConfig;
+    private final HttpClient client;
+
+    public IpApiProvider(GlobalConfig globalConfig) {
+        this(globalConfig, HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(globalConfig.ipReputationProvider.timeoutSeconds))
+                .build());
+    }
+
+    // Package-private for testing
+    IpApiProvider(GlobalConfig globalConfig, HttpClient client) {
+        this.providerConfig = globalConfig.ipReputationProvider;
+        this.client = client;
+    }
+
+    @Override
+    public IpReputationResult lookup(String ip) {
+        if (ip == null || ip.isBlank()) {
+            return null;
+        }
+
+        String normalized = ip.trim();
+        String url = buildUrl(normalized);
+
+        int maxAttempts = Math.max(1, providerConfig.maxRetries + 1);
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                return executeLookup(url);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                PLog.warnTag("IpApiProvider", "Lookup interrupted for @", normalized);
+                return null;
+            } catch (IOException | RuntimeException e) {
+                if (attempt < maxAttempts) {
+                    PLog.warnTag("IpApiProvider", "Lookup failed for @ (attempt @/@), retrying: @",
+                            normalized, attempt, maxAttempts, e.getMessage());
+                    backoff(attempt);
+                } else {
+                    PLog.warnTag("IpApiProvider", "Lookup failed for @ after @ attempts: @",
+                            normalized, maxAttempts, e.getMessage());
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private IpReputationResult executeLookup(String url) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(Duration.ofSeconds(providerConfig.timeoutSeconds))
+                .header("Accept", "application/json")
+                .GET()
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        int statusCode = response.statusCode();
+        if (statusCode < 200 || statusCode >= 300) {
+            throw new IOException("HTTP " + statusCode);
+        }
+
+        return parseResponse(response.body());
+    }
+
+    private IpReputationResult parseResponse(String body) {
+        try {
+            JsonObject json = GSON.fromJson(body, JsonObject.class);
+            if (json == null) {
+                return null;
+            }
+
+            // ip-api returns "status" field; "fail" means the query could not be resolved
+            String status = json.has("status") ? json.get("status").getAsString() : null;
+            if (!"success".equalsIgnoreCase(status)) {
+                return null;
+            }
+
+            String ip = json.has("query") ? json.get("query").getAsString() : null;
+            boolean proxy = json.has("proxy") && json.get("proxy").getAsBoolean();
+            boolean hosting = json.has("hosting") && json.get("hosting").getAsBoolean();
+            boolean mobile = json.has("mobile") && json.get("mobile").getAsBoolean();
+
+            return new IpReputationResult(ip, proxy, hosting, mobile);
+        } catch (JsonParseException | IllegalStateException | ClassCastException e) {
+            PLog.warnTag("IpApiProvider", "Failed to parse response: @", e.getMessage());
+            return null;
+        }
+    }
+
+    private String buildUrl(String ip) {
+        String base = providerConfig.baseUrl;
+        // Normalize: strip trailing slash, then append /{ip}
+        if (base.endsWith("/")) {
+            base = base.substring(0, base.length() - 1);
+        }
+        return base + "/" + ip;
+    }
+
+    private void backoff(int attempt) {
+        try {
+            // Simple exponential backoff: 200ms, 400ms, 800ms...
+            long delayMs = 200L * (1L << (attempt - 1));
+            Thread.sleep(Math.min(delayMs, 2000L));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationAllowlist.java
+++ b/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationAllowlist.java
@@ -1,0 +1,43 @@
+package org.xcore.plugin.security.ingress.ipreputation;
+
+import java.util.Set;
+
+/**
+ * Contract for the IP reputation allowlist.
+ * <p>
+ * IPs on the allowlist bypass reputation checks entirely.
+ * Implementations may use Redis, in-memory stores, or other backends.
+ */
+public interface IpReputationAllowlist {
+
+    /**
+     * Checks whether the given IP is explicitly allowed.
+     *
+     * @param ip the IP address
+     * @return true if the IP is on the allowlist
+     */
+    boolean contains(String ip);
+
+    /**
+     * Adds an IP to the allowlist.
+     *
+     * @param ip the IP address
+     * @return true if the operation succeeded
+     */
+    boolean add(String ip);
+
+    /**
+     * Removes an IP from the allowlist.
+     *
+     * @param ip the IP address
+     * @return true if the operation succeeded
+     */
+    boolean remove(String ip);
+
+    /**
+     * Returns all IPs currently on the allowlist.
+     *
+     * @return a set of allowlisted IPs; may be empty but never null
+     */
+    Set<String> list();
+}

--- a/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationAllowlist.java
+++ b/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationAllowlist.java
@@ -11,19 +11,19 @@ import java.util.Set;
 public interface IpReputationAllowlist {
 
     /**
-     * Checks whether the given IP is explicitly allowed.
-     *
-     * @param ip the IP address
-     * @return true if the IP is on the allowlist
-     */
+ * Determines whether the specified IP address is explicitly allowlisted.
+ *
+ * @param ip the IP address to check
+ * @return `true` if the IP address is on the allowlist, `false` otherwise
+ */
     boolean contains(String ip);
 
     /**
-     * Adds an IP to the allowlist.
-     *
-     * @param ip the IP address
-     * @return true if the operation succeeded
-     */
+ * Add the given IP address to the reputation allowlist so it bypasses reputation checks.
+ *
+ * @param ip the IP address to allowlist
+ * @return {@code true} if the IP was successfully added, {@code false} otherwise
+ */
     boolean add(String ip);
 
     /**
@@ -35,9 +35,9 @@ public interface IpReputationAllowlist {
     boolean remove(String ip);
 
     /**
-     * Returns all IPs currently on the allowlist.
-     *
-     * @return a set of allowlisted IPs; may be empty but never null
-     */
+ * Get all IP addresses currently on the allowlist; these addresses bypass IP reputation checks.
+ *
+ * @return a non-null Set containing all allowlisted IP addresses; may be empty
+ */
     Set<String> list();
 }

--- a/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationCache.java
+++ b/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationCache.java
@@ -9,19 +9,19 @@ package org.xcore.plugin.security.ingress.ipreputation;
 public interface IpReputationCache {
 
     /**
-     * Retrieves a cached result for the given IP.
-     *
-     * @param ip the IP address
-     * @return cached result, or null if not present or lookup failed
-     */
+ * Retrieve the cached reputation result for the specified IP address.
+ *
+ * @param ip the IP address to look up (IPv4 or IPv6)
+ * @return the cached {@link IpReputationResult} for the given IP, or `null` if no entry is present or the lookup failed
+ */
     IpReputationResult get(String ip);
 
     /**
-     * Stores a result in the cache.
-     *
-     * @param ip     the IP address
-     * @param result the reputation result to cache
-     * @return true if the result was stored successfully
-     */
+ * Stores the provided reputation result in the cache for the given IP address.
+ *
+ * @param ip     the IP address used as the cache key
+ * @param result the reputation result to store
+ * @return `true` if the result was stored successfully, `false` otherwise
+ */
     boolean put(String ip, IpReputationResult result);
 }

--- a/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationCache.java
+++ b/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationCache.java
@@ -1,0 +1,27 @@
+package org.xcore.plugin.security.ingress.ipreputation;
+
+/**
+ * Contract for caching IP reputation lookup results.
+ * <p>
+ * Implementations may use Redis, in-memory stores, or other backends.
+ * Cache misses and errors must be handled gracefully by callers.
+ */
+public interface IpReputationCache {
+
+    /**
+     * Retrieves a cached result for the given IP.
+     *
+     * @param ip the IP address
+     * @return cached result, or null if not present or lookup failed
+     */
+    IpReputationResult get(String ip);
+
+    /**
+     * Stores a result in the cache.
+     *
+     * @param ip     the IP address
+     * @param result the reputation result to cache
+     * @return true if the result was stored successfully
+     */
+    boolean put(String ip, IpReputationResult result);
+}

--- a/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationOrchestrationService.java
+++ b/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationOrchestrationService.java
@@ -20,6 +20,15 @@ public class IpReputationOrchestrationService implements IpReputationService {
     private final IpReputationProvider provider;
     private final IpReputationPolicy policy;
 
+    /**
+     * Create an IpReputationOrchestrationService wired with its required collaborators.
+     *
+     * @param config    configuration containing ip reputation settings (e.g., enablement)
+     * @param allowlist allowlist used to short-circuit evaluations for permitted IPs
+     * @param cache     cache used to read/write IpReputationResult entries
+     * @param provider  provider used to perform authoritative IP reputation lookups
+     * @param policy    policy used to decide whether a given IpReputationResult constitutes a block
+     */
     public IpReputationOrchestrationService(
             Config config,
             IpReputationAllowlist allowlist,
@@ -33,6 +42,19 @@ public class IpReputationOrchestrationService implements IpReputationService {
         this.policy = policy;
     }
 
+    /**
+     * Determine whether the given IP address should be blocked by the IP reputation policy.
+     *
+     * <p>The method is gated by the IP reputation feature flag and treats null or blank input as not blocked.
+     * It consults the allowlist (errors cause the method to treat the IP as not blocked), attempts a cache
+     * lookup, falls back to the provider on cache miss (provider errors cause the method to treat the IP as
+     * not blocked), and attempts to write provider results back to the cache (cache errors do not change the
+     * eventual policy evaluation). The final decision is produced by the configured policy and may be based
+     * on a cached result, a provider result, or {@code null}.</p>
+     *
+     * @param ip the IP address to evaluate; if {@code null} or blank it is treated as not blocked
+     * @return {@code true} if the IP is considered blocked by the configured policy, {@code false} otherwise
+     */
     @Override
     public boolean isBlocked(String ip) {
         if (!config.ipReputation.enabled) {
@@ -85,6 +107,16 @@ public class IpReputationOrchestrationService implements IpReputationService {
         return policy.isBlocked(result);
     }
 
+    /**
+     * Retrieve the reputation information for an IP address from the configured provider.
+     *
+     * <p>Whitespace around the input is trimmed before lookup. If IP reputation is disabled,
+     * the input is null or blank, or the provider lookup fails, this method returns {@code null}.</p>
+     *
+     * @param ip the IP address to look up; leading and trailing whitespace will be ignored
+     * @return the {@code IpReputationResult} for the normalized IP, or {@code null} if disabled,
+     *         the input is null/blank, or a provider error occurs
+     */
     @Override
     public IpReputationResult lookup(String ip) {
         if (!config.ipReputation.enabled) {

--- a/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationOrchestrationService.java
+++ b/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationOrchestrationService.java
@@ -1,0 +1,107 @@
+package org.xcore.plugin.security.ingress.ipreputation;
+
+import jakarta.inject.Singleton;
+import org.xcore.plugin.common.PLog;
+import org.xcore.plugin.config.Config;
+
+/**
+ * Concrete implementation of {@link IpReputationService} that orchestrates
+ * allowlist, cache, provider, and policy to produce a blocking decision.
+ * <p>
+ * This class is stateless and safe to inject as a singleton.
+ * Errors at any stage fail open (return {@code false} / {@code null}).
+ */
+@Singleton
+public class IpReputationOrchestrationService implements IpReputationService {
+
+    private final Config config;
+    private final IpReputationAllowlist allowlist;
+    private final IpReputationCache cache;
+    private final IpReputationProvider provider;
+    private final IpReputationPolicy policy;
+
+    public IpReputationOrchestrationService(
+            Config config,
+            IpReputationAllowlist allowlist,
+            IpReputationCache cache,
+            IpReputationProvider provider,
+            IpReputationPolicy policy) {
+        this.config = config;
+        this.allowlist = allowlist;
+        this.cache = cache;
+        this.provider = provider;
+        this.policy = policy;
+    }
+
+    @Override
+    public boolean isBlocked(String ip) {
+        if (!config.ipReputation.enabled) {
+            return false;
+        }
+
+        if (ip == null || ip.isBlank()) {
+            return false;
+        }
+
+        String normalized = ip.trim();
+
+        try {
+            if (allowlist.contains(normalized)) {
+                return false;
+            }
+        } catch (Exception e) {
+            PLog.warnTag("IpReputation", "Allowlist check failed for @: @", normalized, e.getMessage());
+            // fail open: continue to cache/provider
+        }
+
+        IpReputationResult result = null;
+
+        try {
+            result = cache.get(normalized);
+        } catch (Exception e) {
+            PLog.warnTag("IpReputation", "Cache read failed for @: @", normalized, e.getMessage());
+            // fail open: continue to provider
+        }
+
+        if (result == null) {
+            try {
+                result = provider.lookup(normalized);
+            } catch (Exception e) {
+                PLog.warnTag("IpReputation", "Provider lookup failed for @: @", normalized, e.getMessage());
+                // fail open
+                return false;
+            }
+
+            if (result != null) {
+                try {
+                    cache.put(normalized, result);
+                } catch (Exception e) {
+                    PLog.warnTag("IpReputation", "Cache write failed for @: @", normalized, e.getMessage());
+                    // fail open: we still have the result to evaluate
+                }
+            }
+        }
+
+        return policy.isBlocked(result);
+    }
+
+    @Override
+    public IpReputationResult lookup(String ip) {
+        if (!config.ipReputation.enabled) {
+            return null;
+        }
+
+        if (ip == null || ip.isBlank()) {
+            return null;
+        }
+
+        String normalized = ip.trim();
+
+        try {
+            return provider.lookup(normalized);
+        } catch (Exception e) {
+            PLog.warnTag("IpReputation", "Provider lookup failed for @: @", normalized, e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationOrchestrationService.java
+++ b/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationOrchestrationService.java
@@ -51,7 +51,7 @@ public class IpReputationOrchestrationService implements IpReputationService {
             }
         } catch (Exception e) {
             PLog.warnTag("IpReputation", "Allowlist check failed for @: @", normalized, e.getMessage());
-            // fail open: continue to cache/provider
+            return false;
         }
 
         IpReputationResult result = null;

--- a/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationPolicy.java
+++ b/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationPolicy.java
@@ -1,0 +1,44 @@
+package org.xcore.plugin.security.ingress.ipreputation;
+
+import jakarta.inject.Singleton;
+import org.xcore.plugin.config.Config;
+
+/**
+ * Evaluates whether an IP reputation result should trigger a block
+ * according to the per-server policy configuration.
+ * <p>
+ * This class is stateless and safe to inject as a singleton.
+ * It fails open (returns not-blocked) when the result is null.
+ */
+@Singleton
+public class IpReputationPolicy {
+
+    private final Config.IpReputationConfig config;
+
+    public IpReputationPolicy(Config config) {
+        this.config = config.ipReputation;
+    }
+
+    /**
+     * Determines whether the given reputation result should be blocked.
+     *
+     * @param result the reputation lookup result, may be null
+     * @return true if the IP should be denied access
+     */
+    public boolean isBlocked(IpReputationResult result) {
+        if (result == null) {
+            return false;
+        }
+
+        boolean shouldBlockProxy = config.blockProxy || config.blockVpn || config.blockTor;
+        if (shouldBlockProxy && result.proxy()) {
+            return true;
+        }
+
+        if (config.blockHosting && result.hosting()) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationPolicy.java
+++ b/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationPolicy.java
@@ -30,8 +30,17 @@ public class IpReputationPolicy {
             return false;
         }
 
-        boolean shouldBlockProxy = config.blockProxy || config.blockVpn || config.blockTor;
-        if (shouldBlockProxy && result.proxy()) {
+        if (config.blockProxy && result.proxy()) {
+            return true;
+        }
+
+        // ip-api exposes a combined proxy/VPN/Tor signal via the proxy field,
+        // so VPN and Tor policy toggles are evaluated against that same signal.
+        if (config.blockVpn && result.proxy()) {
+            return true;
+        }
+
+        if (config.blockTor && result.proxy()) {
             return true;
         }
 

--- a/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationPolicy.java
+++ b/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationPolicy.java
@@ -15,15 +15,20 @@ public class IpReputationPolicy {
 
     private final Config.IpReputationConfig config;
 
+    /**
+     * Creates a new IpReputationPolicy using values from the provided application configuration.
+     *
+     * @param config the application configuration whose {@code ipReputation} subsection will be used by this policy
+     */
     public IpReputationPolicy(Config config) {
         this.config = config.ipReputation;
     }
 
     /**
-     * Determines whether the given reputation result should be blocked.
+     * Determines whether an IP represented by the given reputation result should be blocked.
      *
-     * @param result the reputation lookup result, may be null
-     * @return true if the IP should be denied access
+     * @param result the reputation lookup result; may be null
+     * @return `true` if the IP should be denied access, `false` otherwise
      */
     public boolean isBlocked(IpReputationResult result) {
         if (result == null) {

--- a/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationProvider.java
+++ b/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationProvider.java
@@ -1,0 +1,18 @@
+package org.xcore.plugin.security.ingress.ipreputation;
+
+/**
+ * Contract for IP reputation data providers (e.g. ip-api).
+ * <p>
+ * Implementations handle transport concerns internally and must
+ * return a domain result or null when lookup cannot be completed.
+ */
+public interface IpReputationProvider {
+
+    /**
+     * Looks up reputation data for the given IP address.
+     *
+     * @param ip the IP address to query
+     * @return reputation result, or null if the lookup failed or is inconclusive
+     */
+    IpReputationResult lookup(String ip);
+}

--- a/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationResult.java
+++ b/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationResult.java
@@ -1,0 +1,15 @@
+package org.xcore.plugin.security.ingress.ipreputation;
+
+/**
+ * Domain model representing the result of an IP reputation lookup.
+ * <p>
+ * Transport-agnostic: this record does not expose HTTP status codes,
+ * JSON structures, or provider-specific response shapes.
+ */
+public record IpReputationResult(
+    String ip,
+    boolean proxy,
+    boolean hosting,
+    boolean mobile
+) {
+}

--- a/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationService.java
+++ b/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationService.java
@@ -1,0 +1,31 @@
+package org.xcore.plugin.security.ingress.ipreputation;
+
+/**
+ * Service contract for IP reputation evaluation.
+ * <p>
+ * Orchestrates allowlist, cache, provider, and policy to produce
+ * a blocking decision for a given IP address.
+ */
+public interface IpReputationService {
+
+    /**
+     * Evaluates whether the given IP should be blocked.
+     * <p>
+     * This method consults the allowlist first, then the cache,
+     * then the configured provider if necessary. Errors at any
+     * stage fail open (return false).
+     *
+     * @param ip the IP address to evaluate
+     * @return true if the IP should be denied access
+     */
+    boolean isBlocked(String ip);
+
+    /**
+     * Performs a fresh provider lookup for the given IP,
+     * bypassing cache. Useful for diagnostics and commands.
+     *
+     * @param ip the IP address to look up
+     * @return the provider result, or null if lookup failed
+     */
+    IpReputationResult lookup(String ip);
+}

--- a/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationService.java
+++ b/src/main/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationService.java
@@ -9,15 +9,13 @@ package org.xcore.plugin.security.ingress.ipreputation;
 public interface IpReputationService {
 
     /**
-     * Evaluates whether the given IP should be blocked.
-     * <p>
-     * This method consults the allowlist first, then the cache,
-     * then the configured provider if necessary. Errors at any
-     * stage fail open (return false).
-     *
-     * @param ip the IP address to evaluate
-     * @return true if the IP should be denied access
-     */
+ * Determine whether the specified IP address should be blocked.
+ *
+ * Evaluation consults the allowlist first, then the cache, and finally the configured provider when needed; any errors cause fail-open behavior (treated as not blocked).
+ *
+ * @param ip the IP address to evaluate
+ * @return `true` if the IP should be blocked, `false` otherwise
+ */
     boolean isBlocked(String ip);
 
     /**

--- a/src/main/java/org/xcore/plugin/service/network/RedisIpReputationAllowlist.java
+++ b/src/main/java/org/xcore/plugin/service/network/RedisIpReputationAllowlist.java
@@ -18,12 +18,25 @@ public class RedisIpReputationAllowlist implements IpReputationAllowlist {
     private final RedisNetworkBackend backend;
     private final Config config;
 
+    /**
+     * Constructs a Redis-backed IP reputation allowlist scoped to the configured server.
+     *
+     * @param backend     RedisNetworkBackend used to execute Redis commands for allowlist operations
+     * @param redisGson   Gson instance bound to "redis" (accepted for injection; not used directly)
+     * @param config      Configuration whose {@code server} field is used to scope the Redis key
+     */
     @Inject
     public RedisIpReputationAllowlist(RedisNetworkBackend backend, @Named("redis") Gson redisGson, Config config) {
         this.backend = backend;
         this.config = config;
     }
 
+    /**
+     * Checks whether the given IP address is present in the Redis-backed allowlist.
+     *
+     * @param ip the IP address to check; if {@code null} or blank the method returns {@code false}
+     * @return {@code true} if the normalized IP is a member of the allowlist, {@code false} otherwise
+     */
     @Override
     public boolean contains(String ip) {
         if (ip == null || ip.isBlank()) {
@@ -37,6 +50,12 @@ public class RedisIpReputationAllowlist implements IpReputationAllowlist {
         }, false);
     }
 
+    /**
+     * Adds the given IP to the allowlist after trimming surrounding whitespace.
+     *
+     * @param ip the IP address to add; may include surrounding whitespace
+     * @return `true` if the add operation was initiated, `false` when `ip` is null or blank
+     */
     @Override
     public boolean add(String ip) {
         if (ip == null || ip.isBlank()) {
@@ -50,6 +69,14 @@ public class RedisIpReputationAllowlist implements IpReputationAllowlist {
         }, false);
     }
 
+    /**
+     * Remove the given IP from the configured Redis allowlist.
+     *
+     * The input is trimmed before use; `null` or blank inputs are rejected.
+     *
+     * @param ip the IP address to remove (will be trimmed)
+     * @return `true` if the remove command was issued to Redis, `false` otherwise
+     */
     @Override
     public boolean remove(String ip) {
         if (ip == null || ip.isBlank()) {
@@ -63,6 +90,11 @@ public class RedisIpReputationAllowlist implements IpReputationAllowlist {
         }, false);
     }
 
+    /**
+     * Retrieve the IP addresses currently stored in the allowlist for the configured server.
+     *
+     * @return the set of allowlisted IP addresses, or an empty set if no members are present or the backend returned null
+     */
     @Override
     public Set<String> list() {
         return backend.withCommands(commands -> {
@@ -71,10 +103,21 @@ public class RedisIpReputationAllowlist implements IpReputationAllowlist {
         }, Collections.emptySet());
     }
 
+    /**
+     * Builds the Redis key used to store the IP allowlist for the current server.
+     *
+     * @return the namespaced Redis key for the allowlist (prefix + ":" + server name)
+     */
     private String allowlistKey() {
         return KEY_PREFIX + ":" + config.server;
     }
 
+    /**
+     * Trim leading and trailing whitespace from an IP string.
+     *
+     * @param ip the IP string to normalize (may contain surrounding whitespace)
+     * @return the input string with leading and trailing whitespace removed
+     */
     private String normalizeIp(String ip) {
         return ip.trim();
     }

--- a/src/main/java/org/xcore/plugin/service/network/RedisIpReputationAllowlist.java
+++ b/src/main/java/org/xcore/plugin/service/network/RedisIpReputationAllowlist.java
@@ -1,0 +1,81 @@
+package org.xcore.plugin.service.network;
+
+import com.google.gson.Gson;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import org.xcore.plugin.config.Config;
+import org.xcore.plugin.security.ingress.ipreputation.IpReputationAllowlist;
+
+import java.util.Collections;
+import java.util.Set;
+
+@Singleton
+public class RedisIpReputationAllowlist implements IpReputationAllowlist {
+
+    private static final String KEY_PREFIX = "xcore:ip-reputation:allowlist:v1";
+
+    private final RedisNetworkBackend backend;
+    private final Config config;
+
+    @Inject
+    public RedisIpReputationAllowlist(RedisNetworkBackend backend, @Named("redis") Gson redisGson, Config config) {
+        this.backend = backend;
+        this.config = config;
+    }
+
+    @Override
+    public boolean contains(String ip) {
+        if (ip == null || ip.isBlank()) {
+            return false;
+        }
+
+        String normalized = normalizeIp(ip);
+        return backend.withCommands(commands -> {
+            Boolean member = commands.sismember(allowlistKey(), normalized);
+            return Boolean.TRUE.equals(member);
+        }, false);
+    }
+
+    @Override
+    public boolean add(String ip) {
+        if (ip == null || ip.isBlank()) {
+            return false;
+        }
+
+        String normalized = normalizeIp(ip);
+        return backend.withCommands(commands -> {
+            commands.sadd(allowlistKey(), normalized);
+            return true;
+        }, false);
+    }
+
+    @Override
+    public boolean remove(String ip) {
+        if (ip == null || ip.isBlank()) {
+            return false;
+        }
+
+        String normalized = normalizeIp(ip);
+        return backend.withCommands(commands -> {
+            commands.srem(allowlistKey(), normalized);
+            return true;
+        }, false);
+    }
+
+    @Override
+    public Set<String> list() {
+        return backend.withCommands(commands -> {
+            Set<String> members = commands.smembers(allowlistKey());
+            return members != null ? members : Collections.emptySet();
+        }, Collections.emptySet());
+    }
+
+    private String allowlistKey() {
+        return KEY_PREFIX + ":" + config.server;
+    }
+
+    private String normalizeIp(String ip) {
+        return ip.trim();
+    }
+}

--- a/src/main/java/org/xcore/plugin/service/network/RedisIpReputationCache.java
+++ b/src/main/java/org/xcore/plugin/service/network/RedisIpReputationCache.java
@@ -1,0 +1,68 @@
+package org.xcore.plugin.service.network;
+
+import com.google.gson.Gson;
+import io.lettuce.core.SetArgs;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import org.xcore.plugin.config.Config;
+import org.xcore.plugin.security.ingress.ipreputation.IpReputationCache;
+import org.xcore.plugin.security.ingress.ipreputation.IpReputationResult;
+
+@Singleton
+public class RedisIpReputationCache implements IpReputationCache {
+
+    private static final String KEY_PREFIX = "xcore:ip-reputation:cache:v1";
+
+    private final RedisNetworkBackend backend;
+    private final Gson redisGson;
+    private final Config config;
+
+    @Inject
+    public RedisIpReputationCache(RedisNetworkBackend backend, @Named("redis") Gson redisGson, Config config) {
+        this.backend = backend;
+        this.redisGson = redisGson;
+        this.config = config;
+    }
+
+    @Override
+    public IpReputationResult get(String ip) {
+        if (ip == null || ip.isBlank()) {
+            return null;
+        }
+
+        String normalized = normalizeIp(ip);
+        return backend.withCommands(commands -> {
+            String payloadJson = commands.get(cacheKey(normalized));
+            if (payloadJson == null || payloadJson.isBlank()) {
+                return null;
+            }
+            return redisGson.fromJson(payloadJson, IpReputationResult.class);
+        }, null);
+    }
+
+    @Override
+    public boolean put(String ip, IpReputationResult result) {
+        if (ip == null || ip.isBlank() || result == null) {
+            return false;
+        }
+
+        String normalized = normalizeIp(ip);
+        return backend.withCommands(commands -> {
+            commands.set(
+                    cacheKey(normalized),
+                    redisGson.toJson(result),
+                    SetArgs.Builder.ex(config.ipReputation.cacheTtlSeconds)
+            );
+            return true;
+        }, false);
+    }
+
+    private String cacheKey(String normalizedIp) {
+        return KEY_PREFIX + ":" + config.server + ":" + normalizedIp;
+    }
+
+    private String normalizeIp(String ip) {
+        return ip.trim();
+    }
+}

--- a/src/main/java/org/xcore/plugin/service/network/RedisIpReputationCache.java
+++ b/src/main/java/org/xcore/plugin/service/network/RedisIpReputationCache.java
@@ -18,6 +18,13 @@ public class RedisIpReputationCache implements IpReputationCache {
     private final Gson redisGson;
     private final Config config;
 
+    /**
+     * Constructs a Redis-backed IP reputation cache using the provided dependencies.
+     *
+     * @param backend   the RedisNetworkBackend used to execute Redis commands
+     * @param redisGson the Gson instance (named "redis") used to serialize/deserialize IpReputationResult
+     * @param config    configuration holding cache TTL and server scoping values
+     */
     @Inject
     public RedisIpReputationCache(RedisNetworkBackend backend, @Named("redis") Gson redisGson, Config config) {
         this.backend = backend;
@@ -25,6 +32,14 @@ public class RedisIpReputationCache implements IpReputationCache {
         this.config = config;
     }
 
+    /**
+     * Retrieve the cached IP reputation for the given IP address.
+     *
+     * If the input is null or blank, or no cached payload exists for the normalized IP, this method returns `null`.
+     *
+     * @param ip the IP address to look up (may contain surrounding whitespace)
+     * @return the cached {@code IpReputationResult} for the normalized IP, or {@code null} if not found or the input is invalid
+     */
     @Override
     public IpReputationResult get(String ip) {
         if (ip == null || ip.isBlank()) {
@@ -41,6 +56,13 @@ public class RedisIpReputationCache implements IpReputationCache {
         }, null);
     }
 
+    /**
+     * Stores an IP reputation entry in Redis under a server-scoped cache key with the configured TTL.
+     *
+     * @param ip the IP address to cache (leading/trailing whitespace is ignored)
+     * @param result the reputation data to store
+     * @return `true` if the entry was issued to Redis, `false` if the input was invalid
+     */
     @Override
     public boolean put(String ip, IpReputationResult result) {
         if (ip == null || ip.isBlank() || result == null) {
@@ -58,10 +80,22 @@ public class RedisIpReputationCache implements IpReputationCache {
         }, false);
     }
 
+    /**
+     * Constructs the Redis cache key for a normalized IP scoped to the current server.
+     *
+     * @param normalizedIp the normalized (trimmed) IP address to include in the key
+     * @return the Redis key in the form "xcore:ip-reputation:cache:v1:{server}:{normalizedIp}"
+     */
     private String cacheKey(String normalizedIp) {
         return KEY_PREFIX + ":" + config.server + ":" + normalizedIp;
     }
 
+    /**
+     * Normalize an IP string by removing leading and trailing whitespace.
+     *
+     * @param ip the IP string to normalize
+     * @return the IP string with surrounding whitespace removed
+     */
     private String normalizeIp(String ip) {
         return ip.trim();
     }

--- a/src/main/resources/bundles/bundle_en.ftl
+++ b/src/main/resources/bundles/bundle_en.ftl
@@ -265,6 +265,15 @@ kick-admintools-outdated =
     { "" }[scarlet]Your AdminTools version: [grey]{ $version }[]
     { "" }
     { "" }[cyan]Please update your AdminTools to join this server.
+ip-reputation-denied =
+    { "[" }scarlet]⚠ Access denied[]
+    { "" }[lightgray]Your connection was flagged as VPN/proxy/Tor and blocked by server policy.
+    { "" }[lightgray]If this is a mistake, appeal in Discord:
+    { "" }[cyan]{ $discordUrl }
+notification-admin-ip-reputation-denied = [scarlet]IP reputation blocked [white]{ $nickname }[lightgray] from [accent]{ $ip }[]
+commands-ipreputation-lookup-result = [accent]{ $ip }[] → proxy=[accent]{ $proxy }[] hosting=[accent]{ $hosting }[] mobile=[accent]{ $mobile }[]
+commands-ipreputation-allowlist-add-success = [green]Added [accent]{ $ip }[] to the IP reputation allowlist.
+commands-ipreputation-allowlist-remove-success = [green]Removed [accent]{ $ip }[] from the IP reputation allowlist.
 support-channel = #reports-appeals
 # ==============================================================================
 # Voting (VoteKick)

--- a/src/main/resources/bundles/bundle_ru.ftl
+++ b/src/main/resources/bundles/bundle_ru.ftl
@@ -265,6 +265,15 @@ kick-admintools-outdated =
     { "" }[scarlet]Ваша версия AdminTools: [grey]{ $version }[]
     { "" }
     { "" }[cyan]Пожалуйста, обновите AdminTools для входа на сервер.
+ip-reputation-denied =
+    { "[" }scarlet]⚠ Доступ запрещён[]
+    { "" }[lightgray]Ваше соединение определено как VPN/прокси/Tor и заблокировано политикой сервера.
+    { "" }[lightgray]Если это ошибка, подайте апелляцию в Discord:
+    { "" }[cyan]{ $discordUrl }
+notification-admin-ip-reputation-denied = [scarlet]IP reputation заблокировал [white]{ $nickname }[lightgray] с [accent]{ $ip }[]
+commands-ipreputation-lookup-result = [accent]{ $ip }[] → proxy=[accent]{ $proxy }[] hosting=[accent]{ $hosting }[] mobile=[accent]{ $mobile }[]
+commands-ipreputation-allowlist-add-success = [green]Добавлен [accent]{ $ip }[] в allowlist IP reputation.
+commands-ipreputation-allowlist-remove-success = [green]Удалён [accent]{ $ip }[] из allowlist IP reputation.
 support-channel = #reports-appeals
 # ==============================================================================
 # Voting (VoteKick)

--- a/src/main/resources/bundles/bundle_uk_UA.ftl
+++ b/src/main/resources/bundles/bundle_uk_UA.ftl
@@ -240,6 +240,15 @@ kick-admintools-outdated =
     { "" }[scarlet]Ваша версія AdminTools: [grey]{ $version }[]
     { "" }
     { "" }[cyan]Будь ласка, оновіть AdminTools для входу на сервер.
+ip-reputation-denied =
+    { "[" }scarlet]⚠ Доступ заборонено[]
+    { "" }[lightgray]Ваше з'єднання визначено як VPN/проксі/Tor і заблоковано політикою сервера.
+    { "" }[lightgray]Якщо це помилка, подайте апеляцію в Discord:
+    { "" }[cyan]{ $discordUrl }
+notification-admin-ip-reputation-denied = [scarlet]IP reputation заблокував [white]{ $nickname }[lightgray] з [accent]{ $ip }[]
+commands-ipreputation-lookup-result = [accent]{ $ip }[] → proxy=[accent]{ $proxy }[] hosting=[accent]{ $hosting }[] mobile=[accent]{ $mobile }[]
+commands-ipreputation-allowlist-add-success = [green]Додано [accent]{ $ip }[] до allowlist IP reputation.
+commands-ipreputation-allowlist-remove-success = [green]Видалено [accent]{ $ip }[] з allowlist IP reputation.
 support-channel = #reports-appeals
 # ==============================================================================
 # Voting (VoteKick)

--- a/src/test/java/org/xcore/plugin/command/controller/server/IpReputationServerControllerTest.java
+++ b/src/test/java/org/xcore/plugin/command/controller/server/IpReputationServerControllerTest.java
@@ -1,0 +1,175 @@
+package org.xcore.plugin.command.controller.server;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.xcore.plugin.cloud.XCoreSender;
+import org.xcore.plugin.security.ingress.ipreputation.IpReputationAllowlist;
+import org.xcore.plugin.security.ingress.ipreputation.IpReputationResult;
+import org.xcore.plugin.security.ingress.ipreputation.IpReputationService;
+
+import java.util.Set;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class IpReputationServerControllerTest {
+
+    @Test
+    @DisplayName("lookup delegates to service and handles result")
+    void lookup_delegatesToService() {
+        var service = mock(IpReputationService.class);
+        var allowlist = mock(IpReputationAllowlist.class);
+        var sender = mock(XCoreSender.class);
+        var controller = new IpReputationServerController(service, allowlist);
+
+        when(service.lookup("1.2.3.4")).thenReturn(new IpReputationResult("1.2.3.4", true, false, false));
+
+        controller.lookup(sender, "1.2.3.4");
+
+        verify(service).lookup("1.2.3.4");
+    }
+
+    @Test
+    @DisplayName("lookup handles null result gracefully")
+    void lookup_handlesNullResult() {
+        var service = mock(IpReputationService.class);
+        var allowlist = mock(IpReputationAllowlist.class);
+        var sender = mock(XCoreSender.class);
+        var controller = new IpReputationServerController(service, allowlist);
+
+        when(service.lookup("1.2.3.4")).thenReturn(null);
+
+        controller.lookup(sender, "1.2.3.4");
+
+        verify(service).lookup("1.2.3.4");
+    }
+
+    @Test
+    @DisplayName("lookup rejects blank ip")
+    void lookup_rejectsBlankIp() {
+        var service = mock(IpReputationService.class);
+        var allowlist = mock(IpReputationAllowlist.class);
+        var sender = mock(XCoreSender.class);
+        var controller = new IpReputationServerController(service, allowlist);
+
+        controller.lookup(sender, "  ");
+
+        verify(service, never()).lookup(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("check delegates to isBlocked")
+    void check_delegatesToIsBlocked() {
+        var service = mock(IpReputationService.class);
+        var allowlist = mock(IpReputationAllowlist.class);
+        var sender = mock(XCoreSender.class);
+        var controller = new IpReputationServerController(service, allowlist);
+
+        when(service.isBlocked("1.2.3.4")).thenReturn(true);
+
+        controller.check(sender, "1.2.3.4");
+
+        verify(service).isBlocked("1.2.3.4");
+    }
+
+    @Test
+    @DisplayName("check rejects blank ip")
+    void check_rejectsBlankIp() {
+        var service = mock(IpReputationService.class);
+        var allowlist = mock(IpReputationAllowlist.class);
+        var sender = mock(XCoreSender.class);
+        var controller = new IpReputationServerController(service, allowlist);
+
+        controller.check(sender, "");
+
+        verify(service, never()).isBlocked(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("allowAdd delegates to allowlist")
+    void allowAdd_delegatesToAllowlist() {
+        var service = mock(IpReputationService.class);
+        var allowlist = mock(IpReputationAllowlist.class);
+        var sender = mock(XCoreSender.class);
+        var controller = new IpReputationServerController(service, allowlist);
+
+        when(allowlist.add("1.2.3.4")).thenReturn(true);
+
+        controller.allowAdd(sender, "1.2.3.4");
+
+        verify(allowlist).add("1.2.3.4");
+    }
+
+    @Test
+    @DisplayName("allowAdd rejects blank ip")
+    void allowAdd_rejectsBlankIp() {
+        var service = mock(IpReputationService.class);
+        var allowlist = mock(IpReputationAllowlist.class);
+        var sender = mock(XCoreSender.class);
+        var controller = new IpReputationServerController(service, allowlist);
+
+        controller.allowAdd(sender, null);
+
+        verify(allowlist, never()).add(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("allowRemove delegates to allowlist")
+    void allowRemove_delegatesToAllowlist() {
+        var service = mock(IpReputationService.class);
+        var allowlist = mock(IpReputationAllowlist.class);
+        var sender = mock(XCoreSender.class);
+        var controller = new IpReputationServerController(service, allowlist);
+
+        when(allowlist.remove("1.2.3.4")).thenReturn(true);
+
+        controller.allowRemove(sender, "1.2.3.4");
+
+        verify(allowlist).remove("1.2.3.4");
+    }
+
+    @Test
+    @DisplayName("allowRemove rejects blank ip")
+    void allowRemove_rejectsBlankIp() {
+        var service = mock(IpReputationService.class);
+        var allowlist = mock(IpReputationAllowlist.class);
+        var sender = mock(XCoreSender.class);
+        var controller = new IpReputationServerController(service, allowlist);
+
+        controller.allowRemove(sender, "   ");
+
+        verify(allowlist, never()).remove(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("allowList delegates to allowlist")
+    void allowList_delegatesToAllowlist() {
+        var service = mock(IpReputationService.class);
+        var allowlist = mock(IpReputationAllowlist.class);
+        var sender = mock(XCoreSender.class);
+        var controller = new IpReputationServerController(service, allowlist);
+
+        when(allowlist.list()).thenReturn(Set.of("1.2.3.4", "5.6.7.8"));
+
+        controller.allowList(sender);
+
+        verify(allowlist).list();
+    }
+
+    @Test
+    @DisplayName("allowList handles empty allowlist")
+    void allowList_handlesEmptyAllowlist() {
+        var service = mock(IpReputationService.class);
+        var allowlist = mock(IpReputationAllowlist.class);
+        var sender = mock(XCoreSender.class);
+        var controller = new IpReputationServerController(service, allowlist);
+
+        when(allowlist.list()).thenReturn(Set.of());
+
+        controller.allowList(sender);
+
+        verify(allowlist).list();
+    }
+}

--- a/src/test/java/org/xcore/plugin/security/ingress/checks/IpReputationCheckTest.java
+++ b/src/test/java/org/xcore/plugin/security/ingress/checks/IpReputationCheckTest.java
@@ -1,0 +1,125 @@
+package org.xcore.plugin.security.ingress.checks;
+
+import com.ospx.flubundle.Bundle;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.xcore.plugin.config.GlobalConfig;
+import org.xcore.plugin.security.ingress.AccessResult;
+import org.xcore.plugin.security.ingress.ipreputation.IpReputationService;
+
+import java.util.Locale;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("IpReputationCheck")
+class IpReputationCheckTest {
+
+    private IpReputationService ipReputationService;
+    private IpReputationCheck check;
+
+    @BeforeEach
+    void setUp() {
+        ipReputationService = mock(IpReputationService.class);
+        var globalConfig = new GlobalConfig();
+        globalConfig.discordUrl = "https://discord.example";
+
+        Bundle bundle = new Bundle(Locale.ENGLISH) {
+            @Override
+            public Locale resolveLocale(String code) {
+                return Locale.ENGLISH;
+            }
+
+            @Override
+            public Locale resolveLocale(Locale locale) {
+                return locale == null ? Locale.ENGLISH : locale;
+            }
+
+            @Override
+            public String format(Locale locale, String id, Map<String, Object> args) {
+                if ("ip-reputation-denied".equals(id)) {
+                    return "ip-reputation-denied: " + args.get("discordUrl");
+                }
+                return id;
+            }
+        };
+
+        check = new IpReputationCheck(ipReputationService, bundle, globalConfig);
+    }
+
+    @Test
+    @DisplayName("shouldAllow when IP is not blocked")
+    void shouldAllow_whenNotBlocked() {
+        var con = new IngressChecksTestSupport.DummyConnection("1.1.1.1");
+        var packet = IngressChecksTestSupport.newPacket();
+        when(ipReputationService.isBlocked("1.1.1.1")).thenReturn(false);
+
+        var result = check.check(con, packet);
+
+        assertThat(result).isSameAs(AccessResult.Allowed.INSTANCE);
+    }
+
+    @Test
+    @DisplayName("shouldDeny with localized reason when IP is blocked")
+    void shouldDeny_whenBlocked() {
+        var con = new IngressChecksTestSupport.DummyConnection("1.1.1.1");
+        var packet = IngressChecksTestSupport.newPacket();
+        when(ipReputationService.isBlocked("1.1.1.1")).thenReturn(true);
+
+        var result = check.check(con, packet);
+
+        assertThat(result).isInstanceOfSatisfying(AccessResult.Denied.class, denied -> {
+            assertThat(denied.reason()).contains("ip-reputation-denied");
+            assertThat(denied.silent()).isFalse();
+        });
+    }
+
+    @Test
+    @DisplayName("shouldAllow when connection address is blank")
+    void shouldAllow_whenBlankAddress() {
+        var con = new IngressChecksTestSupport.DummyConnection("");
+        var packet = IngressChecksTestSupport.newPacket();
+
+        var result = check.check(con, packet);
+
+        assertThat(result).isSameAs(AccessResult.Allowed.INSTANCE);
+    }
+
+    @Test
+    @DisplayName("shouldAllow when connection address is null")
+    void shouldAllow_whenNullAddress() {
+        var con = new IngressChecksTestSupport.DummyConnection(null);
+        var packet = IngressChecksTestSupport.newPacket();
+
+        var result = check.check(con, packet);
+
+        assertThat(result).isSameAs(AccessResult.Allowed.INSTANCE);
+    }
+
+    @Test
+    @DisplayName("shouldAllow and fail open when service throws")
+    void shouldAllow_whenServiceThrows() {
+        var con = new IngressChecksTestSupport.DummyConnection("1.1.1.1");
+        var packet = IngressChecksTestSupport.newPacket();
+        when(ipReputationService.isBlocked("1.1.1.1")).thenThrow(new RuntimeException("provider timeout"));
+
+        var result = check.check(con, packet);
+
+        assertThat(result).isSameAs(AccessResult.Allowed.INSTANCE);
+    }
+
+    @Test
+    @DisplayName("should trim connection address before evaluation")
+    void shouldTrimAddressBeforeEvaluation() {
+        var con = new IngressChecksTestSupport.DummyConnection("  1.1.1.1  ");
+        var packet = IngressChecksTestSupport.newPacket();
+        when(ipReputationService.isBlocked("1.1.1.1")).thenReturn(false);
+
+        var result = check.check(con, packet);
+
+        assertThat(result).isSameAs(AccessResult.Allowed.INSTANCE);
+    }
+}

--- a/src/test/java/org/xcore/plugin/security/ingress/checks/IpReputationCheckTest.java
+++ b/src/test/java/org/xcore/plugin/security/ingress/checks/IpReputationCheckTest.java
@@ -73,6 +73,7 @@ class IpReputationCheckTest {
 
         assertThat(result).isInstanceOfSatisfying(AccessResult.Denied.class, denied -> {
             assertThat(denied.reason()).contains("ip-reputation-denied");
+            assertThat(denied.reason()).contains("https://discord.example");
             assertThat(denied.silent()).isFalse();
         });
     }

--- a/src/test/java/org/xcore/plugin/security/ingress/ipreputation/IpApiProviderTest.java
+++ b/src/test/java/org/xcore/plugin/security/ingress/ipreputation/IpApiProviderTest.java
@@ -12,6 +12,8 @@ import java.net.http.HttpResponse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class IpApiProviderTest {
@@ -142,6 +144,8 @@ class IpApiProviderTest {
         IpApiProvider provider = new IpApiProvider(globalConfig, client);
 
         assertThat(provider.lookup("1.2.3.4")).isNull();
+        verify(client, times(globalConfig.ipReputationProvider.maxRetries + 1))
+                .send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
     }
 
     @Test

--- a/src/test/java/org/xcore/plugin/security/ingress/ipreputation/IpApiProviderTest.java
+++ b/src/test/java/org/xcore/plugin/security/ingress/ipreputation/IpApiProviderTest.java
@@ -1,0 +1,197 @@
+package org.xcore.plugin.security.ingress.ipreputation;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.xcore.plugin.config.GlobalConfig;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class IpApiProviderTest {
+
+    @Test
+    @DisplayName("lookup returns parsed result on success")
+    void lookup_success_returnsParsedResult() throws Exception {
+        HttpClient client = mock(HttpClient.class);
+        @SuppressWarnings("unchecked")
+        HttpResponse<String> response = mock(HttpResponse.class);
+
+        when(response.statusCode()).thenReturn(200);
+        when(response.body()).thenReturn("""
+                {
+                  "status": "success",
+                  "query": "1.2.3.4",
+                  "proxy": true,
+                  "hosting": false,
+                  "mobile": false
+                }
+                """);
+        when(client.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(response);
+
+        IpApiProvider provider = newProvider(client);
+        IpReputationResult result = provider.lookup("1.2.3.4");
+
+        assertThat(result).isNotNull();
+        assertThat(result.ip()).isEqualTo("1.2.3.4");
+        assertThat(result.proxy()).isTrue();
+        assertThat(result.hosting()).isFalse();
+        assertThat(result.mobile()).isFalse();
+    }
+
+    @Test
+    @DisplayName("lookup returns null when status is fail")
+    void lookup_statusFail_returnsNull() throws Exception {
+        HttpClient client = mock(HttpClient.class);
+        @SuppressWarnings("unchecked")
+        HttpResponse<String> response = mock(HttpResponse.class);
+
+        when(response.statusCode()).thenReturn(200);
+        when(response.body()).thenReturn("""
+                {"status":"fail","message":"invalid query"}
+                """);
+        when(client.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(response);
+
+        IpApiProvider provider = newProvider(client);
+
+        assertThat(provider.lookup("1.2.3.4")).isNull();
+    }
+
+    @Test
+    @DisplayName("lookup returns null on non-2xx response")
+    void lookup_non2xx_returnsNull() throws Exception {
+        HttpClient client = mock(HttpClient.class);
+        @SuppressWarnings("unchecked")
+        HttpResponse<String> response = mock(HttpResponse.class);
+
+        when(response.statusCode()).thenReturn(429);
+        when(client.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(response);
+
+        IpApiProvider provider = newProvider(client);
+
+        assertThat(provider.lookup("1.2.3.4")).isNull();
+    }
+
+    @Test
+    @DisplayName("lookup returns null on IOException")
+    void lookup_ioException_returnsNull() throws Exception {
+        HttpClient client = mock(HttpClient.class);
+        when(client.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenThrow(new IOException("connection refused"));
+
+        IpApiProvider provider = newProvider(client);
+
+        assertThat(provider.lookup("1.2.3.4")).isNull();
+    }
+
+    @Test
+    @DisplayName("lookup returns null on RuntimeException")
+    void lookup_runtimeException_returnsNull() throws Exception {
+        HttpClient client = mock(HttpClient.class);
+        when(client.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenThrow(new RuntimeException("unexpected"));
+
+        IpApiProvider provider = newProvider(client);
+
+        assertThat(provider.lookup("1.2.3.4")).isNull();
+    }
+
+    @Test
+    @DisplayName("lookup returns null for blank ip")
+    void lookup_blankIp_returnsNull() {
+        HttpClient client = mock(HttpClient.class);
+        IpApiProvider provider = newProvider(client);
+
+        assertThat(provider.lookup("")).isNull();
+        assertThat(provider.lookup(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("lookup returns null on invalid JSON")
+    void lookup_invalidJson_returnsNull() throws Exception {
+        HttpClient client = mock(HttpClient.class);
+        @SuppressWarnings("unchecked")
+        HttpResponse<String> response = mock(HttpResponse.class);
+
+        when(response.statusCode()).thenReturn(200);
+        when(response.body()).thenReturn("not json");
+        when(client.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(response);
+
+        IpApiProvider provider = newProvider(client);
+
+        assertThat(provider.lookup("1.2.3.4")).isNull();
+    }
+
+    @Test
+    @DisplayName("lookup retries on failure and returns null after exhausting retries")
+    void lookup_retriesThenReturnsNull() throws Exception {
+        HttpClient client = mock(HttpClient.class);
+        when(client.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenThrow(new IOException("connection refused"));
+
+        GlobalConfig globalConfig = new GlobalConfig();
+        globalConfig.ipReputationProvider.maxRetries = 2;
+        globalConfig.ipReputationProvider.timeoutSeconds = 1;
+
+        IpApiProvider provider = new IpApiProvider(globalConfig, client);
+
+        assertThat(provider.lookup("1.2.3.4")).isNull();
+    }
+
+    @Test
+    @DisplayName("lookup succeeds on retry")
+    void lookup_succeedsOnRetry() throws Exception {
+        HttpClient client = mock(HttpClient.class);
+        @SuppressWarnings("unchecked")
+        HttpResponse<String> response = mock(HttpResponse.class);
+
+        when(response.statusCode()).thenReturn(200);
+        when(response.body()).thenReturn("""
+                {
+                  "status": "success",
+                  "query": "1.2.3.4",
+                  "proxy": false,
+                  "hosting": false,
+                  "mobile": false
+                }
+                """);
+        when(client.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenThrow(new IOException("first attempt fails"))
+                .thenReturn(response);
+
+        GlobalConfig globalConfig = new GlobalConfig();
+        globalConfig.ipReputationProvider.maxRetries = 2;
+        globalConfig.ipReputationProvider.timeoutSeconds = 1;
+
+        IpApiProvider provider = new IpApiProvider(globalConfig, client);
+        IpReputationResult result = provider.lookup("1.2.3.4");
+
+        assertThat(result).isNotNull();
+        assertThat(result.proxy()).isFalse();
+    }
+
+    @Test
+    @DisplayName("lookup returns null when interrupted")
+    void lookup_interrupted_returnsNull() throws Exception {
+        HttpClient client = mock(HttpClient.class);
+        when(client.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenThrow(new InterruptedException("interrupted"));
+
+        IpApiProvider provider = newProvider(client);
+
+        assertThat(provider.lookup("1.2.3.4")).isNull();
+    }
+
+    private static IpApiProvider newProvider(HttpClient client) {
+        GlobalConfig globalConfig = new GlobalConfig();
+        globalConfig.ipReputationProvider.maxRetries = 0;
+        globalConfig.ipReputationProvider.timeoutSeconds = 1;
+        return new IpApiProvider(globalConfig, client);
+    }
+}

--- a/src/test/java/org/xcore/plugin/security/ingress/ipreputation/IpApiProviderTest.java
+++ b/src/test/java/org/xcore/plugin/security/ingress/ipreputation/IpApiProviderTest.java
@@ -149,6 +149,37 @@ class IpApiProviderTest {
     }
 
     @Test
+    @DisplayName("lookup returns null when local provider rate limit is exceeded")
+    void lookup_rateLimitExceeded_returnsNullWithoutSecondRequest() throws Exception {
+        HttpClient client = mock(HttpClient.class);
+        @SuppressWarnings("unchecked")
+        HttpResponse<String> response = mock(HttpResponse.class);
+
+        when(response.statusCode()).thenReturn(200);
+        when(response.body()).thenReturn("""
+                {
+                  "status": "success",
+                  "query": "1.2.3.4",
+                  "proxy": false,
+                  "hosting": false,
+                  "mobile": false
+                }
+                """);
+        when(client.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(response);
+
+        GlobalConfig globalConfig = new GlobalConfig();
+        globalConfig.ipReputationProvider.maxRetries = 0;
+        globalConfig.ipReputationProvider.timeoutSeconds = 1;
+        globalConfig.ipReputationProvider.rateLimitPerMinute = 1;
+
+        IpApiProvider provider = new IpApiProvider(globalConfig, client);
+
+        assertThat(provider.lookup("1.2.3.4")).isNotNull();
+        assertThat(provider.lookup("5.6.7.8")).isNull();
+        verify(client, times(1)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+    }
+
+    @Test
     @DisplayName("lookup succeeds on retry")
     void lookup_succeedsOnRetry() throws Exception {
         HttpClient client = mock(HttpClient.class);

--- a/src/test/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationOrchestrationServiceTest.java
+++ b/src/test/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationOrchestrationServiceTest.java
@@ -1,0 +1,239 @@
+package org.xcore.plugin.security.ingress.ipreputation;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.xcore.plugin.config.Config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class IpReputationOrchestrationServiceTest {
+
+    @Test
+    @DisplayName("isBlocked returns false when feature is disabled")
+    void isBlocked_featureDisabled_returnsFalse() {
+        Config config = configWithEnabled(false);
+        var service = newService(config, mockAllowlist(), mockCache(), mockProvider(), mockPolicy());
+
+        assertThat(service.isBlocked("1.2.3.4")).isFalse();
+    }
+
+    @Test
+    @DisplayName("isBlocked returns false for blank ip")
+    void isBlocked_blankIp_returnsFalse() {
+        Config config = configWithEnabled(true);
+        var service = newService(config, mockAllowlist(), mockCache(), mockProvider(), mockPolicy());
+
+        assertThat(service.isBlocked("")).isFalse();
+        assertThat(service.isBlocked(null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("isBlocked returns false when ip is on allowlist")
+    void isBlocked_allowlisted_returnsFalse() {
+        Config config = configWithEnabled(true);
+        IpReputationAllowlist allowlist = mockAllowlist();
+        when(allowlist.contains("1.2.3.4")).thenReturn(true);
+
+        var service = newService(config, allowlist, mockCache(), mockProvider(), mockPolicy());
+
+        assertThat(service.isBlocked("1.2.3.4")).isFalse();
+    }
+
+    @Test
+    @DisplayName("isBlocked uses cache hit when available")
+    void isBlocked_cacheHit_usesCache() {
+        Config config = configWithEnabled(true);
+        IpReputationCache cache = mockCache();
+        IpReputationResult cached = new IpReputationResult("1.2.3.4", true, false, false);
+        when(cache.get("1.2.3.4")).thenReturn(cached);
+
+        IpReputationPolicy policy = mockPolicy();
+        when(policy.isBlocked(cached)).thenReturn(true);
+
+        var service = newService(config, mockAllowlist(), cache, mockProvider(), policy);
+
+        assertThat(service.isBlocked("1.2.3.4")).isTrue();
+        verifyNoInteractions(serviceProvider(mockProvider()));
+    }
+
+    @Test
+    @DisplayName("isBlocked consults provider on cache miss and caches result")
+    void isBlocked_cacheMiss_consultsProviderAndCaches() {
+        Config config = configWithEnabled(true);
+        IpReputationCache cache = mockCache();
+        when(cache.get("1.2.3.4")).thenReturn(null);
+
+        IpReputationProvider provider = mockProvider();
+        IpReputationResult result = new IpReputationResult("1.2.3.4", true, false, false);
+        when(provider.lookup("1.2.3.4")).thenReturn(result);
+
+        IpReputationPolicy policy = mockPolicy();
+        when(policy.isBlocked(result)).thenReturn(true);
+
+        var service = newService(config, mockAllowlist(), cache, provider, policy);
+
+        assertThat(service.isBlocked("1.2.3.4")).isTrue();
+        verify(cache).put("1.2.3.4", result);
+    }
+
+    @Test
+    @DisplayName("isBlocked fails open when provider returns null")
+    void isBlocked_providerNull_failsOpen() {
+        Config config = configWithEnabled(true);
+        IpReputationCache cache = mockCache();
+        when(cache.get("1.2.3.4")).thenReturn(null);
+
+        IpReputationProvider provider = mockProvider();
+        when(provider.lookup("1.2.3.4")).thenReturn(null);
+
+        var service = newService(config, mockAllowlist(), cache, provider, mockPolicy());
+
+        assertThat(service.isBlocked("1.2.3.4")).isFalse();
+    }
+
+    @Test
+    @DisplayName("isBlocked fails open when allowlist throws")
+    void isBlocked_allowlistThrows_failsOpen() {
+        Config config = configWithEnabled(true);
+        IpReputationAllowlist allowlist = mockAllowlist();
+        when(allowlist.contains("1.2.3.4")).thenThrow(new RuntimeException("redis down"));
+
+        IpReputationCache cache = mockCache();
+        when(cache.get("1.2.3.4")).thenReturn(null);
+
+        IpReputationProvider provider = mockProvider();
+        IpReputationResult result = new IpReputationResult("1.2.3.4", false, false, false);
+        when(provider.lookup("1.2.3.4")).thenReturn(result);
+
+        IpReputationPolicy policy = mockPolicy();
+        when(policy.isBlocked(result)).thenReturn(false);
+
+        var service = newService(config, allowlist, cache, provider, policy);
+
+        assertThat(service.isBlocked("1.2.3.4")).isFalse();
+    }
+
+    @Test
+    @DisplayName("isBlocked fails open when cache throws")
+    void isBlocked_cacheThrows_failsOpen() {
+        Config config = configWithEnabled(true);
+        IpReputationCache cache = mockCache();
+        when(cache.get("1.2.3.4")).thenThrow(new RuntimeException("redis down"));
+
+        IpReputationProvider provider = mockProvider();
+        IpReputationResult result = new IpReputationResult("1.2.3.4", false, false, false);
+        when(provider.lookup("1.2.3.4")).thenReturn(result);
+
+        IpReputationPolicy policy = mockPolicy();
+        when(policy.isBlocked(result)).thenReturn(false);
+
+        var service = newService(config, mockAllowlist(), cache, provider, policy);
+
+        assertThat(service.isBlocked("1.2.3.4")).isFalse();
+    }
+
+    @Test
+    @DisplayName("isBlocked fails open when provider throws")
+    void isBlocked_providerThrows_failsOpen() {
+        Config config = configWithEnabled(true);
+        IpReputationCache cache = mockCache();
+        when(cache.get("1.2.3.4")).thenReturn(null);
+
+        IpReputationProvider provider = mockProvider();
+        when(provider.lookup("1.2.3.4")).thenThrow(new RuntimeException("timeout"));
+
+        var service = newService(config, mockAllowlist(), cache, provider, mockPolicy());
+
+        assertThat(service.isBlocked("1.2.3.4")).isFalse();
+    }
+
+    @Test
+    @DisplayName("isBlocked fails open when cache put throws")
+    void isBlocked_cachePutThrows_stillEvaluatesPolicy() {
+        Config config = configWithEnabled(true);
+        IpReputationCache cache = mockCache();
+        when(cache.get("1.2.3.4")).thenReturn(null);
+        when(cache.put(anyString(), any())).thenThrow(new RuntimeException("redis down"));
+
+        IpReputationProvider provider = mockProvider();
+        IpReputationResult result = new IpReputationResult("1.2.3.4", true, false, false);
+        when(provider.lookup("1.2.3.4")).thenReturn(result);
+
+        IpReputationPolicy policy = mockPolicy();
+        when(policy.isBlocked(result)).thenReturn(true);
+
+        var service = newService(config, mockAllowlist(), cache, provider, policy);
+
+        assertThat(service.isBlocked("1.2.3.4")).isTrue();
+    }
+
+    @Test
+    @DisplayName("lookup returns null when feature is disabled")
+    void lookup_featureDisabled_returnsNull() {
+        Config config = configWithEnabled(false);
+        var service = newService(config, mockAllowlist(), mockCache(), mockProvider(), mockPolicy());
+
+        assertThat(service.lookup("1.2.3.4")).isNull();
+    }
+
+    @Test
+    @DisplayName("lookup returns provider result when enabled")
+    void lookup_featureEnabled_returnsProviderResult() {
+        Config config = configWithEnabled(true);
+        IpReputationProvider provider = mockProvider();
+        IpReputationResult result = new IpReputationResult("1.2.3.4", true, false, false);
+        when(provider.lookup("1.2.3.4")).thenReturn(result);
+
+        var service = newService(config, mockAllowlist(), mockCache(), provider, mockPolicy());
+
+        assertThat(service.lookup("1.2.3.4")).isEqualTo(result);
+    }
+
+    @Test
+    @DisplayName("lookup fails open when provider throws")
+    void lookup_providerThrows_failsOpen() {
+        Config config = configWithEnabled(true);
+        IpReputationProvider provider = mockProvider();
+        when(provider.lookup("1.2.3.4")).thenThrow(new RuntimeException("timeout"));
+
+        var service = newService(config, mockAllowlist(), mockCache(), provider, mockPolicy());
+
+        assertThat(service.lookup("1.2.3.4")).isNull();
+    }
+
+    private static IpReputationOrchestrationService newService(
+            Config config,
+            IpReputationAllowlist allowlist,
+            IpReputationCache cache,
+            IpReputationProvider provider,
+            IpReputationPolicy policy) {
+        return new IpReputationOrchestrationService(config, allowlist, cache, provider, policy);
+    }
+
+    private static Config configWithEnabled(boolean enabled) {
+        Config config = new Config();
+        config.ipReputation.enabled = enabled;
+        return config;
+    }
+
+    private static IpReputationAllowlist mockAllowlist() {
+        return mock(IpReputationAllowlist.class);
+    }
+
+    private static IpReputationCache mockCache() {
+        return mock(IpReputationCache.class);
+    }
+
+    private static IpReputationProvider mockProvider() {
+        return mock(IpReputationProvider.class);
+    }
+
+    private static IpReputationPolicy mockPolicy() {
+        return mock(IpReputationPolicy.class);
+    }
+
+    private static IpReputationProvider serviceProvider(IpReputationProvider provider) {
+        return provider;
+    }
+}

--- a/src/test/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationOrchestrationServiceTest.java
+++ b/src/test/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationOrchestrationServiceTest.java
@@ -51,10 +51,11 @@ class IpReputationOrchestrationServiceTest {
         IpReputationPolicy policy = mockPolicy();
         when(policy.isBlocked(cached)).thenReturn(true);
 
-        var service = newService(config, mockAllowlist(), cache, mockProvider(), policy);
+        IpReputationProvider provider = mockProvider();
+        var service = newService(config, mockAllowlist(), cache, provider, policy);
 
         assertThat(service.isBlocked("1.2.3.4")).isTrue();
-        verifyNoInteractions(serviceProvider(mockProvider()));
+        verifyNoInteractions(provider);
     }
 
     @Test
@@ -231,9 +232,5 @@ class IpReputationOrchestrationServiceTest {
 
     private static IpReputationPolicy mockPolicy() {
         return mock(IpReputationPolicy.class);
-    }
-
-    private static IpReputationProvider serviceProvider(IpReputationProvider provider) {
-        return provider;
     }
 }

--- a/src/test/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationOrchestrationServiceTest.java
+++ b/src/test/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationOrchestrationServiceTest.java
@@ -101,18 +101,13 @@ class IpReputationOrchestrationServiceTest {
         when(allowlist.contains("1.2.3.4")).thenThrow(new RuntimeException("redis down"));
 
         IpReputationCache cache = mockCache();
-        when(cache.get("1.2.3.4")).thenReturn(null);
-
         IpReputationProvider provider = mockProvider();
-        IpReputationResult result = new IpReputationResult("1.2.3.4", false, false, false);
-        when(provider.lookup("1.2.3.4")).thenReturn(result);
-
         IpReputationPolicy policy = mockPolicy();
-        when(policy.isBlocked(result)).thenReturn(false);
 
         var service = newService(config, allowlist, cache, provider, policy);
 
         assertThat(service.isBlocked("1.2.3.4")).isFalse();
+        verifyNoInteractions(cache, provider, policy);
     }
 
     @Test

--- a/src/test/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationPolicyTest.java
+++ b/src/test/java/org/xcore/plugin/security/ingress/ipreputation/IpReputationPolicyTest.java
@@ -1,0 +1,83 @@
+package org.xcore.plugin.security.ingress.ipreputation;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.xcore.plugin.config.Config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IpReputationPolicyTest {
+
+    @Test
+    @DisplayName("returns false for null result")
+    void returnsFalse_forNullResult() {
+        Config config = new Config();
+
+        assertThat(new IpReputationPolicy(config).isBlocked(null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("blockProxy honors proxy signal independently")
+    void blockProxy_honorsProxySignalIndependently() {
+        Config config = baseConfig();
+        config.ipReputation.blockProxy = true;
+        config.ipReputation.blockVpn = false;
+        config.ipReputation.blockTor = false;
+
+        assertThat(new IpReputationPolicy(config).isBlocked(proxyResult())).isTrue();
+    }
+
+    @Test
+    @DisplayName("blockVpn honors combined provider proxy signal independently")
+    void blockVpn_honorsCombinedProviderSignalIndependently() {
+        Config config = baseConfig();
+        config.ipReputation.blockProxy = false;
+        config.ipReputation.blockVpn = true;
+        config.ipReputation.blockTor = false;
+
+        assertThat(new IpReputationPolicy(config).isBlocked(proxyResult())).isTrue();
+    }
+
+    @Test
+    @DisplayName("blockTor honors combined provider proxy signal independently")
+    void blockTor_honorsCombinedProviderSignalIndependently() {
+        Config config = baseConfig();
+        config.ipReputation.blockProxy = false;
+        config.ipReputation.blockVpn = false;
+        config.ipReputation.blockTor = true;
+
+        assertThat(new IpReputationPolicy(config).isBlocked(proxyResult())).isTrue();
+    }
+
+    @Test
+    @DisplayName("blockHosting honors hosting signal")
+    void blockHosting_honorsHostingSignal() {
+        Config config = baseConfig();
+        config.ipReputation.blockHosting = true;
+
+        IpReputationResult result = new IpReputationResult("1.2.3.4", false, true, false);
+
+        assertThat(new IpReputationPolicy(config).isBlocked(result)).isTrue();
+    }
+
+    @Test
+    @DisplayName("returns false when all toggles are disabled")
+    void returnsFalse_whenAllTogglesDisabled() {
+        Config config = baseConfig();
+
+        assertThat(new IpReputationPolicy(config).isBlocked(proxyResult())).isFalse();
+    }
+
+    private static Config baseConfig() {
+        Config config = new Config();
+        config.ipReputation.blockProxy = false;
+        config.ipReputation.blockVpn = false;
+        config.ipReputation.blockTor = false;
+        config.ipReputation.blockHosting = false;
+        return config;
+    }
+
+    private static IpReputationResult proxyResult() {
+        return new IpReputationResult("1.2.3.4", true, false, false);
+    }
+}

--- a/src/test/java/org/xcore/plugin/service/network/RedisIpReputationAllowlistTest.java
+++ b/src/test/java/org/xcore/plugin/service/network/RedisIpReputationAllowlistTest.java
@@ -1,0 +1,174 @@
+package org.xcore.plugin.service.network;
+
+import com.google.gson.Gson;
+import io.lettuce.core.api.sync.RedisCommands;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.xcore.plugin.config.Config;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RedisIpReputationAllowlistTest {
+
+    @Test
+    @DisplayName("contains returns false for missing ip")
+    void contains_returnsFalseForMissingIp() {
+        Set<String> store = new HashSet<>();
+        RedisCommands<String, String> commands = redisCommands(store);
+        RedisNetworkBackend backend = backend(commands);
+        RedisIpReputationAllowlist allowlist = new RedisIpReputationAllowlist(backend, new Gson(), config("mini-pvp"));
+
+        assertThat(allowlist.contains("1.2.3.4")).isFalse();
+    }
+
+    @Test
+    @DisplayName("add and contains round trip")
+    void addAndContains_roundTrip() {
+        Set<String> store = new HashSet<>();
+        RedisCommands<String, String> commands = redisCommands(store);
+        RedisNetworkBackend backend = backend(commands);
+        RedisIpReputationAllowlist allowlist = new RedisIpReputationAllowlist(backend, new Gson(), config("mini-pvp"));
+
+        assertThat(allowlist.add("1.2.3.4")).isTrue();
+        assertThat(allowlist.contains("1.2.3.4")).isTrue();
+        assertThat(allowlist.contains("5.6.7.8")).isFalse();
+    }
+
+    @Test
+    @DisplayName("remove deletes ip from allowlist")
+    void remove_deletesIpFromAllowlist() {
+        Set<String> store = new HashSet<>();
+        RedisCommands<String, String> commands = redisCommands(store);
+        RedisNetworkBackend backend = backend(commands);
+        RedisIpReputationAllowlist allowlist = new RedisIpReputationAllowlist(backend, new Gson(), config("mini-pvp"));
+
+        allowlist.add("1.2.3.4");
+        assertThat(allowlist.contains("1.2.3.4")).isTrue();
+
+        assertThat(allowlist.remove("1.2.3.4")).isTrue();
+        assertThat(allowlist.contains("1.2.3.4")).isFalse();
+    }
+
+    @Test
+    @DisplayName("contains returns false for blank ip")
+    void contains_returnsFalseForBlankIp() {
+        Set<String> store = new HashSet<>();
+        RedisCommands<String, String> commands = redisCommands(store);
+        RedisNetworkBackend backend = backend(commands);
+        RedisIpReputationAllowlist allowlist = new RedisIpReputationAllowlist(backend, new Gson(), config("mini-pvp"));
+
+        assertThat(allowlist.contains("")).isFalse();
+        assertThat(allowlist.contains(null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("add and remove return false for blank ip")
+    void addAndRemove_returnFalseForBlankIp() {
+        Set<String> store = new HashSet<>();
+        RedisCommands<String, String> commands = redisCommands(store);
+        RedisNetworkBackend backend = backend(commands);
+        RedisIpReputationAllowlist allowlist = new RedisIpReputationAllowlist(backend, new Gson(), config("mini-pvp"));
+
+        assertThat(allowlist.add("")).isFalse();
+        assertThat(allowlist.add(null)).isFalse();
+        assertThat(allowlist.remove("")).isFalse();
+        assertThat(allowlist.remove(null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("key includes server name and version prefix")
+    void key_includesServerNameAndVersionPrefix() {
+        Set<String> store = new HashSet<>();
+        RedisCommands<String, String> commands = redisCommands(store);
+        RedisNetworkBackend backend = backend(commands);
+        RedisIpReputationAllowlist allowlist = new RedisIpReputationAllowlist(backend, new Gson(), config("alpha"));
+
+        allowlist.add("1.2.3.4");
+
+        assertThat(store).contains("1.2.3.4");
+    }
+
+    @Test
+    @DisplayName("list returns empty set when no entries")
+    void list_returnsEmptySetWhenNoEntries() {
+        Set<String> store = new HashSet<>();
+        RedisCommands<String, String> commands = redisCommands(store);
+        RedisNetworkBackend backend = backend(commands);
+        RedisIpReputationAllowlist allowlist = new RedisIpReputationAllowlist(backend, new Gson(), config("mini-pvp"));
+
+        assertThat(allowlist.list()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("list returns all added entries")
+    void list_returnsAllAddedEntries() {
+        Set<String> store = new HashSet<>();
+        RedisCommands<String, String> commands = redisCommands(store);
+        RedisNetworkBackend backend = backend(commands);
+        RedisIpReputationAllowlist allowlist = new RedisIpReputationAllowlist(backend, new Gson(), config("mini-pvp"));
+
+        allowlist.add("1.2.3.4");
+        allowlist.add("5.6.7.8");
+
+        assertThat(allowlist.list()).containsExactlyInAnyOrder("1.2.3.4", "5.6.7.8");
+    }
+
+    @Test
+    @DisplayName("backend failure returns fallback")
+    void backendFailure_returnsFallback() {
+        RedisNetworkBackend backend = mock(RedisNetworkBackend.class);
+        when(backend.withCommands(any(Function.class), any())).thenAnswer(invocation -> invocation.getArgument(1));
+
+        RedisIpReputationAllowlist allowlist = new RedisIpReputationAllowlist(backend, new Gson(), config("mini-pvp"));
+
+        assertThat(allowlist.contains("1.2.3.4")).isFalse();
+        assertThat(allowlist.add("1.2.3.4")).isFalse();
+        assertThat(allowlist.remove("1.2.3.4")).isFalse();
+        assertThat(allowlist.list()).isEmpty();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static RedisNetworkBackend backend(RedisCommands<String, String> commands) {
+        RedisNetworkBackend backend = mock(RedisNetworkBackend.class);
+        when(backend.withCommands(any(Function.class), any())).thenAnswer(invocation -> {
+            Function<RedisCommands<String, String>, Object> operation = invocation.getArgument(0);
+            return operation.apply(commands);
+        });
+        return backend;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static RedisCommands<String, String> redisCommands(Set<String> store) {
+        RedisCommands<String, String> commands = mock(RedisCommands.class);
+        when(commands.sismember(anyString(), anyString())).thenAnswer(invocation -> {
+            String member = invocation.getArgument(1);
+            return store.contains(member);
+        });
+        when(commands.sadd(anyString(), anyString())).thenAnswer(invocation -> {
+            String member = invocation.getArgument(1);
+            return store.add(member) ? 1L : 0L;
+        });
+        when(commands.srem(anyString(), anyString())).thenAnswer(invocation -> {
+            String member = invocation.getArgument(1);
+            return store.remove(member) ? 1L : 0L;
+        });
+        when(commands.smembers(anyString())).thenAnswer(invocation -> {
+            return new java.util.HashSet<>(store);
+        });
+        return commands;
+    }
+
+    private static Config config(String server) {
+        Config config = new Config();
+        config.server = server;
+        return config;
+    }
+}

--- a/src/test/java/org/xcore/plugin/service/network/RedisIpReputationCacheTest.java
+++ b/src/test/java/org/xcore/plugin/service/network/RedisIpReputationCacheTest.java
@@ -1,0 +1,129 @@
+package org.xcore.plugin.service.network;
+
+import com.google.gson.Gson;
+import io.lettuce.core.SetArgs;
+import io.lettuce.core.api.sync.RedisCommands;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.xcore.plugin.config.Config;
+import org.xcore.plugin.security.ingress.ipreputation.IpReputationResult;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RedisIpReputationCacheTest {
+
+    @Test
+    @DisplayName("get returns null for missing key")
+    void get_returnsNullForMissingKey() {
+        RedisCommands<String, String> commands = redisCommands(new HashMap<>());
+        RedisNetworkBackend backend = backend(commands);
+        RedisIpReputationCache cache = new RedisIpReputationCache(backend, new Gson(), config("mini-pvp"));
+
+        assertThat(cache.get("1.2.3.4")).isNull();
+    }
+
+    @Test
+    @DisplayName("put and get round trip stores result with ttl")
+    void putAndGet_roundTripStoresResult() {
+        RedisCommands<String, String> commands = redisCommands(new HashMap<>());
+        RedisNetworkBackend backend = backend(commands);
+        RedisIpReputationCache cache = new RedisIpReputationCache(backend, new Gson(), config("mini-pvp"));
+
+        IpReputationResult result = new IpReputationResult("1.2.3.4", true, false, false);
+
+        assertThat(cache.put("1.2.3.4", result)).isTrue();
+
+        IpReputationResult cached = cache.get("1.2.3.4");
+        assertThat(cached).isNotNull();
+        assertThat(cached.ip()).isEqualTo("1.2.3.4");
+        assertThat(cached.proxy()).isTrue();
+        assertThat(cached.hosting()).isFalse();
+        assertThat(cached.mobile()).isFalse();
+    }
+
+    @Test
+    @DisplayName("get returns null for blank ip")
+    void get_returnsNullForBlankIp() {
+        RedisCommands<String, String> commands = redisCommands(new HashMap<>());
+        RedisNetworkBackend backend = backend(commands);
+        RedisIpReputationCache cache = new RedisIpReputationCache(backend, new Gson(), config("mini-pvp"));
+
+        assertThat(cache.get("")).isNull();
+        assertThat(cache.get(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("put returns false for blank ip or null result")
+    void put_returnsFalseForInvalidInput() {
+        RedisCommands<String, String> commands = redisCommands(new HashMap<>());
+        RedisNetworkBackend backend = backend(commands);
+        RedisIpReputationCache cache = new RedisIpReputationCache(backend, new Gson(), config("mini-pvp"));
+
+        assertThat(cache.put("", new IpReputationResult("1.2.3.4", true, false, false))).isFalse();
+        assertThat(cache.put("1.2.3.4", null)).isFalse();
+        assertThat(cache.put(null, new IpReputationResult("1.2.3.4", true, false, false))).isFalse();
+    }
+
+    @Test
+    @DisplayName("key includes server name and version prefix")
+    void key_includesServerNameAndVersionPrefix() {
+        Map<String, String> store = new HashMap<>();
+        RedisCommands<String, String> commands = redisCommands(store);
+        RedisNetworkBackend backend = backend(commands);
+        RedisIpReputationCache cache = new RedisIpReputationCache(backend, new Gson(), config("alpha"));
+
+        cache.put("1.2.3.4", new IpReputationResult("1.2.3.4", false, false, false));
+
+        assertThat(store).containsKey("xcore:ip-reputation:cache:v1:alpha:1.2.3.4");
+    }
+
+    @Test
+    @DisplayName("backend failure returns fallback")
+    void backendFailure_returnsFallback() {
+        RedisNetworkBackend backend = mock(RedisNetworkBackend.class);
+        when(backend.withCommands(any(Function.class), any())).thenAnswer(invocation -> invocation.getArgument(1));
+
+        RedisIpReputationCache cache = new RedisIpReputationCache(backend, new Gson(), config("mini-pvp"));
+
+        assertThat(cache.get("1.2.3.4")).isNull();
+        assertThat(cache.put("1.2.3.4", new IpReputationResult("1.2.3.4", true, false, false))).isFalse();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static RedisNetworkBackend backend(RedisCommands<String, String> commands) {
+        RedisNetworkBackend backend = mock(RedisNetworkBackend.class);
+        when(backend.withCommands(any(Function.class), any())).thenAnswer(invocation -> {
+            Function<RedisCommands<String, String>, Object> operation = invocation.getArgument(0);
+            return operation.apply(commands);
+        });
+        return backend;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static RedisCommands<String, String> redisCommands(Map<String, String> store) {
+        RedisCommands<String, String> commands = mock(RedisCommands.class);
+        when(commands.get(anyString())).thenAnswer(invocation -> store.get(invocation.getArgument(0)));
+        doAnswer(invocation -> {
+            String key = invocation.getArgument(0);
+            String value = invocation.getArgument(1);
+            store.put(key, value);
+            return "OK";
+        }).when(commands).set(anyString(), anyString(), any(SetArgs.class));
+        return commands;
+    }
+
+    private static Config config(String server) {
+        Config config = new Config();
+        config.server = server;
+        return config;
+    }
+}


### PR DESCRIPTION
## Summary
- add configurable IP reputation policy and ip-api provider settings
- block flagged VPN/proxy/Tor connections through ingress with Redis-backed cache and allowlist support
- add server commands and focused tests for IP reputation lookups and allowlist management

## Testing
- ./gradlew :test --tests 'org.xcore.plugin.localization.LocalizationPlaceholderConsistencyTest' --tests 'org.xcore.plugin.security.ingress.checks.IpReputationCheckTest' --tests 'org.xcore.plugin.command.controller.server.IpReputationServerControllerTest' --tests 'org.xcore.plugin.service.network.RedisIpReputationAllowlistTest' --tests 'org.xcore.plugin.security.ingress.ipreputation.IpApiProviderTest' --tests 'org.xcore.plugin.security.ingress.ipreputation.IpReputationOrchestrationServiceTest'
- ./gradlew test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IP reputation system with configurable blocking (proxy/VPN/Tor/hosting), provider lookups, caching, retries and rate limits
  * Console commands to lookup reputation, check block status, and manage an IP allowlist
  * Redis-backed allowlist and cache implementations
* **Security**
  * Runtime ingress check that denies connections based on IP reputation with localized denial messages
* **Docs / Localization**
  * English, Russian, Ukrainian messages for denial, admin notifications and command feedback
* **Tests**
  * Unit tests covering orchestration, provider, cache, allowlist, policy, ingress check and commands

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XCore-mindustry/XCore-plugin/pull/9?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->